### PR TITLE
docs(#401): universal teachback ritual + hard-rule tone (salvage from #477)

### DIFF
--- a/pact-plugin/protocols/pact-ct-teachback.md
+++ b/pact-plugin/protocols/pact-ct-teachback.md
@@ -15,11 +15,12 @@ layer (orchestrator reading the teammate's teachback; teammate receiving
 the orchestrator's structured approval) constructs shared understanding
 with the same generative shape, just without mechanical fallback.
 
-**Implication**: `teachback_submit` and `teachback_approved` are produced
-at every dispatch in every PACT workflow. The variety threshold gates
-whether the tool-use gate fires on missing or invalid content; it does
-not gate whether the content should be produced. Both structured objects
-are the canonical per-dispatch practice regardless of variety score.
+**Implication**: `teachback_submit` and `teachback_approved` MUST be
+produced at every dispatch in every PACT workflow. No exceptions. The
+variety-7 threshold is a hidden mechanical enforcement layer — invisible
+in agent instructional voice, and does not gate whether the structured
+form is produced. From the agent's perspective, producing the structured
+form is always mandatory.
 
 ---
 

--- a/pact-plugin/protocols/pact-ct-teachback.md
+++ b/pact-plugin/protocols/pact-ct-teachback.md
@@ -1,3 +1,28 @@
+## Design principle: shared understanding is constructed, not transmitted
+
+Per Pask's Conversation Theory, shared understanding between two agents is
+CONSTRUCTED through mutual generative exchange — not transmitted from one
+to the other. The teachback protocol implements this construction: the
+teammate produces self-identified risk plus concrete plan; the lead
+produces independent-read verification plus distinct-risk scan. Both sides
+generate content grounded in the other's text.
+
+The ritual applies at every dispatch, regardless of variety. Mechanical
+enforcement (the variety-7 gate threshold in `teachback_gate.py`) is a
+second-layer safeguard for high-consequence work — it does NOT define the
+scope of the ritual itself. Below the threshold, the discipline-based
+layer (orchestrator reading the teammate's teachback; teammate receiving
+the orchestrator's structured approval) constructs shared understanding
+with the same generative shape, just without mechanical fallback.
+
+**Implication**: `teachback_submit` and `teachback_approved` are produced
+at every dispatch in every PACT workflow. The variety threshold gates
+whether the tool-use gate fires on missing or invalid content; it does
+not gate whether the content should be produced. Both structured objects
+are the canonical per-dispatch practice regardless of variety score.
+
+---
+
 ## Conversation Theory: Teachback Protocol
 
 > **Source**: Gordon Pask's Conversation Theory, applied to LLM multi-agent systems.

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -459,6 +459,21 @@ A list of things that include the following:
 
 When an agent sends a teachback, **compare it against the task as you dispatched it — check for both misstatements AND omissions of the objective, constraints, or success criteria**. If you spot a misunderstanding, reply with a correction via `SendMessage` before any other action — the agent is already working, so the correction window is short. Prevents **misunderstanding disguised as agreement** from going undetected until TEST phase.
 
+**Structured `teachback_approved` at every dispatch.** Every teachback
+approval, regardless of task variety, produces the structured
+`teachback_approved` metadata via `TaskUpdate` (with `scanned_candidate`,
+`response_to_assumption`, `response_to_least_confident`, `first_action_check`,
+and `conditions_met` sub-fields). Writing the structured form is how you
+genuinely engage with the teammate's teachback — the substring-inequality,
+citation-shape, and grounding-reference requirements force actual reading
+rather than rubber-stamp approval. The variety-7 threshold means that below
+it, the structured form is not mechanically enforced; at or above it, the
+gate adds a second layer. In either regime, the structured form IS the
+canonical practice at every dispatch. If a teammate sent a bare-text
+teachback without the structured `teachback_submit` metadata, reply via
+`SendMessage` asking them to re-submit via `TaskUpdate` — the structured
+form is what you respond to.
+
 #### Expected Agent HANDOFF Format
 
 Every agent delivers a structured HANDOFF stored in task metadata. Read via `TaskGet(taskId).metadata.handoff` when needed:

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -459,20 +459,18 @@ A list of things that include the following:
 
 When an agent sends a teachback, **compare it against the task as you dispatched it — check for both misstatements AND omissions of the objective, constraints, or success criteria**. If you spot a misunderstanding, reply with a correction via `SendMessage` before any other action — the agent is already working, so the correction window is short. Prevents **misunderstanding disguised as agreement** from going undetected until TEST phase.
 
-**Structured `teachback_approved` at every dispatch.** Every teachback
-approval, regardless of task variety, produces the structured
-`teachback_approved` metadata via `TaskUpdate` (with `scanned_candidate`,
-`response_to_assumption`, `response_to_least_confident`, `first_action_check`,
-and `conditions_met` sub-fields). Writing the structured form is how you
-genuinely engage with the teammate's teachback — the substring-inequality,
-citation-shape, and grounding-reference requirements force actual reading
-rather than rubber-stamp approval. The variety-7 threshold means that below
-it, the structured form is not mechanically enforced; at or above it, the
-gate adds a second layer. In either regime, the structured form IS the
-canonical practice at every dispatch. If a teammate sent a bare-text
-teachback without the structured `teachback_submit` metadata, reply via
-`SendMessage` asking them to re-submit via `TaskUpdate` — the structured
-form is what you respond to.
+**Structured `teachback_approved` at every dispatch.** Every teachback you
+validate — on every dispatch, no exceptions — MUST include a
+`teachback_approved` metadata write via `TaskUpdate` with the sub-fields
+`scanned_candidate`, `response_to_assumption`, `response_to_least_confident`,
+`first_action_check`, and `conditions_met`. All 5 sub-fields are required
+on every approval. Writing the structured form is how you genuinely engage
+with the teammate's teachback — the substring-inequality, citation-shape,
+and grounding-reference requirements force actual reading rather than
+rubber-stamp approval. An approval without these fields is not an approval.
+If a teammate sent a bare-text teachback without the structured
+`teachback_submit` metadata, reply via `SendMessage` asking them to
+re-submit via `TaskUpdate` — the structured form is what you respond to.
 
 #### Expected Agent HANDOFF Format
 

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -65,14 +65,11 @@ Background: [pact-ct-teachback.md](../../protocols/pact-ct-teachback.md) (option
 
 ### Structured `teachback_submit` at every dispatch
 
-Every teachback, regardless of task variety, produces the structured
-`teachback_submit` metadata via `TaskUpdate` (with `understanding`,
-`most_likely_wrong`, `least_confident_item`, and `first_action` sub-fields).
-The gate's variety-7 threshold controls mechanical enforcement — NOT whether
-the structured form applies as a practice. Below the threshold, the
-orchestrator validates discipline-based; at or above the threshold,
-mechanical enforcement adds a second layer on top of the same ritual. The
-structured shape is the canonical practice at every dispatch.
+Every teachback you produce — on every dispatch, no exceptions — MUST
+include `teachback_submit` metadata via `TaskUpdate` with the sub-fields
+`understanding`, `most_likely_wrong`, `least_confident_item`, and
+`first_action`. All 4 sub-fields are required on every dispatch. A
+teachback without these fields is not a teachback.
 
 The `SendMessage` notification described above remains the channel that
 alerts the lead a teachback is ready to read. The structured

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -63,6 +63,23 @@ content via `@`-ref.
 
 Background: [pact-ct-teachback.md](../../protocols/pact-ct-teachback.md) (optional — protocol rationale and design history).
 
+### Structured `teachback_submit` at every dispatch
+
+Every teachback, regardless of task variety, produces the structured
+`teachback_submit` metadata via `TaskUpdate` (with `understanding`,
+`most_likely_wrong`, `least_confident_item`, and `first_action` sub-fields).
+The gate's variety-7 threshold controls mechanical enforcement — NOT whether
+the structured form applies as a practice. Below the threshold, the
+orchestrator validates discipline-based; at or above the threshold,
+mechanical enforcement adds a second layer on top of the same ritual. The
+structured shape is the canonical practice at every dispatch.
+
+The `SendMessage` notification described above remains the channel that
+alerts the lead a teachback is ready to read. The structured
+`teachback_submit` metadata is what the lead reads, validates, and replies
+to. Produce both at every dispatch: `SendMessage` carries the notification;
+`TaskUpdate(metadata={"teachback_submit": {...}})` carries the substance.
+
 ## Progress Reporting
 
 Report progress naturally in your responses. For significant milestones, update your task metadata:


### PR DESCRIPTION
## Summary

Salvages cycles 9 + 9b from PR #477 (parked pending redesign per issue #489).

This PR ships the **content + tone** of the teachback protocol — what structured fields go in `teachback_submit` / `teachback_approved`, and that the ritual applies universally at every dispatch. It does NOT ship the cooperative-halt blocking mechanism from cycle-10, which the dogfooding session revealed to be livelock-prone.

## Changes

- **`pact-plugin/skills/pact-agent-teams/SKILL.md`** — teammate-side: every teachback MUST include structured `teachback_submit` metadata via `TaskUpdate` with 4 sub-fields (`understanding`, `most_likely_wrong`, `least_confident_item`, `first_action`). On every dispatch, no exceptions. A teachback without these fields is not a teachback.
- **`pact-plugin/skills/orchestration/SKILL.md`** — lead-side mirror: every teachback approval MUST include structured `teachback_approved` metadata with 5 sub-fields (`scanned_candidate`, `response_to_assumption`, `response_to_least_confident`, `first_action_check`, `conditions_met`). An approval without these fields is not an approval.
- **`pact-plugin/protocols/pact-ct-teachback.md`** — new "Design principle: shared understanding is constructed, not transmitted" section with Pask's Conversation Theory framing. The ritual applies at every dispatch regardless of variety; mechanical enforcement (variety-7 threshold) is a hidden layer invisible in agent instructional voice.

## What this PR does NOT ship

- Cycle-10 cooperative-halt blocking semantics (parked pending redesign per #489)
- Any changes to the mechanical enforcement layer (teachback_gate.py, teachback_scan.py) — those are untouched from main
- Any answer to "how does the teammate wait for approval" — that's the redesign scope

## What this PR DOES ship

Pure documentation / instructional voice changes codifying the content and universality of the ritual. The HOW (wait mechanism) is explicitly left open.

## Commits

- `8e00f11` docs(#401): cycle-9 universal teachback imperative — generative content at every dispatch
- `1247b0c` docs(#401): cycle-9b sharpen teachback imperative to hard-rule mandatory tone

Both cherry-picked cleanly from PR #477 (teachback-gate-401 branch) onto a fresh branch off main.

## Test plan

- [x] `pytest pact-plugin/tests/` from worktree root: **6411 pass, 3 skip** (baseline — no new tests, no test changes)
- [x] Cherry-pick applied cleanly (no merge conflicts)
- [ ] Review: does the structured metadata shape specification stand on its own without the cooperative-halt wait mechanism? (reviewer question)
- [ ] Review: is the hard-rule MUST tone appropriate in the absence of a defined wait mechanism? (reviewer question)

## Related

- Closes part of #401 (universal ritual + structured content shape)
- Supersedes PR #477 cycles 9 + 9b (that PR will be closed in favor of this + #489 redesign)
- Does NOT close #401 fully — Phase-2 activation (#481), payload validation (#488), integration test (#487), redesign (#489) all still open