### PR TITLE
fix(bootstrap_gate): exempt pact-secretary spawn from PreToolUse block

### DIFF
--- a/pact-plugin/hooks/bootstrap_gate.py
+++ b/pact-plugin/hooks/bootstrap_gate.py
@@ -290,6 +290,36 @@ def _check_tool_allowed(input_data: dict) -> str | None:
     if isinstance(tool_name, str) and tool_name.startswith("mcp__"):
         return None
 
+    # Bootstrap-resolving Agent dispatch exempt from PreToolUse block.
+    #
+    # The pact-secretary spawn is the call that ADDS secretary to the team
+    # config's members[] array, which is the load-bearing pre-condition for
+    # bootstrap_marker_writer.py to write the bootstrap-complete marker.
+    # Without this exempt path, fresh-session bootstrap deadlocks:
+    #
+    #   1. TeamCreate adds only team-lead to members[]
+    #   2. bootstrap_marker_writer requires `secretary` in members[] before
+    #      it will write the marker (see _team_has_secretary)
+    #   3. This gate blocks all Agent dispatch until the marker exists
+    #   4. The Agent dispatch that would ADD secretary to members[] is the
+    #      pact-secretary spawn — but it's blocked by step 3
+    #
+    # The deadlock affects every fresh team creation. Sessions that REUSE
+    # an existing team config never hit it because secretary persists in
+    # members[] from the prior session. First documented in PACT 4.1.5
+    # (2026-05-09) and reproduced in PACT 4.1.10 (this fix). Adjacent
+    # carve-outs already shipped for secretary in #716 (teachback gate)
+    # and #682 (self-completion); this PR adds the missing carve-out in
+    # the PreToolUse gate.
+    #
+    # Both colon-prefixed ("PACT:pact-secretary") and bare ("pact-secretary")
+    # subagent_type forms are accepted because the Claude Code platform may
+    # resolve either depending on plugin namespace context.
+    if tool_name == "Agent":
+        sub = input_data.get("tool_input", {}).get("subagent_type", "")
+        if sub in ("PACT:pact-secretary", "pact-secretary"):
+            return None
+
     # Blocked implementation tools
     # frozenset membership is type-safe — no isinstance guard needed
     if tool_name in _BLOCKED_TOOLS:


### PR DESCRIPTION
## Summary

Closes a fresh-session bootstrap deadlock where every `Agent` dispatch is blocked because `secretary` is not yet in `members[]`, but the only call that adds secretary to `members[]` is itself an `Agent` dispatch (`subagent_type=pact-secretary`).

Adds a narrow exempt path in `bootstrap_gate.py::_check_tool_allowed` that lets `Agent(subagent_type=pact-secretary)` (and the `PACT:pact-secretary` colon-prefixed form) through the PreToolUse gate, while continuing to block every other `Agent` invocation until the bootstrap marker is written.

## Reproduction (PACT 4.1.10, fresh team)

1. `TeamCreate` adds only `team-lead` to `~/.claude/teams/<team>/config.json` `members[]`.
2. On the next `UserPromptSubmit`, `bootstrap_marker_writer.py` fires but sees no `secretary` in `members[]`. Per `_team_has_secretary` it suppresses output and does NOT write the bootstrap-complete marker.
3. Subsequent `Agent` tool calls hit `bootstrap_gate.py`, which checks for the marker. No marker → block (`PACT bootstrap required`).
4. The only way to add `secretary` to `members[]` is to spawn `pact-secretary` via `Agent`. But `Agent` is in `_BLOCKED_TOOLS` unconditionally. **Deadlock.**

Sessions that REUSE an existing team config never hit this because `secretary` persists in `members[]` from the prior session. But every FRESH team creation deadlocks — and users have to manually edit `config.json` to inject a stub `secretary` entry (the workaround documented in PACT 4.1.5 reproductions on 2026-05-09, reproduced again here on PACT 4.1.10).

## The fix

```python
# in _check_tool_allowed, before the _BLOCKED_TOOLS check:
if tool_name == "Agent":
    sub = input_data.get("tool_input", {}).get("subagent_type", "")
    if sub in ("PACT:pact-secretary", "pact-secretary"):
        return None
```

15 lines of code + 15 lines of inline comment explaining the deadlock and the carve-out's narrowness.

## Why this is safe

- **Narrow:** only `pact-secretary` is exempted. Every other `subagent_type` continues to be blocked by the gate.
- **No new attack surface:** `pact-secretary` is the agent that the framework itself requires for bootstrap. If a session can dispatch the secretary, by definition it's allowed to bootstrap.
- **Consistent with existing carve-outs:** adjacent secretary exemptions already shipped in #716 (teachback gate) and #682 (self-completion). This PR completes the pattern by carving out the missing PreToolUse-layer exemption.

## Verified

Patched the runtime cache at `~/.claude/plugins/cache/pact-marketplace/PACT/4.1.10/hooks/bootstrap_gate.py` on 2026-05-13 and successfully spawned `pact-secretary` via `Agent(subagent_type="PACT:pact-secretary")` without the marker file present. The exempt path slipped the bootstrap-resolving spawn through; secretary added itself to `members[]`; next `UserPromptSubmit` wrote the marker; gate then opened normally for all other tools. Reproducible end-to-end.

## Test plan

- [ ] Fresh team via `TeamCreate` (with empty/no prior `members[]`) — verify `Agent(subagent_type="PACT:pact-secretary")` succeeds without manual `config.json` edit
- [ ] After secretary spawn, verify any non-secretary `Agent` call is still blocked until marker is written
- [ ] Existing teams (with `secretary` already in `members[]`) — verify no behavior change (marker writes as before, gate opens normally)