### PR TITLE
Bump the plugin version to 4.6.42

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.41",
+      "version": "4.6.42",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.41/     # Plugin version
+│               └── 4.6.42/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.41",
+  "version": "4.6.42",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.41
+> **Version**: 4.6.42
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 


### PR DESCRIPTION
## Summary

PATCH release bump for the #1451 fix shipped in #1505 (merged 0fe26778): the canonical `Agent()` spawn templates now carry the platform-required `description` param, so a template-literal first spawn of a session no longer fails `InputValidationError`.

## What changed

4.6.41 → 4.6.42 in the four release files:
- `.claude-plugin/marketplace.json`
- `pact-plugin/.claude-plugin/plugin.json`
- `pact-plugin/README.md`
- `README.md` (plugin-cache tree diagram)

## Verification

- Repo-wide grep: zero remaining `4.6.41`; exactly 4 `4.6.42` occurrences (the four files)
- Pin sweep: one historical comment match (`tests/test_merge_guard_1140_carrier5_cert.py:79`, `v4.6.4` beside a git SHA) — not a consistency pin, left untouched
- Full suite from `pact-plugin` (no path arg): 14833 passed, 15 skipped, 0 failed, 0 errors — exact baseline match