### PR TITLE
fix: align resolver to re-provisioned teams after resume (#1507)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.42",
+      "version": "4.6.43",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.42/     # Plugin version
+│               └── 4.6.43/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.42",
+  "version": "4.6.43",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.42
+> **Version**: 4.6.43
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/dispatch_gate.py
+++ b/pact-plugin/hooks/dispatch_gate.py
@@ -529,14 +529,20 @@ _STALE_DIAGNOSABLE_RULES = frozenset({"team_name_unavailable", "no_task_assigned
 # warning. The detector names the live-vs-recorded session_id mismatch; this
 # adds the dispatch-specific recovery (the gate read a different task store
 # than the live session's).
+#
+# The remedy is the MEASURED manual repoint, not a bootstrap pointer: the
+# bootstrap ritual does NOT rewrite these records, so a pointer there sends
+# the operator to a ritual that changes nothing for this denial.
 _STALE_REALIGN_HINT = (
     " This dispatch denial is likely a STALE-TEAM/STORE MISMATCH, not a "
     "genuinely missing task: after a Claude Code restart/fork the platform "
     "minted a new team for the live session while PACT's persisted team_name "
-    "went stale, so this gate read an orphaned task store. To re-align: update "
-    "the `team_name` in this session's pact-session-context.json (and the "
-    "project CLAUDE.md '- Team:' line) to the LIVE platform team, then "
-    "re-dispatch. Completing /PACT:bootstrap also rewrites those records."
+    "went stale, so this gate read an orphaned task store. Working recovery "
+    "(measured): edit pact-session-context.json in the OLD session's "
+    "directory (the one named for the OLD session id) and set team_name to "
+    "the LIVE team (the newest teams/session-*/config.json under your "
+    "Claude config dir); leave session_id and the session journal dir "
+    "untouched (journal continuity), then re-dispatch."
 )
 
 
@@ -636,6 +642,11 @@ def _augment_deny_with_stale_diagnosis(
 #
 # The remedy for cause (3) is a pointer, never an inlined setting.
 #
+# The remedy for cause (2) is the MEASURED manual repoint, not a bootstrap
+# pointer: the bootstrap ritual does NOT rewrite the persisted team records,
+# so the earlier pointer ("Completing the bootstrap ritual rewrites those
+# records.") sent that operator to a ritual that changed nothing.
+#
 # That pointer is an ABSOLUTE URL rather than a section name, and ONE ground
 # carries the two halves. The README shipped INSIDE the plugin package does
 # not contain that section — it lives in the repository README — so a reader
@@ -679,7 +690,10 @@ _CAUSE_ENUMERATION = (
     "     cleared. Create the teachback task + the work task, then re-dispatch.\n"
     " (2) This session's recorded team no longer matches the live one, so this\n"
     "     gate reads a different task store than the one the task tools write.\n"
-    "     Completing the bootstrap ritual rewrites those records.\n"
+    "     Recovery: set team_name in the OLD session's pact-session-context.json\n"
+    "     to the LIVE team (the newest teams/session-*/config.json), leaving\n"
+    "     session_id and the journal dir untouched (journal continuity), then\n"
+    "     re-dispatch.\n"
     " (3) The task-management tools are not available in this session at all.\n"
     "     They can be withheld by a server-controlled feature gate keyed on the\n"
     "     session's model — in which case (1) cannot be satisfied, because the\n"

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -484,6 +484,32 @@ def _resume_census_candidate_corroborated(
         return False
 
 
+def _own_tasks_store_fresh(teams_root: Path, session_id: str) -> bool:
+    """#1509 guard input: does this session's OWN sibling tasks store look
+    ALIVE? True iff tasks/<session_id>/ is a dir whose mtime falls within
+    RESUME_CENSUS_RECENCY_SECONDS of now — the same live-team signal the
+    census applies to candidates, applied here to the branch-2 own
+    substrate. A dead-looking own substrate (reaped remnant, or an idle
+    store aged past the window) is the only world where the census may be
+    consulted to preempt branch-2.
+
+    Never raises: False on any error. False pushes ONLY toward
+    preemption/suppression of branch-2 — never toward a foreign team (the
+    census winner must corroborate, and post-N1 the preemption itself is
+    end-marker-gated); a census-empty world still returns the substrate
+    unchanged.
+    """
+    try:
+        tasks_dir = teams_root.parent / "tasks" / session_id
+        if not tasks_dir.is_dir():
+            return False
+        return tasks_dir.stat().st_mtime >= (
+            time.time() - RESUME_CENSUS_RECENCY_SECONDS
+        )
+    except Exception:
+        return False
+
+
 def _resume_census_unique_candidate(teams_root: Path, session_id: str) -> str | None:
     """Branch-3 census (#1507): the single LIVE re-provisioned team, if
     unambiguous AND corroborated as this session's own.
@@ -584,7 +610,9 @@ def _resolve_aligned_team_name(
     mis-resolve.
 
     BRANCH-3 RESUME CENSUS (#1507): after branch-1 (identity match) and
-    branch-2 (config-less full-UUID witness) both miss, a RESUMED session
+    branch-2 (config-less full-UUID witness, GUARDED per #1509 — a
+    corroborated census winner preempts a dead-looking own substrate; see
+    the inline branch-2 comment) both miss, a RESUMED session
     (clean end-session reaped the old team config; a new team + task store
     was provisioned under a new id while hook frames still carry the OLD
     session id) can still be realigned: census the teams root for the
@@ -710,6 +738,23 @@ def _resolve_aligned_team_name(
         # dir). Unreachable under new-CLI: the platform names the dir
         # session-<id8>, so teams/<full-uuid>/ never exists (steady-state AND
         # the ~38s cold-start) -> CLI byte-identical.
+        #
+        # #1509 GUARD: the substrate witness alone cannot tell a LIVE own
+        # session from a DEAD reaped remnant — both present inboxes/ or
+        # file-edits.json. Branch-2 wins only when the own substrate looks
+        # ALIVE (its sibling tasks store is fresh) OR the census has NO
+        # corroborated unique winner to offer; a corroborated census winner
+        # preempts the DEAD substrate (the i-b contract: live team or stale
+        # default, never the dead dir). The census is consulted ONLY when
+        # the witness holds and the own store is stale, and _resume_census_
+        # unique_candidate already enforces the cycle-1 corroboration — an
+        # uncorroborated unique candidate returns None and CANNOT preempt,
+        # so the F1 hole cannot reopen through this path. In every
+        # census-empty world (including every #989 fixture with an empty
+        # teams root) this is byte-identical to the pre-guard branch-2.
+        # Preemption additionally requires an END MARKER in this session's
+        # journal (N1): only an ENDED substrate may be preempted.
+        census_winner: str | None = None
         if (
             is_safe_path_component(session_id)
             and (teams_root / session_id).is_dir()
@@ -718,7 +763,23 @@ def _resolve_aligned_team_name(
                 or (teams_root / session_id / "file-edits.json").exists()
             )
         ):
-            return session_id
+            if not _own_tasks_store_fresh(teams_root, session_id):
+                # N1 (cycle-2 review): preemption is legitimate only when
+                # the own substrate was actually ENDED. A LIVE idle session
+                # has no end marker in its journal and must keep cycle-1's
+                # unconditional branch-2 precedence — otherwise a same-dir
+                # sibling corroborates (cwd matches; birth-order skipped,
+                # no marker) and the write-back makes the mis-alignment
+                # sticky. Crash-resume without markers: pre-#1509 status
+                # quo (no preemption, no regression). The marker conjunct
+                # is the journal-derived gate this preemption path was
+                # missing (it does not rely on branch-3's witness).
+                if _own_journal_last_end_marker_ts() is not None:
+                    census_winner = _resume_census_unique_candidate(
+                        teams_root, session_id
+                    )
+            if census_winner is None:
+                return session_id
         # Branch-3: resume census (#1507). After a clean end-session, resume
         # provisions a NEW team + task store under a new id while every hook
         # frame still carries the OLD session id. Identity-match (branch-1)
@@ -749,7 +810,13 @@ def _resolve_aligned_team_name(
             and not (teams_root / fallback / "config.json").exists()
             and _journal_has_team_activity()
         ):
-            census_winner = _resume_census_unique_candidate(teams_root, session_id)
+            # Reuse the winner the #1509 guard may already have computed in
+            # branch-2 (single census pass per resolution); compute it only
+            # when branch-2 never ran it.
+            if census_winner is None:
+                census_winner = _resume_census_unique_candidate(
+                    teams_root, session_id
+                )
             if census_winner is not None:
                 return census_winner
         return fallback

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -322,12 +322,14 @@ RESUME_CENSUS_RECENCY_SECONDS = 900
 
 # Journal event types proving prior TEAM ACTIVITY for the branch-3 census
 # witness (see _journal_has_team_activity). `task_*` types are matched by
-# prefix; these three are matched exactly. `dispatch_decision` has an
-# ACTIVE writer (dispatch_gate emits one per gate decision; only its READER
-# was retired with the Q5 coverage ratio), so the type is DELIBERATELY in
-# the witness set — dispatch events are real lived-session activity.
+# prefix; these two are matched exactly. `dispatch_decision` is
+# DELIBERATELY EXCLUDED (F1a, PR #1510 review): the gate journals EVERY
+# decision INCLUDING DENIALS, so a single denied spawn would arm the
+# "lived session" witness without any real team life — the cold-start
+# guard's premise. Denials are gate verdicts, not team activity; the #1507
+# incident journal satisfies `task_*` + `session_end` regardless.
 _RESUME_CENSUS_ACTIVITY_EXACT_TYPES = frozenset(
-    {"dispatch_decision", "session_end", "session_consolidated"}
+    {"session_end", "session_consolidated"}
 )
 
 
@@ -335,8 +337,8 @@ def _journal_has_team_activity() -> bool:
     """Branch-3 witness (#1507): has THIS session LIVED as a team session?
 
     Proves the journal get_session_dir() points at contains at least one
-    prior team ACTIVITY event (`task_*` / `dispatch_decision` /
-    `session_end` / `session_consolidated`). This is the load-bearing
+    prior team ACTIVITY event (`task_*` / `session_end` /
+    `session_consolidated`). This is the load-bearing
     cold-start guard: a FRESH session's journal has no prior team activity,
     so its census can never fire — without this witness, a fresh session
     (own team config unborn in the ~38 s cold-start window) plus a
@@ -372,17 +374,131 @@ def _journal_has_team_activity() -> bool:
         return False
 
 
+def _own_journal_last_end_marker_ts() -> float | None:
+    """Epoch seconds of this session's journal's LAST end-of-life marker.
+
+    The max ts across `session_end` / `session_consolidated` events — the
+    anchor the corroboration strengthening compares a candidate lead's
+    joinedAt against (a re-provisioned team is born AFTER the old life
+    ended; a sibling session active ACROSS the resume predates it). None
+    when the journal has no end marker or the ts is unparseable (the
+    strengthening is then skipped, never fatal). Never raises.
+    """
+    try:
+        session_dir = get_session_dir()
+        if not session_dir:
+            return None
+        from .session_journal import read_events_from
+
+        last_ts: float | None = None
+        for event in read_events_from(session_dir):
+            if str(event.get("type", "")) not in ("session_end",
+                                                  "session_consolidated"):
+                continue
+            raw_ts = str(event.get("ts", ""))
+            try:
+                parsed = datetime.fromisoformat(
+                    raw_ts.replace("Z", "+00:00")
+                ).timestamp()
+            except ValueError:
+                continue
+            if last_ts is None or parsed > last_ts:
+                last_ts = parsed
+        return last_ts
+    except Exception:
+        return None
+
+
+def _resume_census_candidate_corroborated(
+    team_dir_name: str, config_data: dict
+) -> bool:
+    """Bind a census candidate to THIS session's platform identity (#1507 F1).
+
+    Set-uniqueness alone proves nothing (a sibling session's fresh store can
+    be the unique candidate whenever this session's own team is unborn), so
+    the unique candidate must additionally corroborate as THIS session's
+    team, by mechanism:
+
+      * LEAD ENTRY: the config's members[] entry whose agentId EQUALS the
+        config's leadAgentId (the platform's first-class key — NOT a
+        members[0] or shape heuristic). A member-less / malformed config
+        corroborates nothing -> suppressed.
+      * SELF-CONSISTENCY: the lead's agentId embeds "@<team-dir-name>",
+        binding the entry to the dir it sits in (a config copied from
+        another team's dir fails this).
+      * SUBJECT ANCHOR: the lead entry's cwd must RAW-match (no resolve —
+        an unresolved mismatch only ever fails safe) the hook process's
+        LIVE cwd OR the persisted project_dir — the re-provisioned team's
+        lead lives where THIS session lives; a sibling in another project
+        or worktree does not.
+      * BIRTH ORDER (strengthening): when the journal has an end-of-life
+        marker, the lead's joinedAt (epoch MILLIS, platform-verified) must
+        sit strictly AFTER it — the own re-provisioned team is born after
+        the old life ended; a sibling active ACROSS the resume predates it.
+        Skipped (not fatal) when no marker or an unparseable ts.
+
+    TRUST BOUNDARY (documented residual, mirrors the Backend-F2 pattern):
+    this defeats ACCIDENTAL/environmental cross-alignment (the F1 class).
+    A same-user MIRRORING adversary that reads this session's journal and
+    context can also rewrite the plugin hooks themselves — every pure-read
+    control here sits inside that same boundary, so mirroring-resistance
+    is out of scope by construction. Residual hole: a sibling BORN between
+    this session's end marker and its resume, running from the same
+    directory.
+
+    Never raises: any parse/compare failure corroborates nothing (False),
+    which suppresses the census (fail-safe direction).
+    """
+    try:
+        lead_agent_id = str(config_data.get("leadAgentId", ""))
+        if not lead_agent_id:
+            return False
+        if f"@{team_dir_name}" not in lead_agent_id:
+            return False
+        lead_entry = None
+        for member in config_data.get("members") or []:
+            if (isinstance(member, dict)
+                    and str(member.get("agentId", "")) == lead_agent_id):
+                lead_entry = member
+                break
+        if lead_entry is None:
+            return False
+        lead_cwd = str(lead_entry.get("cwd", ""))
+        if not lead_cwd:
+            return False
+        if lead_cwd not in (os.getcwd(), get_project_dir()):
+            return False
+        end_marker_ts = _own_journal_last_end_marker_ts()
+        if end_marker_ts is not None:
+            joined_at = lead_entry.get("joinedAt")
+            if not isinstance(joined_at, (int, float)):
+                return False
+            if (joined_at / 1000.0) <= end_marker_ts:
+                return False
+        return True
+    except Exception:
+        return False
+
+
 def _resume_census_unique_candidate(teams_root: Path, session_id: str) -> str | None:
     """Branch-3 census (#1507): the single LIVE re-provisioned team, if
-    unambiguous.
+    unambiguous AND corroborated as this session's own.
 
     Enumerates teams/*/config.json. A dir is a CANDIDATE iff its
     config.json carries a leadSessionId DIFFERENT from this session's id
     AND its sibling tasks/<dir>/ store mtime falls within
     RESUME_CENSUS_RECENCY_SECONDS of now (the "live team" signal). Returns
-    the dir name only when EXACTLY ONE candidate survives (unambiguous-only);
-    None on zero, on >= 2 (two simultaneous broken resumes -> stale
-    default), or on any error.
+    the dir name only when EXACTLY ONE candidate survives AND that
+    candidate corroborates as this session's team (see
+    _resume_census_candidate_corroborated — F1: uniqueness is an
+    environmental accident, never an ownership proof). None on zero, on
+    >= 2 (two simultaneous broken resumes -> stale default), on an
+    UNCORROBORATED unique candidate (pre-birth window / foreign sibling ->
+    fail-safe suppression), or on any error.
+
+    The corroboration lives HERE, inside the get_team_name resolution path,
+    so the marker-writer write-back (which calls get_team_name) can never
+    persist an uncorroborated winner.
 
     Pure / FS-read-only / NEVER raises — same contract as the resolver that
     calls it. The tasks root is derived as the SIBLING of teams_root
@@ -392,7 +508,7 @@ def _resume_census_unique_candidate(teams_root: Path, session_id: str) -> str | 
     try:
         tasks_root = teams_root.parent / "tasks"
         cutoff = time.time() - RESUME_CENSUS_RECENCY_SECONDS
-        candidates: list[str] = []
+        candidates: list[tuple[str, dict]] = []
         for entry in sorted(teams_root.iterdir()):
             try:
                 if not entry.is_dir():
@@ -411,14 +527,20 @@ def _resume_census_unique_candidate(teams_root: Path, session_id: str) -> str | 
                 # candidate (mirrors the identity-match loop's tamper guard).
                 if not is_safe_path_component(entry.name):
                     continue
-                candidates.append(entry.name)
+                candidates.append((entry.name, data))
             except (OSError, json.JSONDecodeError, ValueError, TypeError,
                     AttributeError):
                 # Unreadable / malformed sibling — skip it, keep scanning.
                 continue
-        if len(candidates) == 1:
-            return candidates[0]
-        return None
+        if len(candidates) != 1:
+            # Zero or >= 2: ambiguous -> fail-safe stale default.
+            return None
+        winner_name, winner_config = candidates[0]
+        if not _resume_census_candidate_corroborated(winner_name, winner_config):
+            # Unique but UNBOUND to this session (pre-birth window / foreign
+            # sibling): suppress — never return a uniqueness-only winner.
+            return None
+        return winner_name
     except Exception:
         # Total fail-safe: the census is an upgrade path, never a new raise
         # source. Any unexpected error -> "no candidate" -> stale default.
@@ -455,12 +577,16 @@ def _resolve_aligned_team_name(
     was provisioned under a new id while hook frames still carry the OLD
     session id) can still be realigned: census the teams root for the
     single LIVE re-provisioned team (config leadSessionId != this session's
-    id, tasks store mtime within RESUME_CENSUS_RECENCY_SECONDS). Gated by
-    a journal lived-session witness (prior team activity in THIS session's
-    journal — kills cold-start concurrent-session cross-alignment) and by
-    the fallback team's config being ABSENT (post-convergence the census
-    goes inert). UNAMBIGUOUS-only: exactly one candidate wins; zero or >= 2
-    fall to the fail-safe default. See the inline branch-3 comment.
+    id, tasks store mtime within RESUME_CENSUS_RECENCY_SECONDS), and return
+    it only if it CORROBORATES as this session's team (lead member cwd
+    anchor + birth order — see _resume_census_candidate_corroborated; F1:
+    uniqueness alone is not an ownership proof). Gated by a journal
+    lived-session witness (prior team activity in THIS session's journal —
+    kills cold-start concurrent-session cross-alignment) and by the
+    fallback team's config being ABSENT (post-convergence the census goes
+    inert). UNAMBIGUOUS-only: exactly one candidate wins; zero, >= 2, or an
+    uncorroborated unique candidate fall to the fail-safe default. See the
+    inline branch-3 comment.
 
     FAIL-SAFE DEFAULT: on no identity match (the team dir is half-formed —
     ``inboxes/`` present but ``config.json`` not yet written — or simply

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -423,9 +423,10 @@ def _resume_census_candidate_corroborated(
         config's leadAgentId (the platform's first-class key — NOT a
         members[0] or shape heuristic). A member-less / malformed config
         corroborates nothing -> suppressed.
-      * SELF-CONSISTENCY: the lead's agentId embeds "@<team-dir-name>",
+      * SELF-CONSISTENCY: the lead's agentId ENDS WITH "@<team-dir-name>",
         binding the entry to the dir it sits in (a config copied from
-        another team's dir fails this).
+        another team's dir — or from a longer-named team into a
+        prefix-named dir — fails this; #1514).
       * SUBJECT ANCHOR: the lead entry's cwd must RAW-match (no resolve —
         an unresolved mismatch only ever fails safe) the hook process's
         LIVE cwd OR the persisted project_dir — the re-provisioned team's
@@ -453,7 +454,10 @@ def _resume_census_candidate_corroborated(
         lead_agent_id = str(config_data.get("leadAgentId", ""))
         if not lead_agent_id:
             return False
-        if f"@{team_dir_name}" not in lead_agent_id:
+        # SUFFIX match (#1514), not substring: a config copied from
+        # session-aaaa1111 into a dir named session-aaaa must NOT
+        # corroborate — "@<dir>" has to be the agentId's TAIL.
+        if not lead_agent_id.endswith(f"@{team_dir_name}"):
             return False
         lead_entry = None
         for member in config_data.get("members") or []:
@@ -485,8 +489,9 @@ def _resume_census_unique_candidate(teams_root: Path, session_id: str) -> str | 
     unambiguous AND corroborated as this session's own.
 
     Enumerates teams/*/config.json. A dir is a CANDIDATE iff its
-    config.json carries a leadSessionId DIFFERENT from this session's id
-    AND its sibling tasks/<dir>/ store mtime falls within
+    config.json carries a REAL string leadSessionId DIFFERENT from this
+    session's id (a config missing/null on the field is malformed and
+    never counts) AND its sibling tasks/<dir>/ store mtime falls within
     RESUME_CENSUS_RECENCY_SECONDS of now (the "live team" signal). Returns
     the dir name only when EXACTLY ONE candidate survives AND that
     candidate corroborates as this session's team (see
@@ -516,7 +521,14 @@ def _resume_census_unique_candidate(teams_root: Path, session_id: str) -> str | 
                 data = json.loads(
                     (entry / "config.json").read_text(encoding="utf-8")
                 )
-                if data.get("leadSessionId") == session_id:
+                # M1: a candidate must carry a REAL string leadSessionId that
+                # differs from this session's id. A config MISSING the field
+                # (None) is malformed and no longer counts — the != alone
+                # would treat absence as foreign identity.
+                candidate_lead_sid = data.get("leadSessionId")
+                if not isinstance(candidate_lead_sid, str):
+                    continue
+                if candidate_lead_sid == session_id:
                     continue  # this session's own team — identity-match owns it
                 tasks_dir = tasks_root / entry.name
                 if not tasks_dir.is_dir():

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -18,6 +18,7 @@ import re
 import secrets
 import sys
 import tempfile
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -309,6 +310,121 @@ def get_pact_context() -> dict:
         return _cache
 
 
+# Recency window for the branch-3 resume census (#1507), in SECONDS: a
+# candidate team's tasks/<dir>/ store mtime must be within this window of
+# "now" to count as LIVE. RESUME_CENSUS_RECENCY_SECONDS = 900 (15 minutes)
+# — minutes-scale so a resume followed by a delayed dispatch still lands
+# inside the window, while aged stores fall out. The window is a NARROWING
+# parameter only: zero or >= 2 surviving candidates always fail safe to the
+# persisted default, so a mis-tuned window can only suppress the census,
+# never mis-align.
+RESUME_CENSUS_RECENCY_SECONDS = 900
+
+# Journal event types proving prior TEAM ACTIVITY for the branch-3 census
+# witness (see _journal_has_team_activity). `task_*` types are matched by
+# prefix; these three are matched exactly. `dispatch_decision` has an
+# ACTIVE writer (dispatch_gate emits one per gate decision; only its READER
+# was retired with the Q5 coverage ratio), so the type is DELIBERATELY in
+# the witness set — dispatch events are real lived-session activity.
+_RESUME_CENSUS_ACTIVITY_EXACT_TYPES = frozenset(
+    {"dispatch_decision", "session_end", "session_consolidated"}
+)
+
+
+def _journal_has_team_activity() -> bool:
+    """Branch-3 witness (#1507): has THIS session LIVED as a team session?
+
+    Proves the journal get_session_dir() points at contains at least one
+    prior team ACTIVITY event (`task_*` / `dispatch_decision` /
+    `session_end` / `session_consolidated`). This is the load-bearing
+    cold-start guard: a FRESH session's journal has no prior team activity,
+    so its census can never fire — without this witness, a fresh session
+    (own team config unborn in the ~38 s cold-start window) plus a
+    concurrently ACTIVE second PACT session would present exactly one
+    candidate (the OTHER session) and the unambiguous-only rule alone would
+    mis-align to it.
+
+    Pure read; NEVER raises (any error -> False, i.e. census does not fire).
+
+    The session_journal import is FUNCTION-LOCAL on purpose: session_journal
+    itself imports pact_context function-LOCAL (see its get_session_dir /
+    is_initialized call sites — there is no module-level cycle), so this
+    mirrors the package's existing import idiom and keeps the journal
+    reader loaded only on the census path.
+    """
+    try:
+        session_dir = get_session_dir()
+        if not session_dir:
+            return False
+        from .session_journal import read_events_from
+
+        for event in read_events_from(session_dir):
+            event_type = str(event.get("type", ""))
+            if (
+                event_type.startswith("task_")
+                or event_type in _RESUME_CENSUS_ACTIVITY_EXACT_TYPES
+            ):
+                return True
+        return False
+    except Exception:
+        # Never raises: the witness is a gate, and an unreadable/missing
+        # journal means "cannot prove a lived session" -> census stays off.
+        return False
+
+
+def _resume_census_unique_candidate(teams_root: Path, session_id: str) -> str | None:
+    """Branch-3 census (#1507): the single LIVE re-provisioned team, if
+    unambiguous.
+
+    Enumerates teams/*/config.json. A dir is a CANDIDATE iff its
+    config.json carries a leadSessionId DIFFERENT from this session's id
+    AND its sibling tasks/<dir>/ store mtime falls within
+    RESUME_CENSUS_RECENCY_SECONDS of now (the "live team" signal). Returns
+    the dir name only when EXACTLY ONE candidate survives (unambiguous-only);
+    None on zero, on >= 2 (two simultaneous broken resumes -> stale
+    default), or on any error.
+
+    Pure / FS-read-only / NEVER raises — same contract as the resolver that
+    calls it. The tasks root is derived as the SIBLING of teams_root
+    (teams_root.parent / "tasks") so a teams_dir override relocates the
+    tasks probe with it.
+    """
+    try:
+        tasks_root = teams_root.parent / "tasks"
+        cutoff = time.time() - RESUME_CENSUS_RECENCY_SECONDS
+        candidates: list[str] = []
+        for entry in sorted(teams_root.iterdir()):
+            try:
+                if not entry.is_dir():
+                    continue
+                data = json.loads(
+                    (entry / "config.json").read_text(encoding="utf-8")
+                )
+                if data.get("leadSessionId") == session_id:
+                    continue  # this session's own team — identity-match owns it
+                tasks_dir = tasks_root / entry.name
+                if not tasks_dir.is_dir():
+                    continue  # no live task store under this name
+                if tasks_dir.stat().st_mtime < cutoff:
+                    continue  # live-looking config, but an AGED task store
+                # Path-safety the dir name BEFORE accepting it as a
+                # candidate (mirrors the identity-match loop's tamper guard).
+                if not is_safe_path_component(entry.name):
+                    continue
+                candidates.append(entry.name)
+            except (OSError, json.JSONDecodeError, ValueError, TypeError,
+                    AttributeError):
+                # Unreadable / malformed sibling — skip it, keep scanning.
+                continue
+        if len(candidates) == 1:
+            return candidates[0]
+        return None
+    except Exception:
+        # Total fail-safe: the census is an upgrade path, never a new raise
+        # source. Any unexpected error -> "no candidate" -> stale default.
+        return None
+
+
 def _resolve_aligned_team_name(
     session_id: str,
     teams_dir: str | None = None,
@@ -332,6 +448,19 @@ def _resolve_aligned_team_name(
     first-class. A stale/foreign dir from another session carries a DIFFERENT
     ``leadSessionId`` and is rejected, so an ``id8`` collision cannot
     mis-resolve.
+
+    BRANCH-3 RESUME CENSUS (#1507): after branch-1 (identity match) and
+    branch-2 (config-less full-UUID witness) both miss, a RESUMED session
+    (clean end-session reaped the old team config; a new team + task store
+    was provisioned under a new id while hook frames still carry the OLD
+    session id) can still be realigned: census the teams root for the
+    single LIVE re-provisioned team (config leadSessionId != this session's
+    id, tasks store mtime within RESUME_CENSUS_RECENCY_SECONDS). Gated by
+    a journal lived-session witness (prior team activity in THIS session's
+    journal — kills cold-start concurrent-session cross-alignment) and by
+    the fallback team's config being ABSENT (post-convergence the census
+    goes inert). UNAMBIGUOUS-only: exactly one candidate wins; zero or >= 2
+    fall to the fail-safe default. See the inline branch-3 comment.
 
     FAIL-SAFE DEFAULT: on no identity match (the team dir is half-formed —
     ``inboxes/`` present but ``config.json`` not yet written — or simply
@@ -452,6 +581,39 @@ def _resolve_aligned_team_name(
             )
         ):
             return session_id
+        # Branch-3: resume census (#1507). After a clean end-session, resume
+        # provisions a NEW team + task store under a new id while every hook
+        # frame still carries the OLD session id. Identity-match (branch-1)
+        # cannot fire: the new config carries a leadSessionId != this
+        # session's id, and the OLD team's config was reaped at end-session.
+        # Census the live teams root for the single recently-active
+        # re-provisioned team. TRIGGER — all conjuncts, cheapest first:
+        #   * fallback non-empty + path-safe (an empty fail-safe default
+        #     has nothing to realign; get_team_name already short-circuits
+        #     an EMPTY SSOT before calling the resolver, so this branch is
+        #     reachable only on the NON-empty path — the empty-SSOT
+        #     fail-closed gate stays untouched).
+        #   * the fallback team's OWN config.json is ABSENT (teams/<fallback>
+        #     missing or half-formed — the reaped-old-team signal; post-
+        #     convergence the write-back persists the census winner, its
+        #     config EXISTS, this conjunct goes false, and the census is
+        #     inert — no flicker).
+        #   * journal lived-session witness (_journal_has_team_activity) —
+        #     prior team activity in THIS session's journal. Kills the
+        #     cold-start concurrent-session cross-alignment: a fresh
+        #     session's journal has no prior activity, so its census never
+        #     fires even when another live session is the sole candidate.
+        # UNAMBIGUOUS-only: zero or >= 2 candidates -> fall through to the
+        # fail-safe default, byte-identical to today.
+        if (
+            fallback
+            and is_safe_path_component(fallback)
+            and not (teams_root / fallback / "config.json").exists()
+            and _journal_has_team_activity()
+        ):
+            census_winner = _resume_census_unique_candidate(teams_root, session_id)
+            if census_winner is not None:
+                return census_winner
         return fallback
     except Exception:
         # TOTAL fail-safe: home-resolution RuntimeError (get_claude_config_dir

--- a/pact-plugin/hooks/shared/stale_session.py
+++ b/pact-plugin/hooks/shared/stale_session.py
@@ -41,7 +41,7 @@ _STALENESS_WARNING_TEMPLATE = (
     "{actual}. session_init likely failed at SessionStart this session "
     "(or the CLAUDE.md write failed). Do NOT trust the recorded Team/"
     "Session dir/Resume lines for THIS session; completing bootstrap "
-    "will rewrite them."
+    "will rewrite the CLAUDE.md session records."
 )
 
 # FORWARD NOTE — a SIBLING restart-detection signal is planned for this leaf:

--- a/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
+++ b/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
@@ -565,6 +565,85 @@ def test_every_known_cause_carries_its_own_marker(tmp_path, monkeypatch, capsys)
 
 
 # ══════════════════════════════════════════════════════════════════════════
+# Cause (2)'s REMEDY — the measured manual repoint, not a bootstrap pointer
+# ══════════════════════════════════════════════════════════════════════════
+
+# Elements of the measured recovery, hardcoded per the POST-FIX marker
+# convention above (importing a post-fix symbol would yield an ImportError
+# artifact under revert rather than a behavioural failure). ASCII-only, and
+# the positive assertions below are their own liveness check.
+_CAUSE2_RECOVERY_MARKERS = (
+    "OLD session",
+    "pact-session-context.json",
+    "teams/session-*/config.json",
+    "session_id",
+    "journal",
+)
+
+# The falsified claim, in the constructions already seen. Same declared
+# bound as the other phrase denylists in this file: it cannot be complete
+# over free prose; it forces a human to look when the known-bad construction
+# returns. Completing bootstrap does NOT rewrite the persisted team records,
+# so the pointer sent that operator to a ritual that changed nothing.
+_FORBIDDEN_INERT_REMEDIES = (
+    "bootstrap ritual rewrites",
+    "bootstrap also rewrites",
+    "rewrites those records",
+    "bootstrap will rewrite",
+)
+
+
+def test_cause_two_names_the_measured_manual_repoint_not_a_bootstrap_pointer(
+    tmp_path, monkeypatch, capsys
+):
+    """COUPLED PAIR IN ONE BODY: the recovery elements PRESENT and the inert
+    bootstrap-pointer phrasings ABSENT, asserted against the SAME emitted
+    deny. Either half alone is vacuous — absence-only passes on a cause (2)
+    emptied of any remedy at all; presence-only passes with the inert
+    pointer still appended after the real recovery.
+
+    The recovery pinned here is the MEASURED one: set team_name in the OLD
+    session's pact-session-context.json to the LIVE team, leaving
+    session_id + the journal dir untouched (journal continuity). "OLD
+    session" is the load-bearing element — after a resume there are two
+    session dirs and only the OLD one holds the records this gate reads.
+
+    Written against observable deny text only, importing no post-fix symbol,
+    so it carries revert-cardinality like its section neighbours.
+    """
+    _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
+    _write_project_claude_md(monkeypatch, tmp_path, _LIVE_SESSION_ID)
+    _reset_context_caches(monkeypatch)
+
+    code, out = _run_main(_make_input(), capsys)
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+
+    assert code == 2, "rule 8 must actually DENY, else this test is vacuous"
+    assert _ENUM_MARKER in reason, "enumeration absent — nothing to check"
+    assert _CAUSE_MARKERS[2] in reason, "precondition: cause 2 present"
+
+    for marker in _CAUSE2_RECOVERY_MARKERS:
+        assert marker.isascii(), (
+            f"cause-2 recovery marker is not ASCII-only: {marker!r}. A "
+            "marker that spans a non-ASCII character invites a "
+            "transcription that substitutes a hyphen for U+2014, after "
+            "which it can never fail."
+        )
+        assert marker in reason, (
+            f"measured-recovery element missing from cause (2): {marker!r}. "
+            "The reader in this cause is being sent to chase a team "
+            "mismatch without the one edit that recovers it."
+        )
+    for phrase in _FORBIDDEN_INERT_REMEDIES:
+        assert phrase not in reason, (
+            f"inert bootstrap-pointer remedy reintroduced: {phrase!r}. "
+            "Completing bootstrap does not rewrite these records, so that "
+            "pointer sends the operator to a ritual that changes nothing "
+            "for this denial."
+        )
+
+
+# ══════════════════════════════════════════════════════════════════════════
 # Advice soundness — the branch arms NARROW, they do not CLOSE
 # ══════════════════════════════════════════════════════════════════════════
 

--- a/pact-plugin/tests/test_dispatch_gate_stale_diagnosis.py
+++ b/pact-plugin/tests/test_dispatch_gate_stale_diagnosis.py
@@ -67,7 +67,13 @@ from dispatch_gate import _STALE_REALIGN_HINT  # noqa: E402
 # A marker substring unique to the augmentation — asserting on it proves the
 # net-new self-diagnosis text is present without coupling to exact wording.
 _AUGMENT_MARKER = "STALE-TEAM/STORE MISMATCH"
-_REALIGN_MARKER = "pact-session-context.json"
+# NOT the context filename: the rule-⑧ cause enumeration's cause (2) now
+# names pact-session-context.json too (both texts deliberately name the same
+# measured recovery), so on every leg where the enumeration legitimately
+# appends the filename appears WITHOUT this hint and a filename marker would
+# false-fail the absence cells. "Working recovery" is unique to the hint's
+# remedy block; the enumeration says only "Recovery:".
+_REALIGN_MARKER = "Working recovery"
 
 
 def test_stale_markers_are_live_and_ascii():
@@ -118,6 +124,81 @@ def test_stale_markers_are_live_and_ascii():
             "file is now vacuous. Re-derive the marker from the production "
             "constant; do not re-type it."
         )
+
+# =============================================================================
+# The REMEDY the hint names — the measured manual repoint, not a pointer at
+# the bootstrap ritual. Completing bootstrap does NOT rewrite the persisted
+# team records, so the earlier pointer ("Completing /PACT:bootstrap also
+# rewrites those records.") sent the operator to a ritual that changed
+# nothing for this denial; the measured working recovery is a manual edit.
+# =============================================================================
+
+# Elements of the measured recovery. Each is ASCII-only and typed once; the
+# positive assertions below are their own liveness check (a marker absent
+# from the live constant fails the test, not silently passes).
+_RECOVERY_MARKERS = (
+    "OLD session",
+    "pact-session-context.json",
+    "teams/session-*/config.json",
+    "session_id",
+    "journal",
+)
+
+# The falsified claim, in the constructions already seen. A phrase denylist
+# over free prose cannot be complete — its job is to force a human to look
+# when the known-bad construction returns, exactly like the sibling
+# tripwires in test_dispatch_gate_cause_enumeration.py.
+_FORBIDDEN_INERT_REMEDIES = (
+    "bootstrap ritual rewrites",
+    "bootstrap also rewrites",
+    "rewrites those records",
+    "bootstrap will rewrite",
+)
+
+
+def test_hint_names_the_measured_manual_repoint_not_a_bootstrap_pointer(
+    tmp_path, monkeypatch, capsys
+):
+    """COUPLED PAIR IN ONE BODY: the recovery elements PRESENT and the inert
+    bootstrap-pointer phrasings ABSENT, asserted against the SAME emitted
+    deny. Either half alone is vacuous — absence-only passes on a hint
+    emptied of any remedy at all; presence-only passes with the inert
+    pointer still appended after the real recovery.
+
+    The recovery pinned here is the MEASURED one: edit
+    pact-session-context.json in the OLD session's directory, set team_name
+    to the LIVE team, and leave session_id + the journal dir untouched
+    (journal continuity). "OLD session" is the load-bearing element — after
+    a resume there are two session dirs and only the OLD one holds the
+    records this gate reads.
+    """
+    _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
+    _seed_team_with_lead(tmp_path, _TEAM, _LIVE_SESSION_ID)
+    _write_project_claude_md(monkeypatch, tmp_path, _RECORDED_STALE_ID)
+
+    code, out = _run_main(_make_input(), capsys)
+
+    assert code == 2, "stale-mismatch deny must still fire, else vacuous"
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert _AUGMENT_MARKER in reason, "precondition: the hint actually appended"
+
+    for marker in _RECOVERY_MARKERS:
+        assert marker.isascii(), f"recovery marker not ASCII-only: {marker!r}"
+        assert marker in reason, (
+            f"measured-recovery element missing from the hint: {marker!r}"
+        )
+    # Scoped to the HINT constant, not the emitted reason: the shared
+    # detector's stale-block — legitimately prepended on this leg — carries
+    # its own "completing bootstrap will rewrite them" claim about the
+    # CLAUDE.md records, which is a different sentence from a different
+    # module and not this tripwire's subject.
+    for phrase in _FORBIDDEN_INERT_REMEDIES:
+        assert phrase not in _STALE_REALIGN_HINT, (
+            f"inert bootstrap-pointer remedy reintroduced into the hint: "
+            f"{phrase!r}. Completing bootstrap does not rewrite these "
+            "records."
+        )
+
 
 # session_id values for the both-modes matrix.
 _LIVE_SESSION_ID = "test-session"          # the stdin session_id _make_input uses

--- a/pact-plugin/tests/test_dispatch_gate_stale_diagnosis.py
+++ b/pact-plugin/tests/test_dispatch_gate_stale_diagnosis.py
@@ -189,8 +189,8 @@ def test_hint_names_the_measured_manual_repoint_not_a_bootstrap_pointer(
         )
     # Scoped to the HINT constant, not the emitted reason: the shared
     # detector's stale-block — legitimately prepended on this leg — carries
-    # its own "completing bootstrap will rewrite them" claim about the
-    # CLAUDE.md records, which is a different sentence from a different
+    # its own "completing bootstrap will rewrite the CLAUDE.md session
+    # records" claim, which is a different sentence from a different
     # module and not this tripwire's subject.
     for phrase in _FORBIDDEN_INERT_REMEDIES:
         assert phrase not in _STALE_REALIGN_HINT, (

--- a/pact-plugin/tests/test_resume_team_realign_1507.py
+++ b/pact-plugin/tests/test_resume_team_realign_1507.py
@@ -54,6 +54,7 @@ the FAIL counts — an xfailed cell reports xfailed, not failed):
 
 import io
 import json
+import os
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -137,17 +138,32 @@ def _write_context(monkeypatch, tmp_path, plugin_root, *, team_name,
 
 
 def _seed_team_store(config_root, *, team_name, lead_session_id, members=(),
-                     tasks=()):
+                     tasks=(), corroborate=False, lead_cwd=None,
+                     joined_at=None):
     """Platform-shaped team store under a CONFIG ROOT (the dir
     get_claude_config_dir() resolves to — tmp/.claude for the default-root
     worlds, the scratch root itself for the CLAUDE_CONFIG_DIR cell):
     teams/{team}/config.json (name + leadSessionId + members) plus
-    tasks/{team}/*.json task files."""
+    tasks/{team}/*.json task files. corroborate=True adds the F1 ownership
+    binding fields the staged corroboration requires (leadAgentId
+    first-class key + the members[] lead entry found by agentId ==, with
+    cwd/joinedAt as given); a MINIMAL config (corroborate=False) is the
+    member-less shape the fix deliberately SUPPRESSES."""
     team_dir = config_root / "teams" / team_name
     team_dir.mkdir(parents=True, exist_ok=True)
     config = {"name": team_name, "members": [{"name": m} for m in members]}
     if lead_session_id is not None:
         config["leadSessionId"] = lead_session_id
+    if corroborate:
+        lead_agent_id = f"team-lead@{team_name}"
+        config["leadAgentId"] = lead_agent_id
+        config["members"] = [{
+            "agentId": lead_agent_id,
+            "name": "team-lead",
+            "cwd": lead_cwd,
+            "joinedAt": joined_at if joined_at is not None
+            else CORROBORATED_JOINED_AT_MS,
+        }]
     (team_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
     tasks_dir = config_root / "tasks" / team_name
     tasks_dir.mkdir(parents=True, exist_ok=True)
@@ -223,8 +239,9 @@ def _reset_aligned_cache():
 
 
 def _seed_census_world(monkeypatch, tmp_path, *, live_team=NEW_TEAM_ID8,
-                       live_lead_sid=NEW_SID, journal_events=("task_claimed",),
-                       with_journal=True, tasks=((_NAME, "pending"),)):
+                       live_lead_sid=NEW_SID, journal_events=("task_metadata_snapshot",),
+                       with_journal=True, tasks=((_NAME, "pending"),),
+                       corroborate_live_team=True, live_lead_cwd=None):
     """The canonical #1507 world: OLD team config REAPED (dir absent), the
     live re-provisioned team present with a fresh task store carrying the
     owner's task (non-vacuity: an ALLOW is reachable ONLY by resolving the
@@ -239,6 +256,9 @@ def _seed_census_world(monkeypatch, tmp_path, *, live_team=NEW_TEAM_ID8,
     _seed_team_store(
         tmp_path / ".claude", team_name=live_team,
         lead_session_id=live_lead_sid, members=(), tasks=tasks,
+        corroborate=corroborate_live_team,
+        lead_cwd=(live_lead_cwd if live_lead_cwd is not None
+                  else str(tmp_path / "project")),  # RAW-matches project_dir
     )
     # The stale team is FULLY reaped: neither its config nor its dir exists.
     assert not (tmp_path / ".claude" / "teams" / OLD_TEAM).exists()
@@ -405,7 +425,7 @@ def test_iii_empty_ssot_fails_closed_with_census_inputs(tmp_path, monkeypatch,
     _seed_team_store(tmp_path / ".claude", team_name=NEW_TEAM_ID8,
                      lead_session_id=NEW_SID, members=(),
                      tasks=((_NAME, "pending"),))
-    _seed_session_journal(monkeypatch, tmp_path, ["task_claimed"])
+    _seed_session_journal(monkeypatch, tmp_path, ["task_metadata_snapshot"])
     import shared.pact_context as ctx_module
     assert ctx_module.get_team_name() == ""
     spawn = _make_spawn()
@@ -440,7 +460,7 @@ def test_iv_identity_match_outranks_census(tmp_path, monkeypatch, capsys):
     # A census candidate that WOULD win if the census ran first.
     _seed_team_store(tmp_path / ".claude", team_name=NEW_TEAM_ID8,
                      lead_session_id=NEW_SID, members=(), tasks=())
-    _seed_session_journal(monkeypatch, tmp_path, ["task_claimed"])
+    _seed_session_journal(monkeypatch, tmp_path, ["task_metadata_snapshot"])
     code, out = _run_dispatch(_make_spawn(), capsys)
     assert code == 0, "identity-match must resolve before the census"
     import shared.pact_context as ctx_module
@@ -477,7 +497,7 @@ def test_v_branch2_witness_preempts_census(tmp_path, monkeypatch, capsys):
     # The census candidate that would win if ordering were inverted.
     _seed_team_store(tmp_path / ".claude", team_name=NEW_TEAM_ID8,
                      lead_session_id=NEW_SID, members=(), tasks=())
-    _seed_session_journal(monkeypatch, tmp_path, ["task_claimed"])
+    _seed_session_journal(monkeypatch, tmp_path, ["task_metadata_snapshot"])
     code, out = _run_dispatch(_make_spawn(), capsys)
     assert code == 0, "branch-2 must preempt the census on own-substrate"
     import shared.pact_context as ctx_module
@@ -544,7 +564,7 @@ def test_vii_post_convergence_stable_with_foreign_candidate(tmp_path,
                      tasks=((_NAME, "pending"),))
     _seed_team_store(tmp_path / ".claude", team_name=FOREIGN_TEAM,
                      lead_session_id=FOREIGN_SID, members=(), tasks=())
-    _seed_session_journal(monkeypatch, tmp_path, ["task_claimed"])
+    _seed_session_journal(monkeypatch, tmp_path, ["task_metadata_snapshot"])
     code, out = _run_dispatch(_make_spawn(), capsys)
     assert code == 0, "post-convergence resolution must stay on the winner"
     import shared.pact_context as ctx_module
@@ -576,7 +596,9 @@ def test_viii_scratch_root_no_default_root_leakage(tmp_path, monkeypatch,
     # The LIVE candidate under the SCRATCH root (owner's task lives here).
     _seed_team_store(scratch, team_name=NEW_TEAM_ID8,
                      lead_session_id=NEW_SID, members=(),
-                     tasks=((_NAME, "pending"),))
+                     tasks=((_NAME, "pending"),),
+                     corroborate=True,
+                     lead_cwd=str(tmp_path / "project"))
     # The journal witness must also resolve under the scratch root.
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     import shared.pact_context as ctx_module
@@ -586,7 +608,7 @@ def test_viii_scratch_root_no_default_root_leakage(tmp_path, monkeypatch,
     )
     session_dir.mkdir(parents=True, exist_ok=True)
     (session_dir / "session-journal.jsonl").write_text(
-        json.dumps({"v": 1, "type": "task_claimed",
+        json.dumps({"v": 1, "type": "task_metadata_snapshot",
                     "ts": "2026-08-24T00:00:00Z"}) + "\n",
         encoding="utf-8",
     )
@@ -660,10 +682,16 @@ def test_x_config_missing_leadsessionid_counts_as_candidate(
                    team_name=OLD_TEAM, session_id=OLD_SID)
     _reset_aligned_cache()
     # The malformed candidate: config.json EXISTS but carries NO
-    # leadSessionId key; fresh sibling tasks store.
+    # leadSessionId key; fresh sibling tasks store. Corroboration fields ARE
+    # present, so the candidate is BOTH counted and bound — post-remediation
+    # semantics (resolver-coder's note): a missing leadSessionId still COUNTS
+    # as a candidate, realigning only when corroborated; a malformed-config
+    # positive realign requires the binding fields, which corroborate=True
+    # provides.
     _seed_team_store(tmp_path / ".claude", team_name=NEW_TEAM_ID8, lead_session_id=None,
-                     members=(), tasks=())
-    _seed_session_journal(monkeypatch, tmp_path, ["task_claimed"])
+                     members=(), tasks=(),
+                     corroborate=True, lead_cwd=str(tmp_path / "project"))
+    _seed_session_journal(monkeypatch, tmp_path, ["task_metadata_snapshot"])
     import shared.pact_context as ctx_module
     resolved = ctx_module._resolve_aligned_team_name(
         OLD_SID, teams_dir=str(tmp_path / ".claude" / "teams"),
@@ -725,3 +753,365 @@ def test_xi_stale_block_and_working_recovery_coexist_scoped(tmp_path,
     # ...and the composer did NOT also append the enumeration (A-xor-B), so
     # no second, competing remedy block rides in the same message.
     assert _ENUMERATION_HEADER not in reason
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 15. REMEDIATION CYCLE 1 (F1-F7) — cells written against the ACCEPTANCE BAR in
+#     docs/review/1507-resume-team-realign-review.md, NOT against any
+#     implementation. The F1 cells were RED against the pre-fix source (the
+#     reproduced defect) and are GREEN against the landed corroboration —
+#     they now PIN that contract; a regression back to unbound uniqueness
+#     reddens them. The F2-F7 pins pin the named conjuncts/stances.
+# ══════════════════════════════════════════════════════════════════════════════
+
+# The ONLY task_*-prefixed journal type any real hook writes (verified against
+# _REQUIRED_FIELDS_BY_TYPE in shared/session_journal.py — no emitter of any
+# other task_* type exists in hooks/). Used for witness seeds in place of the
+# fictional "task_claimed" the original suite seeded (review F6 nit).
+REAL_TASK_EVENT = "task_metadata_snapshot"
+# Epoch MILLIS strictly after the journals' seeded ts (2026-08-24T00:00:00Z
+# = 1787529600000 ms): the corroborated lead JOINED after the old life
+# ended, satisfying the birth-order strengthening for journals that seed an
+# end-of-life marker (session_end / session_consolidated legs). The constant
+# itself is 2026-08-24T10:40:00Z — comfortably after, never boundary-adjacent.
+CORROBORATED_JOINED_AT_MS = 1787568000000
+
+
+def _seed_scenario_a_world(monkeypatch, tmp_path, *, journal_events,
+                           foreign_tasks=((_NAME, "pending"),),
+                           foreign_corroboration="foreign-cwd",
+                           foreign_joined_at_ms=None):
+    """SCENARIO A (review F1): a LIVED session (journal armed) whose OWN new
+    team substrate is UNBORN (old config reaped, no own-team config anywhere)
+    while a concurrently ACTIVE sibling session's team is the SOLE fresh
+    candidate. Pre-fix, the census aligns to the FOREIGN team and the write-
+    back makes it sticky; the acceptance bar requires STALE DEFAULT here.
+    foreign_corroboration selects the binding arm: "foreign-cwd" seeds the
+    FULL corroboration fields with the sibling's OWN cwd (the real F1 kill —
+    suppressed by the subject anchor); "own-cwd" seeds them pointing at THIS
+    session's project dir (the documented same-dir residual — aligns);
+    "none" seeds the minimal member-less config (suppressed: corroborates
+    nothing)."""
+    plugin_root = tmp_path / "plugin"
+    _seed_plugin(plugin_root)
+    _write_context(monkeypatch, tmp_path, plugin_root,
+                   team_name=OLD_TEAM, session_id=OLD_SID)
+    _reset_aligned_cache()
+    # The sole candidate: a FOREIGN concurrent session's team — config carries
+    # ITS leadSessionId, fresh task store holding the owner's task (so an
+    # ALLOW is reachable ONLY via foreign alignment: the mis-alignment is
+    # observable, not hypothetical).
+    _seed_team_store(
+        tmp_path / ".claude", team_name=FOREIGN_TEAM,
+        lead_session_id=FOREIGN_SID, members=(), tasks=foreign_tasks,
+        corroborate=(foreign_corroboration != "none"),
+        lead_cwd=(str(tmp_path / "project")
+                  if foreign_corroboration == "own-cwd"
+                  else "/foreign/sibling/session"),
+        joined_at=foreign_joined_at_ms,
+    )
+    _seed_session_journal(monkeypatch, tmp_path, list(journal_events))
+    return plugin_root
+
+
+class TestF1OwnershipBinding:
+    """F1 (BLOCKING, security+backend independently): the census candidate
+    predicate has NO ownership tie and the witness is armable by the gate's
+    OWN DENIALS. Acceptance bar (review doc, all four): scenario A -> stale
+    default; post-birth semantics unchanged; write-back cannot persist an
+    uncorroborated winner. These cells assert the POST-FIX contract."""
+
+    def test_f1a_scenario_a_stale_default(self, tmp_path, monkeypatch, capsys):
+        """ACCEPTANCE 2 — scenario A gate-level: lived journal (armed via the
+        REAL task_* type) + own team config ABSENT + sole foreign fresh store
+        -> resolution stays the STALE DEFAULT and the gate DENIES. NON-VACUITY:
+        the owner's task lives ONLY under the foreign team, so an ALLOW would
+        PROVE the sticky cross-session mis-alignment (the pre-fix behavior and
+        the backend lane's sandboxed repro). EXPECTED RED until the fix lands."""
+        _seed_scenario_a_world(monkeypatch, tmp_path,
+                               journal_events=[REAL_TASK_EVENT],
+                               foreign_corroboration="foreign-cwd")
+        import shared.pact_context as ctx_module
+        assert ctx_module.get_team_name() == OLD_TEAM
+        code, out = _run_dispatch(_make_spawn(), capsys)
+        assert code == 2, "scenario A must not align to the foreign team"
+        reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "no Task assigned" in reason
+        assert ctx_module.get_team_name() != FOREIGN_TEAM
+
+    def test_f1b_deny_armed_witness_never_aligns(self, tmp_path, monkeypatch,
+                                                 capsys):
+        """F2-family acceptance — the witness must NOT be armable by the
+        guarded system's OWN denials: dispatch_gate journals EVERY decision
+        including denies (dispatch_gate.py _journal_decision), so one denied
+        spawn writes dispatch_decision. A journal armed ONLY by that event is
+        a session that was denied, not one that LIVED — no alignment. EXPECTED
+        RED against the pre-fix exact-set; dispatch_decision has since been
+        REMOVED — the cell now pins that exclusion (re-adding the type
+        reddens it)."""
+        _seed_scenario_a_world(monkeypatch, tmp_path,
+                               journal_events=["dispatch_decision"],
+                               foreign_corroboration="foreign-cwd")
+        import shared.pact_context as ctx_module
+        assert ctx_module.get_team_name() == OLD_TEAM
+        code, out = _run_dispatch(_make_spawn(), capsys)
+        assert code == 2, "a deny-armed witness must not align"
+
+    def test_f1_repro_security_lane_hermetic(self, tmp_path, monkeypatch):
+        """NAMED REGRESSION PIN — the security lane's hermetic repro, pinned
+        verbatim in shape: same scenario-A substrate observed at the resolver
+        seam. get_team_name() must return the STALE DEFAULT, never the foreign
+        team's name. EXPECTED RED until the fix lands."""
+        _seed_scenario_a_world(monkeypatch, tmp_path,
+                               journal_events=[REAL_TASK_EVENT])
+        import shared.pact_context as ctx_module
+        resolved = ctx_module.get_team_name()
+        assert resolved == OLD_TEAM, (
+            f"cross-session alignment reproduced: resolved {resolved!r}"
+        )
+
+    def test_f1_repro_backend_lane_end_to_end(self, tmp_path, monkeypatch,
+                                              capsys):
+        """NAMED REGRESSION PIN — the backend lane's sandboxed end-to-end
+        repro: pre-fix, the gate ALLOWed a spawn whose owner task lived ONLY
+        under the FOREIGN team's store (the observable mis-alignment). Post-
+        fix contract: DENY on the stale default; the foreign task must not be
+        reachable. Was RED pre-fix (the sandboxed repro); now pins the fix."""
+        _seed_scenario_a_world(monkeypatch, tmp_path,
+                               journal_events=[REAL_TASK_EVENT])
+        code, out = _run_dispatch(_make_spawn(), capsys)
+        assert code == 2
+        assert out != _SUPPRESS_EXPECTED
+
+
+
+    def test_f1_same_cwd_residual_is_pinned(self, tmp_path, monkeypatch,
+                                            capsys):
+        """DOCUMENTED RESIDUAL (backend lane's requested pin): a sibling team
+        whose lead runs from THIS session's directory (cwd RAW-matches the
+        persisted project_dir) passes the subject anchor — the census aligns
+        and the gate ALLOWs against its store. This is the trust-boundary
+        residual the staged corroboration docstring names (same-user
+        same-dir mirroring is out of scope by construction): the cell PINS
+        the boundary honestly rather than pretending a guard exists. If a
+        future hardening narrows it, flip this cell WITH that change.
+        SCOPE NOTE (security footnote b): this residual is closed for FRESH
+        sessions only by the conjunction witness-arming-requires-task-writes
+        AND the atomic substrate birth (config.json lands with the first
+        team write, so an unborn own team never coexists with a readable
+        own config); it would EXTEND to fresh sessions if substrate birth
+        ever lagged task writes."""
+        _seed_scenario_a_world(monkeypatch, tmp_path,
+                               journal_events=[REAL_TASK_EVENT],
+                               foreign_corroboration="own-cwd")
+        import shared.pact_context as ctx_module
+        assert ctx_module.get_team_name() == FOREIGN_TEAM
+        code, out = _run_dispatch(_make_spawn(), capsys)
+        assert code == 0, "same-cwd sibling passes the anchor (residual)"
+
+    def test_f1_same_cwd_pre_birth_suppressed_by_birth_order(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """ROUTED RESIDUAL (resolver-coder #35 open-questions): a sibling in
+        THIS session's directory whose lead JOINED BEFORE the old life ended
+        (joinedAt epoch-millis <= the journal's last session_end ts — a
+        session active ACROSS the resume, not born after it) is suppressed
+        by the birth-order strengthening even though its cwd passes the
+        subject anchor. Requires an end marker in the journal: this cell
+        seeds session_end (which also arms the witness), so the
+        strengthening is ACTIVE, unlike the post-birth residual cell above
+        (no marker -> cwd-only binding)."""
+        # 1787000000000 ms = 2026-08-17T20:53:20Z — strictly BEFORE the
+        # seeded journal ts 2026-08-24T00:00:00Z (1787529600000 ms).
+        _seed_scenario_a_world(monkeypatch, tmp_path,
+                               journal_events=["session_end"],
+                               foreign_corroboration="own-cwd",
+                               foreign_joined_at_ms=1787000000000)
+        import shared.pact_context as ctx_module
+        assert ctx_module.get_team_name() == OLD_TEAM
+        code, out = _run_dispatch(_make_spawn(), capsys)
+        assert code == 2, "pre-birth same-cwd sibling must be suppressed"
+
+    def test_f1_mirroring_boundary_pin(self, tmp_path, monkeypatch, capsys):
+        """ROUTED RESIDUAL (security ruling 6, per resolver-coder #35): a
+        same-user MIRRORING sibling — a config that mirrors every binding
+        field (leadAgentId self-consistent with its own dir, cwd ==
+        THIS session's project dir, joinedAt strictly after our end
+        marker) — PASSES corroboration and the census aligns to it. This is
+        the documented trust boundary: a mirroring adversary can also
+        rewrite the plugin hooks themselves, so mirroring-resistance is out
+        of scope BY CONSTRUCTION. The cell PINS the boundary so a future
+        claim of mirroring-resistance has a test to flip."""
+        _seed_scenario_a_world(monkeypatch, tmp_path,
+                               journal_events=["session_end"],
+                               foreign_corroboration="own-cwd")
+        import shared.pact_context as ctx_module
+        assert ctx_module.get_team_name() == FOREIGN_TEAM
+        code, out = _run_dispatch(_make_spawn(), capsys)
+        assert code == 0, "full mirror passes corroboration (trust boundary)"
+
+@pytest.mark.parametrize("witness_event",
+                         ["session_end", "session_consolidated"],
+                         ids=["session-end-arm", "session-consolidated-arm"])
+def test_f2_witness_exact_set_positive_arms(tmp_path, monkeypatch, capsys,
+                                            witness_event):
+    """F2 pin — each SURVIVING exact-set member must independently arm the
+    witness in the LEGITIMATE no-sibling realign world (old config reaped,
+    own re-provisioned team present with a fresh store holding the owner's
+    task). Dropping session_end (the canonical clean-end witness) or
+    session_consolidated from _RESUME_CENSUS_ACTIVITY_EXACT_TYPES reddens the
+    corresponding leg: the witness stays unarmed and the resolution falls to
+    the stale default. Green against the current source AND mandated green
+    post-fix (acceptance 3: the no-sibling common case still converges)."""
+    _seed_census_world(monkeypatch, tmp_path, live_team=NEW_TEAM_ID8,
+                       live_lead_sid=NEW_SID, journal_events=[witness_event])
+    code, out = _run_dispatch(_make_spawn(), capsys)
+    assert code == 0, f"{witness_event} alone must arm the witness"
+    import shared.pact_context as ctx_module
+    assert ctx_module.get_team_name() == NEW_TEAM_ID8
+
+
+@pytest.mark.parametrize(
+    "lead_cwd_choice,mode",
+    [("live-cwd", "cross-directory-resume"),
+     ("project-dir", "persisted-project")],
+)
+def test_f1_cross_directory_resume_either_match(tmp_path, monkeypatch, capsys,
+                                                lead_cwd_choice, mode):
+    """ROUTED CELL (resolver-coder #35, backend ruling 4) — the subject
+    anchor's EITHER-MATCH design: the lead's cwd RAW-matches the hook
+    process's LIVE os.getcwd() OR the persisted project_dir. A resume
+    launched from a DIFFERENT working directory than the original project
+    still binds via the live-cwd leg; the normal in-project resume binds
+    via the persisted leg. Both legs corroborate and the census realigns —
+    pinning the design so a future narrowing to a single leg flips this
+    cell."""
+    live_cwd = os.getcwd()  # RAW compare — seed exactly what the hook sees
+    _seed_census_world(
+        monkeypatch, tmp_path, live_team=NEW_TEAM_ID8, live_lead_sid=NEW_SID,
+        live_lead_cwd=(live_cwd if lead_cwd_choice == "live-cwd"
+                       else str(tmp_path / "project")),
+    )
+    code, out = _run_dispatch(_make_spawn(), capsys)
+    assert code == 0, f"{mode} leg must corroborate (either-match)"
+
+
+def test_f3_config_without_tasks_store_not_a_candidate(tmp_path, monkeypatch):
+    """F3 pin — the candidate predicate's live-store conjunct: a team dir
+    whose config carries a foreign leadSessionId but whose sibling tasks/
+    store is ABSENT is NOT a candidate (config alone must not win). With it
+    as the sole would-be candidate, the resolution stays the stale default.
+    Green now; reddens if the tasks-dir conjunct is dropped."""
+    plugin_root = tmp_path / "plugin"
+    _seed_plugin(plugin_root)
+    _write_context(monkeypatch, tmp_path, plugin_root,
+                   team_name=OLD_TEAM, session_id=OLD_SID)
+    _reset_aligned_cache()
+    config_root = tmp_path / ".claude"
+    team_dir = config_root / "teams" / FOREIGN_TEAM
+    team_dir.mkdir(parents=True, exist_ok=True)
+    (team_dir / "config.json").write_text(
+        json.dumps({"name": FOREIGN_TEAM, "leadSessionId": FOREIGN_SID,
+                    "members": []}), encoding="utf-8")
+    assert not (config_root / "tasks" / FOREIGN_TEAM).exists()  # the stance
+    _seed_session_journal(monkeypatch, tmp_path, [REAL_TASK_EVENT])
+    import shared.pact_context as ctx_module
+    assert ctx_module.get_team_name() == OLD_TEAM
+
+
+def test_f4_unparseable_config_mid_census_skipped(tmp_path, monkeypatch):
+    """F4 pin — the census's own malformed-sibling stance: a team dir whose
+    config.json is UNPARSEABLE is skipped (neither candidate nor abort), with
+    scanning continuing. Sole unparseable sibling -> zero candidates -> stale
+    default. The branch-1 malformed pin (detect_align.py) does NOT transfer
+    to the census loop — this is its census-path counterpart. Green now;
+    reddens if the stance flips to candidate (e.g. defaulting a failed parse
+    to {})."""
+    plugin_root = tmp_path / "plugin"
+    _seed_plugin(plugin_root)
+    _write_context(monkeypatch, tmp_path, plugin_root,
+                   team_name=OLD_TEAM, session_id=OLD_SID)
+    _reset_aligned_cache()
+    config_root = tmp_path / ".claude"
+    bad = config_root / "teams" / FOREIGN_TEAM
+    bad.mkdir(parents=True, exist_ok=True)
+    (bad / "config.json").write_text("{not json", encoding="utf-8")
+    tasks_dir = config_root / "tasks" / FOREIGN_TEAM
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / "task_0.json").write_text("{}", encoding="utf-8")
+    _seed_session_journal(monkeypatch, tmp_path, [REAL_TASK_EVENT])
+    import shared.pact_context as ctx_module
+    assert ctx_module.get_team_name() == OLD_TEAM
+
+
+def test_f6_recency_boundary_semantics(tmp_path, monkeypatch):
+    """F6 pin — the recency window's boundary, pinned EXACTLY with the clock
+    stubbed (a wall-clock boundary test would race the code's own
+    time.time()). The implemented comparison is `mtime < cutoff -> skip`
+    (cutoff = now - RESUME_CENSUS_RECENCY_SECONDS), i.e. a store aged EXACTLY
+    900 s is still a candidate and 901 s is not. Also pins the constant
+    (retune guard). Green now; reddens if the operator flips to <= or the
+    window is retuned without this file noticing."""
+    import shared.pact_context as ctx_module
+    assert ctx_module.RESUME_CENSUS_RECENCY_SECONDS == 900
+
+    fixed_now = 1_800_000_000.0
+    config_root = tmp_path / ".claude"
+
+    def _boundary_world(candidate_mtime):
+        plugin_root = tmp_path / "plugin"
+        _seed_plugin(plugin_root)
+        _write_context(monkeypatch, tmp_path, plugin_root,
+                       team_name=OLD_TEAM, session_id=OLD_SID)
+        _reset_aligned_cache()
+        _seed_team_store(config_root, team_name=NEW_TEAM_ID8,
+                         lead_session_id=NEW_SID, members=(), tasks=(),
+                         corroborate=True,
+                         lead_cwd=str(tmp_path / "project"))
+        tasks_dir = config_root / "tasks" / NEW_TEAM_ID8
+        os.utime(tasks_dir, (candidate_mtime, candidate_mtime))
+        _seed_session_journal(monkeypatch, tmp_path, [REAL_TASK_EVENT])
+
+    # EXACTLY 900 s old: on the boundary, still a candidate -> realigns.
+    _boundary_world(fixed_now - 900)
+    import shared.pact_context as pc
+    monkeypatch.setattr(pc.time, "time", lambda: fixed_now)
+    assert pc._resolve_aligned_team_name(
+        OLD_SID, teams_dir=str(config_root / "teams"), default=OLD_TEAM,
+    ) == NEW_TEAM_ID8
+    _reset_aligned_cache()
+
+    # 901 s old: outside -> not a candidate -> stale default.
+    _boundary_world(fixed_now - 901)
+    assert pc._resolve_aligned_team_name(
+        OLD_SID, teams_dir=str(config_root / "teams"), default=OLD_TEAM,
+    ) == OLD_TEAM
+
+
+def test_f7_path_unsafe_candidate_name_skipped(tmp_path, monkeypatch):
+    """F7 future-pin (greedy batch) — the census loop's tamper guard: a
+    candidate dir whose NAME fails is_safe_path_component (here: an embedded
+    C0 control char) is skipped even though its config and fresh tasks store
+    would otherwise qualify. Green now; reddens if the guard is dropped from
+    the census loop (the branch-1 analog is separately pinned)."""
+    plugin_root = tmp_path / "plugin"
+    _seed_plugin(plugin_root)
+    _write_context(monkeypatch, tmp_path, plugin_root,
+                   team_name=OLD_TEAM, session_id=OLD_SID)
+    _reset_aligned_cache()
+    config_root = tmp_path / ".claude"
+    tampered = "session-evil\x01"
+    team_dir = config_root / "teams" / tampered
+    team_dir.mkdir(parents=True, exist_ok=True)
+    (team_dir / "config.json").write_text(
+        json.dumps({"name": tampered, "leadSessionId": FOREIGN_SID,
+                    "members": []}), encoding="utf-8")
+    tasks_dir = config_root / "tasks" / tampered
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / "task_0.json").write_text("{}", encoding="utf-8")
+    _seed_session_journal(monkeypatch, tmp_path, [REAL_TASK_EVENT])
+    import shared.pact_context as ctx_module
+    resolved = ctx_module._resolve_aligned_team_name(
+        OLD_SID, teams_dir=str(config_root / "teams"), default=OLD_TEAM,
+    )
+    assert resolved == OLD_TEAM

--- a/pact-plugin/tests/test_resume_team_realign_1507.py
+++ b/pact-plugin/tests/test_resume_team_realign_1507.py
@@ -318,48 +318,28 @@ def test_i_b_dead_incident_shaped_dir_never_resolved(tmp_path, monkeypatch,
     assert ctx_module.get_team_name() != OLD_TEAM
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Accepted residual (lead ruling, follow-up #1509): the world needs "
-        "TWO unobserved platform behaviors to co-occur — bare-uuid remnant "
-        "naming AND inboxes/ surviving end-session. Measured remnants are "
-        "session-<id8>-named with file-edits.json (branch-2 never matches "
-        "them); PACT's own reaper rmtrees whole dirs. Branch-2 returns the "
-        "dead name before the census runs. The unguarded liveness conjunct "
-        "is REJECTED (silent sticky foreign-team alignment in the "
-        "live-but-idle config-less world); the guarded branch-2 override "
-        "sketch lives in #1509. strict=True is the deliberate tripwire: when "
-        "#1509 lands, this XPASSes and the suite REDDENS, forcing the "
-        "un-xfail-and-turn-green step that issue's acceptance requires."
-    ),
-    strict=True,
-)
 def test_i_b_dead_desktop_shaped_uuid_dir_never_resolved(
     tmp_path, monkeypatch, capsys
 ):
     """CELL i-b (Desktop composition shape) — the reaped OLD team dir is named
     with the BARE OLD full uuid and carries inboxes/ (branch-2's config-less
-    witness is SATISFIED by a DEAD dir), while the live re-provisioned team is
-    the sole census candidate. PLAN CONTRACT (Test-phase table, i-b): the
-    resolution must be the live team or the stale default — NEVER the dead
-    dir's name. MEASURED RED on the landed code (branch-2 fires on the dead
-    substrate and returns the dead name before the census), ruled an ACCEPTED
-    RESIDUAL: reachability requires (a) bare-uuid dir naming (Desktop
-    2.1.177 shape) AND (b) inboxes/ surviving end-session to CO-OCCUR — both
-    unobserved on this platform (5 config-less remnants measured at the zai
-    teams root: all session-<id8>-named, all file-edits.json, ZERO inboxes/,
-    ZERO bare-uuid; session_end's reaper is ^pact--scoped whole-dir rmtree,
-    so PACT itself cannot leave this half-corpse). The xfail pins the
-    contract against future platform change and tracks follow-up #1509
-    (guarded branch-2 override: fire branch-2 only when own tasks are fresh
-    OR the census has no unique candidate — preserves matrix v and every
-    census-empty #989 pin). The plainly-fresh-tasks liveness conjunct was
-    REJECTED: in the live-but-idle config-less world it would fall through
-    branch-2 to the census, silently align to a concurrent FOREIGN team, and
-    the write-back would make that sticky — a worse hole than this deny,
-    which at least self-diagnoses with the manual-repoint remedy."""
+    witness is SATISFIED by a DEAD dir), while the live re-provisioned team
+    is the sole CORROBORATED census candidate. Contract: the resolution is
+    the live team or the stale default — NEVER the dead dir's name.
+    Originally RED (unguarded branch-2 returned the dead name before the
+    census ran) and xfailed as a two-unobserved-platform-behaviors residual
+    with a strict tripwire; #1509's GUARDED OVERRIDE now handles the world —
+    branch-2 wins only when its own substrate looks alive (fresh sibling
+    tasks store) OR the census has no corroborated unique winner, so a DEAD
+    substrate with a corroborated winner is preempted and the resolution
+    lands on the live team. The strict xfail did its job: XPASSed against
+    the landed guard and reddened the suite, forcing exactly this
+    un-xfail-and-turn-green step. See test_1509_idle_config_less_branch2_
+    unstarved for the guard's not-starving complement."""
     _seed_census_world(monkeypatch, tmp_path, live_team=NEW_TEAM_ID8,
-                       live_lead_sid=NEW_SID)
+                       live_lead_sid=NEW_SID,
+                       journal_events=["session_end",
+                                       "task_metadata_snapshot"])
     _seed_dead_team_dir(tmp_path, team_name=OLD_SID, with_inboxes=True)
     import shared.pact_context as ctx_module
     resolved = ctx_module.get_team_name()
@@ -370,6 +350,44 @@ def test_i_b_dead_desktop_shaped_uuid_dir_never_resolved(
     # Live team or stale default are both acceptable per the plan contract;
     # the dead name is the only forbidden outcome.
     assert resolved in (NEW_TEAM_ID8, OLD_TEAM)
+
+
+def test_1509_idle_config_less_branch2_unstarved(tmp_path, monkeypatch,
+                                                 capsys):
+    """#1509 acceptance complement — the guard must not starve the legitimate
+    #989 world: a config-less OWN-session substrate whose tasks store is AGED
+    (a live-but-idle Desktop session — nothing wrote inside the recency
+    window) in a census-EMPTY world (no config-bearing teams at all). The
+    guard consults the census, gets None, and branch-2 still wins: the
+    resolution is the own substrate, never the stale default. NON-VACUITY:
+    the owner's task lives only under the substrate's tasks dir, so the
+    ALLOW is reachable only via the branch-2 resolution (a stale-default
+    resolution would DENY)."""
+    plugin_root = tmp_path / "plugin"
+    _seed_plugin(plugin_root)
+    _write_context(monkeypatch, tmp_path, plugin_root,
+                   team_name=OLD_TEAM, session_id=OLD_SID)
+    _reset_aligned_cache()
+    config_root = tmp_path / ".claude"
+    # The config-less OWN substrate (the #989 Desktop shape) with an AGED
+    # (idle) tasks store — nothing fresh anywhere.
+    _seed_dead_team_dir(tmp_path, team_name=OLD_SID, with_inboxes=True)
+    tasks_dir = config_root / "tasks" / OLD_SID
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / "task_0.json").write_text(
+        json.dumps({"id": "0", "owner": _NAME, "status": "pending"}),
+        encoding="utf-8",
+    )
+    aged = 1  # epoch — far outside the 900 s window on any clock
+    os.utime(tasks_dir, (aged, aged))
+    _seed_session_journal(monkeypatch, tmp_path, ["task_metadata_snapshot"])
+    # Census-empty: no team dir carries a config.json (the substrate is
+    # config-less, so it is not a candidate either).
+    assert not list((config_root / "teams").glob("*/config.json"))
+    code, out = _run_dispatch(_make_spawn(), capsys)
+    assert code == 0, "idle config-less own substrate must still win (branch-2)"
+    import shared.pact_context as ctx_module
+    assert ctx_module.get_team_name() == OLD_SID
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/pact-plugin/tests/test_resume_team_realign_1507.py
+++ b/pact-plugin/tests/test_resume_team_realign_1507.py
@@ -660,34 +660,27 @@ def test_ix_composition_both_divergences_both_topologies(
 # ══════════════════════════════════════════════════════════════════════════════
 
 
-def test_x_config_missing_leadsessionid_counts_as_candidate(
+def test_x_config_missing_leadsessionid_not_a_candidate(
     tmp_path, monkeypatch
 ):
-    """CELL x — the resolver's candidate predicate is the LITERAL spec
-    (``leadSessionId != session_id`` — NO non-empty requirement), so a config
-    whose leadSessionId key is MISSING (``data.get`` -> None != the persisted
-    id) COUNTS as a census candidate whenever its tasks store is fresh. This
-    test ASSERTS that implemented stance and records it (resolver-coder's
-    open question #1): the stance is acceptable because it is bounded by the
-    unambiguous-only rule, the journal witness, and the recency window — a
-    malformed sibling can only WIN when it is the sole fresh candidate of a
-    lived session whose persisted team config is reaped, i.e. a world where
-    returning the stale default denies every spawn anyway. If a future change
-    tightens the predicate (e.g. requires a non-string-safe, present,
-    non-empty leadSessionId), flip this test WITH it — the stance is pinned,
-    not endorsed."""
+    """CELL x — HARDENED M1 stance: a candidate must carry a REAL string
+    leadSessionId that differs from this session's id; a config MISSING the
+    field (``data.get`` -> None) is malformed identity and does NOT count as
+    a candidate — the ``!=`` alone would treat absence as foreign identity.
+    The sole malformed candidate leaves ZERO candidates and the stale
+    default stands. This cell originally pinned the literal None-counts
+    stance (bounded by unambiguous-only + witness + recency); resolver-
+    coder's isinstance(str) hardening ENDORSED the stricter reading and the
+    cell was flipped WITH it."""
     plugin_root = tmp_path / "plugin"
     _seed_plugin(plugin_root)
     _write_context(monkeypatch, tmp_path, plugin_root,
                    team_name=OLD_TEAM, session_id=OLD_SID)
     _reset_aligned_cache()
     # The malformed candidate: config.json EXISTS but carries NO
-    # leadSessionId key; fresh sibling tasks store. Corroboration fields ARE
-    # present, so the candidate is BOTH counted and bound — post-remediation
-    # semantics (resolver-coder's note): a missing leadSessionId still COUNTS
-    # as a candidate, realigning only when corroborated; a malformed-config
-    # positive realign requires the binding fields, which corroborate=True
-    # provides.
+    # leadSessionId key; fresh sibling tasks store; corroboration fields
+    # otherwise complete (a deliberately tempting candidate that the
+    # hardened predicate must still refuse).
     _seed_team_store(tmp_path / ".claude", team_name=NEW_TEAM_ID8, lead_session_id=None,
                      members=(), tasks=(),
                      corroborate=True, lead_cwd=str(tmp_path / "project"))
@@ -697,7 +690,7 @@ def test_x_config_missing_leadsessionid_counts_as_candidate(
         OLD_SID, teams_dir=str(tmp_path / ".claude" / "teams"),
         default=OLD_TEAM,
     )
-    assert resolved == NEW_TEAM_ID8
+    assert resolved == OLD_TEAM
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -712,8 +705,8 @@ def test_xi_stale_block_and_working_recovery_coexist_scoped(tmp_path,
     the ambiguous-census deny, the composite reason carries BOTH diagnoses,
     each scoped to ITS OWN records with no contradiction inside one message:
       * the stale-block WARNING (about the CLAUDE.md 'Current Session' block —
-        its 'completing bootstrap will rewrite them' claim is TRUE for the
-        CLAUDE.md records it names), and
+        its 'completing bootstrap will rewrite the CLAUDE.md session records'
+        claim is scoped to exactly those records), and
       * the re-align HINT (about pact-session-context.json — the measured
         working recovery, leaving session_id/journal untouched).
     The composer is A-xor-B by construction: with the incumbent fired the
@@ -994,6 +987,54 @@ def test_f1_cross_directory_resume_either_match(tmp_path, monkeypatch, capsys,
     )
     code, out = _run_dispatch(_make_spawn(), capsys)
     assert code == 0, f"{mode} leg must corroborate (either-match)"
+
+
+def test_1514_prefix_colliding_leadagentid_not_corroborated(tmp_path,
+                                                            monkeypatch):
+    """#1514 pin — the leadAgentId self-consistency check is a SUFFIX match,
+    not substring: a config whose leadAgentId is "team-lead@session-aaaa1111"
+    sitting in a dir named "session-aaaa" (a PREFIX COLLISION — a config
+    copied or mis-placed from the longer-named team) must NOT corroborate,
+    even with every other binding field complete (matching members entry,
+    cwd anchored to this session, joinedAt fine). The substring form
+    ("@session-aaaa" in the agentId) passes this collision; the suffix form
+    (endswith) rejects it -> suppressed -> stale default. Reddens if the
+    check ever regresses to substring containment."""
+    plugin_root = tmp_path / "plugin"
+    _seed_plugin(plugin_root)
+    _write_context(monkeypatch, tmp_path, plugin_root,
+                   team_name=OLD_TEAM, session_id=OLD_SID)
+    _reset_aligned_cache()
+    config_root = tmp_path / ".claude"
+    colliding_dir = "session-aaaa"
+    team_dir = config_root / "teams" / colliding_dir
+    team_dir.mkdir(parents=True, exist_ok=True)
+    colliding_agent_id = "team-lead@session-aaaa1111"
+    (team_dir / "config.json").write_text(
+        json.dumps({
+            "name": colliding_dir,
+            "leadSessionId": NEW_SID,
+            "leadAgentId": colliding_agent_id,
+            "members": [{
+                "agentId": colliding_agent_id,
+                "name": "team-lead",
+                "cwd": str(tmp_path / "project"),
+                "joinedAt": CORROBORATED_JOINED_AT_MS,
+            }],
+        }),
+        encoding="utf-8",
+    )
+    tasks_dir = config_root / "tasks" / colliding_dir
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / "task_0.json").write_text("{}", encoding="utf-8")
+    _seed_session_journal(monkeypatch, tmp_path, ["task_metadata_snapshot"])
+    import shared.pact_context as ctx_module
+    resolved = ctx_module._resolve_aligned_team_name(
+        OLD_SID, teams_dir=str(config_root / "teams"), default=OLD_TEAM,
+    )
+    assert resolved == OLD_TEAM, (
+        "prefix-colliding leadAgentId must not corroborate (#1514)"
+    )
 
 
 def test_f3_config_without_tasks_store_not_a_candidate(tmp_path, monkeypatch):

--- a/pact-plugin/tests/test_resume_team_realign_1507.py
+++ b/pact-plugin/tests/test_resume_team_realign_1507.py
@@ -1,0 +1,727 @@
+"""#1507 resume team-realign — comprehensive TEST-phase matrix for branch-3 census.
+
+After a clean end-session, ``claude --resume <old-id>`` provisions a NEW team +
+task store under a NEW id while every hook frame still carries the OLD session
+id; the OLD team config is reaped, so #989's identity-match cannot align and
+``dispatch_gate`` denied every spawn (#1507). The fix (fork b) is a branch-3
+census in ``_resolve_aligned_team_name``: when identity-match failed, the
+persisted team's config is ABSENT, and the session journal shows prior team
+ACTIVITY, the single LIVE re-provisioned team (config ``leadSessionId`` != the
+persisted id + sibling ``tasks/<dir>/`` mtime within
+``RESUME_CENSUS_RECENCY_SECONDS``) wins; zero or >= 2 candidates fail safe to
+the stale default. Convergence persists via the EXISTING marker-writer
+write-back; the gate's stale-team remedy texts now name the measured manual
+repoint.
+
+This file owns the plan's Test-phase matrix (docs/plans/
+1507-resume-team-realign-plan.md, cells i-xi) at the GATE level, end-to-end
+through ``dispatch_gate.main()`` wherever the plan's assertion is a gate
+decision, plus resolver-level legs where the cell pins a predicate directly.
+The resolver-coder's focused verification lives in
+``test_team_name_detect_align.py`` section 14 (TestBranch3ResumeCensus); the
+standing both-modes merge gate lives in ``test_team_name_resolution_both_modes.py``
+(sibling files — this file adds the #1507 scenario family without polluting
+either).
+
+Assertions are CONTRACT-FIRST (resolved team / gate decision / message
+markers), never fork-internals. Non-vacuity by store placement: in every ALLOW
+cell the owner's task is seeded ONLY under the team the cell must resolve, so
+an ALLOW is reachable only via the intended resolution path. mtime
+determinism: every "fresh" store in this file is left at CREATION time —
+inside the 900 s window on any conceivable clock — with no clock-relative
+arithmetic; the aged-store arm (``os.utime``-pinned mtimes) lives in the
+sibling's section 14 (test_team_name_detect_align.py).
+
+COUNTER-TEST-BY-REVERT (source-only; the fix commits bundle source with their
+own focused tests, so a whole-commit revert would mask). MEASURED (before the
+i-b Desktop leg was xfailed per the lead ruling; the xfail does not change
+the FAIL counts — an xfailed cell reports xfailed, not failed):
+  git checkout 1c722640^ -- pact-plugin/hooks/shared/pact_context.py
+    -> {6 failed, 1 xfailed, 9 passed}: the six census-dependent cells
+       {i, i-b incident-shape, viii, ix (2 legs), x} FAIL; i-b Desktop-shape
+       reports xfailed (it is xfail-red on the fixed tree too — the accepted
+       branch-2 dead-dir residual, see that test's docstring). Cells
+       ii/v/vi/vii stay GREEN (fail-safe arms whose pass-condition does not
+       require the census to exist); iii/iv stay GREEN (empty-SSOT /
+       identity-match are pre-existing branches the census must not
+       disturb); xi stays GREEN (its text comes from 6c676bbb).
+  git checkout 6c676bbb^ -- pact-plugin/hooks/dispatch_gate.py
+    -> {2 failed, 1 xfailed, 13 passed}: the two message-marker cells
+       {ii, xi} FAIL; i-b Desktop reports xfailed (resolution axis
+       untouched).
+  Restore: git checkout HEAD -- <path>; git diff --quiet -- <path> exits 0.
+"""
+
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+_SUPPRESS_EXPECTED = {"suppressOutput": True}
+_NAME = "tester"
+
+# ── Ids / names: the OLD (persisted, reaped) world vs the NEW (live) one ──────
+# OLD_SID is the session id every hook frame carries (the platform model: the
+# OLD id remains the SESSION id; the NEW id is the TEAM provisioning id).
+OLD_SID = "0001639f-a74f-41c4-bd0b-93d9d206e7f7"
+OLD_TEAM = "session-0001639f"          # persisted-but-reaped stale default
+# The NEW team's provisioning id + the two dir-naming shapes it can take.
+NEW_SID = "aaaa1111-2222-4333-8444-555566667777"
+NEW_TEAM_ID8 = "session-aaaa1111"      # CLI naming (the #1507 incident shape)
+NEW_UUID_DIR = NEW_SID                 # bare full UUID (Desktop composition)
+# A second live candidate (the ambiguity arm) + a foreign concurrent session.
+AMBIG_SID = "beefbeef-1111-4222-8333-444455556666"
+AMBIG_TEAM = "session-beefbeef"
+FOREIGN_SID = "cafe1234-5678-4abc-9def-0123456789ab"
+FOREIGN_TEAM = "session-cafe1234"
+# A tmux-shaped spawn-frame id (topology axis — != the lead/persisted id).
+TMUX_FRAME_SID = "ffff8888-bbbb-4ccc-9ddd-eeeeeeeeeeee"
+
+# Message markers (contract-first; the exact constants live in
+# dispatch_gate.py — these substrings are the STABLE contract each text owns).
+_CAUSE2_RECOVERY_MARKER = (
+    "Recovery: set team_name in the OLD session's pact-session-context.json"
+)
+_HINT_MARKER = "Working recovery"
+_STALE_BLOCK_MARKER = "stale session block"
+_ENUMERATION_HEADER = "DIAGNOSIS — this gate did not OBSERVE"
+_FORBIDDEN_INERT_PHRASES = (
+    "bootstrap ritual rewrites",
+    "bootstrap also rewrites",
+    "rewrites those records",
+)
+
+
+# ── seeding helpers (self-contained; modeled on the sibling files) ───────────
+
+
+def _seed_plugin(plugin_root: Path, agents=("pact-architect",)):
+    agents_dir = plugin_root / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    for stem in agents:
+        (agents_dir / f"{stem}.md").write_text(f"---\nname: {stem}\n---\n")
+
+
+def _write_context(monkeypatch, tmp_path, plugin_root, *, team_name,
+                   session_id):
+    """Persist the SSOT context and point _context_path at it (caches cleared,
+    init stubbed so dispatch_gate.main cannot re-derive the path from the
+    spawn frame's own session_id)."""
+    import shared.pact_context as ctx_module
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    ctx_path = tmp_path / "pact-session-context.json"
+    ctx_path.write_text(
+        json.dumps(
+            {
+                "team_name": team_name,
+                "session_id": session_id,
+                "project_dir": str(tmp_path / "project"),
+                "plugin_root": str(plugin_root),
+                "started_at": "2026-01-01T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ctx_module, "_context_path", ctx_path)
+    monkeypatch.setattr(ctx_module, "_cache", None)
+    monkeypatch.setattr(ctx_module, "init", lambda input_data: None)
+    import shared.dispatch_helpers as dh
+    dh._specialist_registry.cache_clear()
+    return ctx_path
+
+
+def _seed_team_store(config_root, *, team_name, lead_session_id, members=(),
+                     tasks=()):
+    """Platform-shaped team store under a CONFIG ROOT (the dir
+    get_claude_config_dir() resolves to — tmp/.claude for the default-root
+    worlds, the scratch root itself for the CLAUDE_CONFIG_DIR cell):
+    teams/{team}/config.json (name + leadSessionId + members) plus
+    tasks/{team}/*.json task files."""
+    team_dir = config_root / "teams" / team_name
+    team_dir.mkdir(parents=True, exist_ok=True)
+    config = {"name": team_name, "members": [{"name": m} for m in members]}
+    if lead_session_id is not None:
+        config["leadSessionId"] = lead_session_id
+    (team_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    tasks_dir = config_root / "tasks" / team_name
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    for i, (owner, status) in enumerate(tasks):
+        (tasks_dir / f"task_{i}.json").write_text(
+            json.dumps({"id": str(i), "owner": owner, "status": status}),
+            encoding="utf-8",
+        )
+    return team_dir
+
+
+def _seed_dead_team_dir(tmp_path, *, team_name, with_inboxes=True):
+    """A REAPED team dir: present on disk with the half-formed witness but NO
+    config.json (the end-session reaper removes config while the dir survives).
+    This is the adversarial substrate — its inboxes/ satisfies branch-2's
+    witness whenever the dir is named with the bare OLD session uuid."""
+    team_dir = tmp_path / ".claude" / "teams" / team_name
+    team_dir.mkdir(parents=True, exist_ok=True)
+    if with_inboxes:
+        (team_dir / "inboxes").mkdir(exist_ok=True)
+    assert not (team_dir / "config.json").exists()
+    return team_dir
+
+
+def _seed_session_journal(monkeypatch, tmp_path, event_types):
+    """Write the session journal at the dir get_session_dir() points at (the
+    branch-3 witness's read location), one event per given type. Must run
+    AFTER _write_context (the session dir derives from the persisted
+    context)."""
+    import shared.pact_context as ctx_module
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    session_dir = Path(ctx_module.get_session_dir())
+    session_dir.mkdir(parents=True, exist_ok=True)
+    lines = [
+        json.dumps({"v": 1, "type": t, "ts": "2026-08-24T00:00:00Z"})
+        for t in event_types
+    ]
+    (session_dir / "session-journal.jsonl").write_text(
+        "\n".join(lines) + "\n", encoding="utf-8"
+    )
+    return session_dir
+
+
+def _make_spawn(team_name_arg="ignored-by-platform"):
+    """A specialist spawn frame; the team_name arg is platform-ignored, kept
+    deliberately wrong so it can never be the resolution source."""
+    return {
+        "hook_event_name": "PreToolUse",
+        "session_id": "spawn-frame-session",
+        "tool_name": "Agent",
+        "tool_input": {
+            "subagent_type": "pact-architect",
+            "name": _NAME,
+            "team_name": team_name_arg,
+            "prompt": "Standard mission. Check TaskList for tasks assigned to you.",
+        },
+    }
+
+
+def _run_dispatch(spawn, capsys):
+    from dispatch_gate import main
+    with patch("sys.stdin", io.StringIO(json.dumps(spawn))):
+        with pytest.raises(SystemExit) as exc:
+            main()
+    out = capsys.readouterr().out.strip()
+    return exc.value.code, (json.loads(out) if out else {})
+
+
+def _reset_aligned_cache():
+    import shared.pact_context as ctx_module
+    ctx_module._aligned_cache = None
+
+
+def _seed_census_world(monkeypatch, tmp_path, *, live_team=NEW_TEAM_ID8,
+                       live_lead_sid=NEW_SID, journal_events=("task_claimed",),
+                       with_journal=True, tasks=((_NAME, "pending"),)):
+    """The canonical #1507 world: OLD team config REAPED (dir absent), the
+    live re-provisioned team present with a fresh task store carrying the
+    owner's task (non-vacuity: an ALLOW is reachable ONLY by resolving the
+    live team), and a lived-session journal for the branch-3 witness."""
+    plugin_root = tmp_path / "plugin"
+    _seed_plugin(plugin_root)
+    _write_context(
+        monkeypatch, tmp_path, plugin_root,
+        team_name=OLD_TEAM, session_id=OLD_SID,
+    )
+    _reset_aligned_cache()
+    _seed_team_store(
+        tmp_path / ".claude", team_name=live_team,
+        lead_session_id=live_lead_sid, members=(), tasks=tasks,
+    )
+    # The stale team is FULLY reaped: neither its config nor its dir exists.
+    assert not (tmp_path / ".claude" / "teams" / OLD_TEAM).exists()
+    if with_journal:
+        _seed_session_journal(monkeypatch, tmp_path, list(journal_events))
+    return plugin_root
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# (i) THE REALIGN CELL — reaped old config + single fresh candidate + lived
+#     journal -> census returns the live team; the gate ALLOWs.
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_i_census_resolves_live_team_gate_allows(tmp_path, monkeypatch, capsys):
+    """CELL i — the #1507 incident shape end-to-end: persisted OLD team +
+    OLD session id, old team config reaped, the live re-provisioned team
+    (session-<new8> naming, NEW leadSessionId, fresh task store holding the
+    owner's task) + a lived journal. The census realigns, get_team_name()
+    returns the LIVE team, and the gate ALLOWs. NON-VACUITY: the task lives
+    ONLY under the live team; a resolver that stayed on the stale default
+    would MISS the store and DENY."""
+    _seed_census_world(monkeypatch, tmp_path, live_team=NEW_TEAM_ID8,
+                       live_lead_sid=NEW_SID)
+    code, out = _run_dispatch(_make_spawn(team_name_arg="wrong-team"), capsys)
+    assert code == 0, "census must realign to the live re-provisioned team"
+    assert out == _SUPPRESS_EXPECTED
+    # Load-bearing: the owner's task exists ONLY under the live team.
+    assert (tmp_path / ".claude" / "tasks" / NEW_TEAM_ID8).exists()
+    assert not (tmp_path / ".claude" / "tasks" / OLD_TEAM).exists()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# (i-b) ADVERSARIAL DEAD DIR — branch-2's witness satisfied by a DEAD dir
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_i_b_dead_incident_shaped_dir_never_resolved(tmp_path, monkeypatch,
+                                                     capsys):
+    """CELL i-b (incident shape) — the reaped OLD team dir SURVIVES on disk
+    (session-<old8> naming) with inboxes/ but no config.json, while the live
+    re-provisioned team is the sole census candidate. The resolution must be
+    the LIVE team (or at minimum the stale default) — NEVER the dead dir's
+    name. Branch-2 cannot hijack here: it anchors on teams/<bare-old-uuid>/,
+    and the dead dir is named session-<old8>. NON-VACUITY: the owner's task
+    lives only under the live team, so the ALLOW proves the resolution landed
+    there."""
+    _seed_census_world(monkeypatch, tmp_path, live_team=NEW_TEAM_ID8,
+                       live_lead_sid=NEW_SID)
+    _seed_dead_team_dir(tmp_path, team_name=OLD_TEAM, with_inboxes=True)
+    code, out = _run_dispatch(_make_spawn(), capsys)
+    assert code == 0, (
+        "dead session-<old8> dir must not block the census realign"
+    )
+    import shared.pact_context as ctx_module
+    assert ctx_module.get_team_name() == NEW_TEAM_ID8
+    assert ctx_module.get_team_name() != OLD_TEAM
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Accepted residual (lead ruling, follow-up #1509): the world needs "
+        "TWO unobserved platform behaviors to co-occur — bare-uuid remnant "
+        "naming AND inboxes/ surviving end-session. Measured remnants are "
+        "session-<id8>-named with file-edits.json (branch-2 never matches "
+        "them); PACT's own reaper rmtrees whole dirs. Branch-2 returns the "
+        "dead name before the census runs. The unguarded liveness conjunct "
+        "is REJECTED (silent sticky foreign-team alignment in the "
+        "live-but-idle config-less world); the guarded branch-2 override "
+        "sketch lives in #1509. strict=True is the deliberate tripwire: when "
+        "#1509 lands, this XPASSes and the suite REDDENS, forcing the "
+        "un-xfail-and-turn-green step that issue's acceptance requires."
+    ),
+    strict=True,
+)
+def test_i_b_dead_desktop_shaped_uuid_dir_never_resolved(
+    tmp_path, monkeypatch, capsys
+):
+    """CELL i-b (Desktop composition shape) — the reaped OLD team dir is named
+    with the BARE OLD full uuid and carries inboxes/ (branch-2's config-less
+    witness is SATISFIED by a DEAD dir), while the live re-provisioned team is
+    the sole census candidate. PLAN CONTRACT (Test-phase table, i-b): the
+    resolution must be the live team or the stale default — NEVER the dead
+    dir's name. MEASURED RED on the landed code (branch-2 fires on the dead
+    substrate and returns the dead name before the census), ruled an ACCEPTED
+    RESIDUAL: reachability requires (a) bare-uuid dir naming (Desktop
+    2.1.177 shape) AND (b) inboxes/ surviving end-session to CO-OCCUR — both
+    unobserved on this platform (5 config-less remnants measured at the zai
+    teams root: all session-<id8>-named, all file-edits.json, ZERO inboxes/,
+    ZERO bare-uuid; session_end's reaper is ^pact--scoped whole-dir rmtree,
+    so PACT itself cannot leave this half-corpse). The xfail pins the
+    contract against future platform change and tracks follow-up #1509
+    (guarded branch-2 override: fire branch-2 only when own tasks are fresh
+    OR the census has no unique candidate — preserves matrix v and every
+    census-empty #989 pin). The plainly-fresh-tasks liveness conjunct was
+    REJECTED: in the live-but-idle config-less world it would fall through
+    branch-2 to the census, silently align to a concurrent FOREIGN team, and
+    the write-back would make that sticky — a worse hole than this deny,
+    which at least self-diagnoses with the manual-repoint remedy."""
+    _seed_census_world(monkeypatch, tmp_path, live_team=NEW_TEAM_ID8,
+                       live_lead_sid=NEW_SID)
+    _seed_dead_team_dir(tmp_path, team_name=OLD_SID, with_inboxes=True)
+    import shared.pact_context as ctx_module
+    resolved = ctx_module.get_team_name()
+    assert resolved != OLD_SID, (
+        f"resolver returned the DEAD dir name {resolved!r} — branch-2's "
+        "witness was satisfied by the reaped Desktop-shaped old team dir"
+    )
+    # Live team or stale default are both acceptable per the plan contract;
+    # the dead name is the only forbidden outcome.
+    assert resolved in (NEW_TEAM_ID8, OLD_TEAM)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# (ii) AMBIGUOUS CENSUS — two fresh candidates -> stale default + honest deny
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_ii_two_candidates_stale_default_and_new_remedy(tmp_path, monkeypatch,
+                                                        capsys):
+    """CELL ii — two live candidates (two simultaneous broken resumes) ->
+    AMBIGUOUS -> the stale default stands and the gate DENIES with
+    no_task_assigned. The deny carries the enumeration's cause-(2) remedy
+    naming the MEASURED recovery (edit pact-session-context.json); none of the
+    falsified inert 'bootstrap ritual' phrases may appear (this leg has no
+    CLAUDE.md, so the stale block is silent and the enumeration is the sole
+    appended diagnosis)."""
+    _seed_census_world(monkeypatch, tmp_path, live_team=NEW_TEAM_ID8,
+                       live_lead_sid=NEW_SID, tasks=())  # stale store: no task
+    _seed_team_store(tmp_path / ".claude", team_name=AMBIG_TEAM,
+                     lead_session_id=AMBIG_SID, members=(), tasks=())
+    code, out = _run_dispatch(_make_spawn(), capsys)
+    assert code == 2, "ambiguous census must fail safe to a deny"
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "no Task assigned" in reason
+    # The NEW remedy names the measured manual repoint...
+    assert _CAUSE2_RECOVERY_MARKER in reason
+    # ...and no inert bootstrap-ritual claim survives anywhere in the deny.
+    for phrase in _FORBIDDEN_INERT_PHRASES:
+        assert phrase not in reason, f"inert remedy phrase leaked: {phrase!r}"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# (iii) EMPTY-SSOT SECURITY GATE — census must sit BEHIND the short-circuit
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize("frame_sid", [OLD_SID, TMUX_FRAME_SID],
+                         ids=["in-process", "tmux"])
+def test_iii_empty_ssot_fails_closed_with_census_inputs(tmp_path, monkeypatch,
+                                                        capsys, frame_sid):
+    """CELL iii — the empty-SSOT fail-closed gate, extended with the #1507
+    census's OWN inputs: an empty persisted team_name plus a fully-seeded live
+    re-provisioned team and a lived journal. Identity-match AND the census are
+    both unreachable on the empty path — get_team_name() returns '' and the
+    gate DENIES team_name_unavailable in BOTH topologies. The census must
+    never recover a team from an empty SSOT (that would over-reach the
+    security gate pinned by test_empty_ssot_team_fails_closed_both_modes)."""
+    plugin_root = tmp_path / "plugin"
+    _seed_plugin(plugin_root)
+    _write_context(monkeypatch, tmp_path, plugin_root,
+                   team_name="", session_id=OLD_SID)
+    _reset_aligned_cache()
+    _seed_team_store(tmp_path / ".claude", team_name=NEW_TEAM_ID8,
+                     lead_session_id=NEW_SID, members=(),
+                     tasks=((_NAME, "pending"),))
+    _seed_session_journal(monkeypatch, tmp_path, ["task_claimed"])
+    import shared.pact_context as ctx_module
+    assert ctx_module.get_team_name() == ""
+    spawn = _make_spawn()
+    spawn["session_id"] = frame_sid
+    code, out = _run_dispatch(spawn, capsys)
+    assert code == 2, f"empty SSOT must fail-closed (frame_sid={frame_sid})"
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "session team_name is unavailable" in reason
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# (iv) #989 SAME-ID PATH + INTERFERENCE — identity-match OUTRANKS the census
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_iv_identity_match_outranks_census(tmp_path, monkeypatch, capsys):
+    """CELL iv — the #989 world (persisted id == a real dir's leadSessionId,
+    dir NAMED with the bare full uuid) with a census candidate ALSO present
+    and every census trigger conjunct satisfied (stale fallback config absent,
+    lived journal, fresh foreign store). Identity-match must win: resolution
+    is the SAME-ID full-uuid dir, never the census candidate. NON-VACUITY:
+    the owner's task lives only under the same-id dir."""
+    plugin_root = tmp_path / "plugin"
+    _seed_plugin(plugin_root)
+    _write_context(monkeypatch, tmp_path, plugin_root,
+                   team_name=OLD_TEAM, session_id=OLD_SID)
+    _reset_aligned_cache()
+    # The same-id divergent dir (#989): bare full uuid, config carries the
+    # PERSISTED id, owner's task lives here.
+    _seed_team_store(tmp_path / ".claude", team_name=OLD_SID, lead_session_id=OLD_SID,
+                     members=(), tasks=((_NAME, "pending"),))
+    # A census candidate that WOULD win if the census ran first.
+    _seed_team_store(tmp_path / ".claude", team_name=NEW_TEAM_ID8,
+                     lead_session_id=NEW_SID, members=(), tasks=())
+    _seed_session_journal(monkeypatch, tmp_path, ["task_claimed"])
+    code, out = _run_dispatch(_make_spawn(), capsys)
+    assert code == 0, "identity-match must resolve before the census"
+    import shared.pact_context as ctx_module
+    assert ctx_module.get_team_name() == OLD_SID
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# (v) ORDERING — branch-2's config-less witness fires BEFORE the census
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_v_branch2_witness_preempts_census(tmp_path, monkeypatch, capsys):
+    """CELL v — the legitimate branch-2 substrate (a config-less OWN-session
+    dir: teams/<old-uuid>/ with inboxes/, the #989 Desktop/SDK shape) with a
+    census candidate also live. Branch-2 must resolve FIRST (its return
+    preempts the census), so the resolution is the own-session substrate —
+    the census candidate is never consulted. NON-VACUITY: the owner's task
+    lives only under the branch-2 dir; if the census had won, the gate would
+    read the candidate's empty store and DENY."""
+    plugin_root = tmp_path / "plugin"
+    _seed_plugin(plugin_root)
+    _write_context(monkeypatch, tmp_path, plugin_root,
+                   team_name=OLD_TEAM, session_id=OLD_SID)
+    _reset_aligned_cache()
+    # Branch-2 substrate: config-less, inboxes witness, task store under the
+    # SAME name the branch-2 return addresses (the bare OLD uuid).
+    _seed_dead_team_dir(tmp_path, team_name=OLD_SID, with_inboxes=True)
+    tasks_dir = tmp_path / ".claude" / "tasks" / OLD_SID
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / "task_0.json").write_text(
+        json.dumps({"id": "0", "owner": _NAME, "status": "pending"}),
+        encoding="utf-8",
+    )
+    # The census candidate that would win if ordering were inverted.
+    _seed_team_store(tmp_path / ".claude", team_name=NEW_TEAM_ID8,
+                     lead_session_id=NEW_SID, members=(), tasks=())
+    _seed_session_journal(monkeypatch, tmp_path, ["task_claimed"])
+    code, out = _run_dispatch(_make_spawn(), capsys)
+    assert code == 0, "branch-2 must preempt the census on own-substrate"
+    import shared.pact_context as ctx_module
+    assert ctx_module.get_team_name() == OLD_SID
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# (vi) COLD-START GUARD — fresh journal + foreign fresh candidate -> NO align
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize(
+    "journal_events",
+    [[], ["variety_assessed"]],
+    ids=["no-journal", "journal-without-team-activity"],
+)
+def test_vi_fresh_journal_never_aligns_to_foreign_candidate(
+    tmp_path, monkeypatch, capsys, journal_events
+):
+    """CELL vi — THE cold-start guard, gate-level: a FRESH session's journal
+    (absent, or carrying only non-activity events) plus a concurrently ACTIVE
+    foreign session as the SOLE fresh candidate. Without the journal witness
+    the unambiguous-only rule alone would mis-align to the foreign team and
+    the write-back would make it sticky; the witness kills the census.
+    NON-VACUITY: the owner's task lives ONLY under the foreign candidate, so
+    an ALLOW would PROVE mis-alignment — the deny is the guard observable."""
+    _seed_census_world(
+        monkeypatch, tmp_path, live_team=FOREIGN_TEAM,
+        live_lead_sid=FOREIGN_SID, journal_events=journal_events,
+        with_journal=bool(journal_events),
+    )
+    code, out = _run_dispatch(_make_spawn(), capsys)
+    assert code == 2, (
+        "fresh journal + sole foreign candidate must NOT align (witness)"
+    )
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "no Task assigned" in reason
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# (vii) POST-CONVERGENCE STABILITY — persisted winner's config exists -> inert
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_vii_post_convergence_stable_with_foreign_candidate(tmp_path,
+                                                            monkeypatch,
+                                                            capsys):
+    """CELL vii — after the write-back converges (persisted team_name = the
+    census winner, whose config EXISTS), the census trigger's config-absent
+    conjunct is false and the census is INERT — no flicker — even with a
+    fresh foreign candidate present (the concurrent-session world). The
+    resolution stays on the persisted winner and the gate ALLOWs. NON-VACUITY:
+    the owner's task lives only under the winner."""
+    plugin_root = tmp_path / "plugin"
+    _seed_plugin(plugin_root)
+    _write_context(monkeypatch, tmp_path, plugin_root,
+                   team_name=NEW_TEAM_ID8, session_id=OLD_SID)
+    _reset_aligned_cache()
+    # The winner's own config EXISTS (post-convergence shape) — identity-match
+    # still misses (NEW leadSessionId != persisted OLD id) but the census
+    # trigger is false, so the fail-safe default (the winner) stands.
+    _seed_team_store(tmp_path / ".claude", team_name=NEW_TEAM_ID8,
+                     lead_session_id=NEW_SID, members=(),
+                     tasks=((_NAME, "pending"),))
+    _seed_team_store(tmp_path / ".claude", team_name=FOREIGN_TEAM,
+                     lead_session_id=FOREIGN_SID, members=(), tasks=())
+    _seed_session_journal(monkeypatch, tmp_path, ["task_claimed"])
+    code, out = _run_dispatch(_make_spawn(), capsys)
+    assert code == 0, "post-convergence resolution must stay on the winner"
+    import shared.pact_context as ctx_module
+    assert ctx_module.get_team_name() == NEW_TEAM_ID8
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# (viii) SCRATCH ROOT — census reads ONLY $CLAUDE_CONFIG_DIR, never default
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_viii_scratch_root_no_default_root_leakage(tmp_path, monkeypatch,
+                                                   capsys):
+    """CELL viii (spec Verification 4) — under CLAUDE_CONFIG_DIR at a scratch
+    root, the census and witness read ONLY that root's teams/tasks/journal. A
+    DECOY candidate seeded under the DEFAULT root (tmp/.claude — what the
+    resolution would read if it ignored the env var) carries an even-fresher
+    config+tasks store: on any default-root leakage the census would resolve
+    the DECOY (whose task store is absent here), not the scratch candidate.
+    The ALLOW + resolved-team assertion prove the scratch root was the only
+    root read."""
+    scratch = tmp_path / "scratch-root"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(scratch))
+    plugin_root = tmp_path / "plugin"
+    _seed_plugin(plugin_root)
+    _write_context(monkeypatch, tmp_path, plugin_root,
+                   team_name=OLD_TEAM, session_id=OLD_SID)
+    _reset_aligned_cache()
+    # The LIVE candidate under the SCRATCH root (owner's task lives here).
+    _seed_team_store(scratch, team_name=NEW_TEAM_ID8,
+                     lead_session_id=NEW_SID, members=(),
+                     tasks=((_NAME, "pending"),))
+    # The journal witness must also resolve under the scratch root.
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    import shared.pact_context as ctx_module
+    session_dir = Path(ctx_module.get_session_dir())
+    assert str(scratch) in str(session_dir), (
+        "session dir must derive from CLAUDE_CONFIG_DIR when set"
+    )
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / "session-journal.jsonl").write_text(
+        json.dumps({"v": 1, "type": "task_claimed",
+                    "ts": "2026-08-24T00:00:00Z"}) + "\n",
+        encoding="utf-8",
+    )
+    # The DECOY under the DEFAULT root: config + fresh tasks dir, no owner
+    # task. Fresh mtime so it would WIN the census on leakage.
+    _seed_team_store(tmp_path / ".claude", team_name="session-decoy",
+                     lead_session_id="d0c0aaaa-1111-4222-8333-444455556666",
+                     members=(), tasks=())
+    code, out = _run_dispatch(_make_spawn(), capsys)
+    assert code == 0, "census must resolve the SCRATCH-root candidate"
+    assert ctx_module.get_team_name() == NEW_TEAM_ID8
+    assert ctx_module.get_team_name() != "session-decoy"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# (ix) COMPOSITION — both divergences at once, both spawn-frame topologies
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize("frame_sid,mode",
+                         [(OLD_SID, "in-process"),
+                          (TMUX_FRAME_SID, "tmux")])
+def test_ix_composition_both_divergences_both_topologies(
+    tmp_path, monkeypatch, capsys, frame_sid, mode
+):
+    """CELL ix — the full composition: persisted OLD id, old config reaped,
+    the live team dir NAMED with the bare NEW full uuid AND carrying the NEW
+    leadSessionId (dir-name divergence AND id divergence at once — #1507 on
+    top of #989), across BOTH spawn-frame topologies (frame id == the
+    persisted/lead id, and !=). The resolver keys on the PERSISTED id (never
+    the acting frame's), so the census realigns identically in both modes.
+    NON-VACUITY: the owner's task lives only under the live dir."""
+    _seed_census_world(monkeypatch, tmp_path, live_team=NEW_UUID_DIR,
+                       live_lead_sid=NEW_SID)
+    spawn = _make_spawn(team_name_arg="wrong-team")
+    spawn["session_id"] = frame_sid
+    # Per-leg cache reset: the aligned cache would bleed across legs in this
+    # same-process harness.
+    _reset_aligned_cache()
+    code, out = _run_dispatch(spawn, capsys)
+    assert code == 0, f"census must compose both divergences ({mode})"
+    assert out == _SUPPRESS_EXPECTED
+    assert not (tmp_path / ".claude" / "tasks" / OLD_TEAM).exists()
+    assert (tmp_path / ".claude" / "tasks" / NEW_UUID_DIR).exists()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# (x) MALFORMED-CONFIG CANDIDATE STANCE — a config MISSING leadSessionId
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_x_config_missing_leadsessionid_counts_as_candidate(
+    tmp_path, monkeypatch
+):
+    """CELL x — the resolver's candidate predicate is the LITERAL spec
+    (``leadSessionId != session_id`` — NO non-empty requirement), so a config
+    whose leadSessionId key is MISSING (``data.get`` -> None != the persisted
+    id) COUNTS as a census candidate whenever its tasks store is fresh. This
+    test ASSERTS that implemented stance and records it (resolver-coder's
+    open question #1): the stance is acceptable because it is bounded by the
+    unambiguous-only rule, the journal witness, and the recency window — a
+    malformed sibling can only WIN when it is the sole fresh candidate of a
+    lived session whose persisted team config is reaped, i.e. a world where
+    returning the stale default denies every spawn anyway. If a future change
+    tightens the predicate (e.g. requires a non-string-safe, present,
+    non-empty leadSessionId), flip this test WITH it — the stance is pinned,
+    not endorsed."""
+    plugin_root = tmp_path / "plugin"
+    _seed_plugin(plugin_root)
+    _write_context(monkeypatch, tmp_path, plugin_root,
+                   team_name=OLD_TEAM, session_id=OLD_SID)
+    _reset_aligned_cache()
+    # The malformed candidate: config.json EXISTS but carries NO
+    # leadSessionId key; fresh sibling tasks store.
+    _seed_team_store(tmp_path / ".claude", team_name=NEW_TEAM_ID8, lead_session_id=None,
+                     members=(), tasks=())
+    _seed_session_journal(monkeypatch, tmp_path, ["task_claimed"])
+    import shared.pact_context as ctx_module
+    resolved = ctx_module._resolve_aligned_team_name(
+        OLD_SID, teams_dir=str(tmp_path / ".claude" / "teams"),
+        default=OLD_TEAM,
+    )
+    assert resolved == NEW_TEAM_ID8
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# (xi) COMPOSITE-DENY COHERENCE — stale block + Working-recovery hint
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_xi_stale_block_and_working_recovery_coexist_scoped(tmp_path,
+                                                            monkeypatch,
+                                                            capsys):
+    """CELL xi (auditor note) — when the stale-block detector fires ALONGSIDE
+    the ambiguous-census deny, the composite reason carries BOTH diagnoses,
+    each scoped to ITS OWN records with no contradiction inside one message:
+      * the stale-block WARNING (about the CLAUDE.md 'Current Session' block —
+        its 'completing bootstrap will rewrite them' claim is TRUE for the
+        CLAUDE.md records it names), and
+      * the re-align HINT (about pact-session-context.json — the measured
+        working recovery, leaving session_id/journal untouched).
+    The composer is A-xor-B by construction: with the incumbent fired the
+    rule-⑧ enumeration is NOT also appended, so the message carries exactly
+    one remedy path per record-type, not two competing instructions. Fixture:
+    CLAUDE.md records a PREVIOUS session's id while the acting frame carries
+    the current one (the session_init-crash overlap world where the detector
+    was designed to fire) on top of the ambiguous-census stale world."""
+    _seed_census_world(monkeypatch, tmp_path, live_team=NEW_TEAM_ID8,
+                       live_lead_sid=NEW_SID, tasks=())
+    _seed_team_store(tmp_path / ".claude", team_name=AMBIG_TEAM,
+                     lead_session_id=AMBIG_SID, members=(), tasks=())
+    # The stale-block trigger: project CLAUDE.md whose Resume line records a
+    # PREVIOUS session id, with the acting frame carrying a different one.
+    project_dir = tmp_path / "project"
+    (project_dir / ".claude").mkdir(parents=True, exist_ok=True)
+    prev_sid = "11112222-3333-4444-8555-666677778888"
+    (project_dir / ".claude" / "CLAUDE.md").write_text(
+        "# PACT Framework and Managed Project Memory\n\n"
+        "## Current Session\n"
+        f"- Resume: `claude --resume {prev_sid}`\n"
+        f"- Team: `session-11112222`\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project_dir))
+    spawn = _make_spawn()
+    spawn["session_id"] = OLD_SID  # != recorded prev_sid -> mismatch fires
+    code, out = _run_dispatch(spawn, capsys)
+    assert code == 2
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    # BOTH diagnoses present, each naming its own record surface...
+    assert _STALE_BLOCK_MARKER in reason
+    assert "CLAUDE.md" in reason                      # stale-block's surface
+    assert _HINT_MARKER in reason                     # the hint's marker
+    assert "pact-session-context.json" in reason      # the hint's surface
+    assert "journal continuity" in reason             # the hint's constraint
+    # ...and the composer did NOT also append the enumeration (A-xor-B), so
+    # no second, competing remedy block rides in the same message.
+    assert _ENUMERATION_HEADER not in reason

--- a/pact-plugin/tests/test_team_name_detect_align.py
+++ b/pact-plugin/tests/test_team_name_detect_align.py
@@ -1081,7 +1081,8 @@ def _seed_session_journal(ctx_module, event_types):
 def _seed_census_candidate(teams_root, dir_name=NEW_UUID_DIR,
                            lead_session_id=NEW_SID, *, mtime=None,
                            lead_cwd="/foreign/launch/dir",
-                           lead_joined_at_ms=LEAD_JOINED_AT_MS):
+                           lead_joined_at_ms=LEAD_JOINED_AT_MS,
+                           lead_agent_id=None):
     """Seed a census candidate: a team dir whose config carries a DIFFERENT
     leadSessionId plus a live sibling tasks store. The config is
     REAL-SHAPED (F1 corroboration fixture — a member-less config never
@@ -1090,9 +1091,11 @@ def _seed_census_candidate(teams_root, dir_name=NEW_UUID_DIR,
     and joinedAt (epoch millis). lead_cwd DEFAULTS to a directory matching
     NEITHER corroboration anchor, so a candidate BINDS only when a cell
     explicitly passes the context's project_dir (or the live cwd) — an
-    unbound candidate suppresses."""
+    unbound candidate suppresses. lead_agent_id overrides the derived
+    "team-lead@<dir>" for the #1514 suffix-mismatch pin."""
     team_dir = _seed_team_dir(teams_root, dir_name, lead_session_id=lead_session_id)
-    lead_agent_id = f"team-lead@{dir_name}"
+    if lead_agent_id is None:
+        lead_agent_id = f"team-lead@{dir_name}"
     (team_dir / "config.json").write_text(
         json.dumps({
             "name": dir_name,
@@ -1232,3 +1235,44 @@ class TestBranch3ResumeCensus:
                             team_name="", session_id=LEAD_SID)
         _seed_session_journal(ctx_module, ["task_metadata_snapshot"])
         assert ctx_module.get_team_name() == ""
+
+    def test_agentid_suffix_mismatch_never_corroborates(self, ctx, monkeypatch,
+                                                        tmp_path):
+        """#1514 — SELF-CONSISTENCY is a SUFFIX match: a config copied from
+        session-aaaa1111 into a dir named session-aaaa carries an agentId
+        that CONTAINS "@session-aaaa" but does not END with it. Every other
+        corroboration leg binds (cwd matches) yet the candidate must be
+        suppressed — the substring form would have corroborated it."""
+        ctx_module, teams_root = ctx
+        _seed_census_candidate(
+            teams_root, dir_name="session-aaaa",
+            lead_session_id="aaaa1111-2222-4333-8444-555566667777",
+            lead_cwd=str(tmp_path / "project"),
+            lead_agent_id="team-lead@session-aaaa1111",
+        )
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name=STALE_TEAM, session_id=LEAD_SID)
+        _seed_session_journal(ctx_module, ["task_metadata_snapshot"])
+        resolved = ctx_module._resolve_aligned_team_name(
+            LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
+        )
+        assert resolved == STALE_TEAM
+
+    def test_missing_leadsessionid_not_a_candidate(self, ctx, monkeypatch,
+                                                   tmp_path):
+        """M1 — a candidate config with NO real-string leadSessionId (null or
+        absent) no longer counts as a candidate at all: the != comparison
+        alone used to treat absence (None) as foreign identity. Every
+        corroboration leg otherwise binds, yet zero candidates -> the stale
+        default. (Endorses hard the cell-x stance the sibling suite pinned
+        as not-endorsed.)"""
+        ctx_module, teams_root = ctx
+        _seed_census_candidate(teams_root, lead_session_id=None,
+                               lead_cwd=str(tmp_path / "project"))
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name=STALE_TEAM, session_id=LEAD_SID)
+        _seed_session_journal(ctx_module, ["task_metadata_snapshot"])
+        resolved = ctx_module._resolve_aligned_team_name(
+            LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
+        )
+        assert resolved == STALE_TEAM

--- a/pact-plugin/tests/test_team_name_detect_align.py
+++ b/pact-plugin/tests/test_team_name_detect_align.py
@@ -1276,3 +1276,151 @@ class TestBranch3ResumeCensus:
             LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
         )
         assert resolved == STALE_TEAM
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 15. #1509 GUARDED BRANCH-2 OVERRIDE — corroborated census preempts a
+#     dead-looking own substrate; every census-empty world is byte-identical
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def _seed_dead_own_substrate(teams_root, *, own_tasks_mtime=None):
+    """The #1509 adversarial substrate: teams/<LEAD_SID>/ with inboxes/ and
+    NO config.json (branch-2's witness satisfied by a DEAD dir), plus an
+    optional own tasks store pinned to a given mtime (None = absent)."""
+    _seed_team_dir(teams_root, LEAD_SID, lead_session_id=None,
+                   with_config=False, with_inboxes=True)
+    if own_tasks_mtime is not None:
+        _seed_tasks_store(teams_root, LEAD_SID, mtime=own_tasks_mtime)
+
+
+class TestGuardedBranchTwoOverride:
+    """#1509 — the guard only ADDS suppression of branch-2 in ONE conjunctive
+    world (substrate witness AND dead-looking own store AND a corroborated
+    unique census winner). Each pin isolates one leg of that conjunction."""
+
+    def test_guarded_census_preempts_dead_substrate(self, ctx, monkeypatch,
+                                                    tmp_path):
+        """THE i-b CONTRACT — dead own-id dir (witness satisfied, no config,
+        no own tasks) + a CORROBORATED live candidate + reaped fallback
+        config + lived journal -> the resolver returns the LIVE team, NEVER
+        the dead dir name."""
+        ctx_module, teams_root = ctx
+        _seed_dead_own_substrate(teams_root)
+        _seed_census_candidate(teams_root, lead_cwd=str(tmp_path / "project"))
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name=STALE_TEAM, session_id=LEAD_SID)
+        # The substrate is DEAD = the session ENDED -> the journal carries
+        # the end marker the N1 conjunct requires for preemption.
+        _seed_session_journal(ctx_module,
+                              ["session_end", "task_metadata_snapshot"])
+        resolved = ctx_module._resolve_aligned_team_name(
+            LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
+        )
+        assert resolved == NEW_UUID_DIR  # live team — never LEAD_SID (dead dir)
+
+    def test_census_empty_does_not_preempt_idle_substrate(self, ctx,
+                                                          monkeypatch,
+                                                          tmp_path):
+        """THE IDLE-CONFIG-LESS WORLD — own substrate witness holds, own
+        tasks store AGED past the window (an idle #989 session), lived
+        journal, but the census is EMPTY (no candidates). Branch-2 still
+        wins: byte-identical to the pre-guard behavior, so idleness alone
+        can never strand a config-less session on its fallback."""
+        ctx_module, teams_root = ctx
+        _seed_dead_own_substrate(teams_root, own_tasks_mtime=ANCIENT_MTIME)
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name=STALE_TEAM, session_id=LEAD_SID)
+        _seed_session_journal(ctx_module, ["task_metadata_snapshot"])
+        resolved = ctx_module._resolve_aligned_team_name(
+            LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
+        )
+        assert resolved == LEAD_SID  # branch-2 anchor — the own substrate
+
+    def test_uncorroborated_does_not_preempt(self, ctx, monkeypatch,
+                                             tmp_path):
+        """F1 CANNOT REOPEN THROUGH THE OVERRIDE — a fresh unique candidate
+        that FAILS corroboration (lead cwd matches neither anchor) returns
+        None from the census, so it cannot preempt branch-2: the resolver
+        anchors to the own substrate, not the foreign team."""
+        ctx_module, teams_root = ctx
+        _seed_dead_own_substrate(teams_root)
+        # Candidate with the DEFAULT non-matching lead cwd: fresh, unique,
+        # uncorroborated. End marker PRESENT so the census is consulted and
+        # ONLY the corroboration leg fails.
+        _seed_census_candidate(teams_root)
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name=STALE_TEAM, session_id=LEAD_SID)
+        _seed_session_journal(ctx_module,
+                              ["session_end", "task_metadata_snapshot"])
+        resolved = ctx_module._resolve_aligned_team_name(
+            LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
+        )
+        assert resolved == LEAD_SID  # substrate beats the uncorroborated foreign team
+
+    def test_guard_suppressed_but_converged_returns_fallback(self, ctx,
+                                                             monkeypatch,
+                                                             tmp_path):
+        """LEAD-RULED EDGE — guard suppresses branch-2 (dead-looking own
+        store + corroborated winner) but the branch-3 trigger is FALSE
+        because the persisted fallback's config EXISTS (the converged /
+        #989-resume-revert world): the resolver returns the READABLE
+        persisted fallback — not the census winner, not the dead-looking
+        substrate."""
+        ctx_module, teams_root = ctx
+        _seed_dead_own_substrate(teams_root)
+        _seed_census_candidate(teams_root, lead_cwd=str(tmp_path / "project"))
+        # The fallback team's config EXISTS (converged world); its
+        # leadSessionId is foreign so branch-1 identity-match stays out.
+        _seed_team_dir(teams_root, STALE_TEAM,
+                       lead_session_id="beefbeef-1111-4222-8333-444455556666")
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name=STALE_TEAM, session_id=LEAD_SID)
+        # End marker present so the guard's preemption path is walked (the
+        # edge under test is branch-3's trigger going false, not the N1 gate).
+        _seed_session_journal(ctx_module,
+                              ["session_end", "task_metadata_snapshot"])
+        resolved = ctx_module._resolve_aligned_team_name(
+            LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
+        )
+        assert resolved == STALE_TEAM  # readable persisted team beats a substrate guess
+
+    def test_live_idle_sibling_never_preempts_without_marker(self, ctx,
+                                                             monkeypatch,
+                                                             tmp_path):
+        """N1 CELL (a) — a LIVE config-less session, idle past the window
+        (own tasks AGED, journal has activity but NO end marker), with a
+        corroborated SAME-DIR fresh sibling (lead cwd == the persisted
+        project_dir; birth-order strengthening has no marker to key on).
+        Cycle-1's unconditional branch-2 precedence MUST hold: the own
+        substrate wins; the sibling must not preempt and stick via the
+        write-back."""
+        ctx_module, teams_root = ctx
+        _seed_dead_own_substrate(teams_root, own_tasks_mtime=ANCIENT_MTIME)
+        # Same-dir sibling: corroborates on the cwd leg precisely because
+        # it shares this session's project dir.
+        _seed_census_candidate(teams_root, lead_cwd=str(tmp_path / "project"))
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name=STALE_TEAM, session_id=LEAD_SID)
+        _seed_session_journal(ctx_module, ["task_metadata_snapshot"])
+        resolved = ctx_module._resolve_aligned_team_name(
+            LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
+        )
+        assert resolved == LEAD_SID  # own substrate — the live session's anchor
+
+    def test_same_world_with_marker_sibling_preempts(self, ctx, monkeypatch,
+                                                     tmp_path):
+        """N1 CELL (b) — the SAME world plus the end marker (the session
+        actually ENDED): preemption is legitimate, the corroborated sibling
+        wins over the dead-looking substrate."""
+        ctx_module, teams_root = ctx
+        _seed_dead_own_substrate(teams_root, own_tasks_mtime=ANCIENT_MTIME)
+        _seed_census_candidate(teams_root, lead_cwd=str(tmp_path / "project"))
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name=STALE_TEAM, session_id=LEAD_SID)
+        _seed_session_journal(ctx_module,
+                              ["session_end", "task_metadata_snapshot"])
+        resolved = ctx_module._resolve_aligned_team_name(
+            LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
+        )
+        assert resolved == NEW_UUID_DIR  # corroborated sibling preempts the ENDED substrate

--- a/pact-plugin/tests/test_team_name_detect_align.py
+++ b/pact-plugin/tests/test_team_name_detect_align.py
@@ -1023,3 +1023,175 @@ class TestNonVacuity:
 
         monkeypatch.setattr(pc, "_resolve_aligned_team_name", _boom)
         assert ctx_module.get_team_name() == first  # served from cache, no re-call
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 14. BRANCH-3 RESUME CENSUS (#1507) — reaped old config + journal witness
+# ══════════════════════════════════════════════════════════════════════════════
+
+# The NEW team's lead id: a clean end-session reaps the OLD team config and
+# resume provisions a fresh team + task store under a NEW id while every hook
+# frame still carries LEAD_SID (the OLD id). The new team dir is named with
+# the full NEW uuid.
+NEW_SID = "aaaa1111-2222-4333-8444-555566667777"
+NEW_UUID_DIR = NEW_SID
+# The persisted-but-reaped OLD team (non-empty fail-safe default under test).
+STALE_TEAM = SESSION_ID8_DIR
+# A deterministic ANCIENT epoch for mtime-window tests (2001-09-09): far
+# outside RESUME_CENSUS_RECENCY_SECONDS on any conceivable clock.
+ANCIENT_MTIME = 1_000_000_000
+
+
+def _seed_tasks_store(teams_root, dir_name, *, mtime=None):
+    """Create the sibling tasks/<dir_name>/ store (the census LIVE-team
+    signal). Optionally pin its mtime (epoch seconds) for window tests."""
+    tasks_dir = teams_root.parent / "tasks" / dir_name
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / "2.json").write_text("{}", encoding="utf-8")  # a write happened
+    if mtime is not None:
+        os.utime(tasks_dir, (mtime, mtime))
+    return tasks_dir
+
+
+def _seed_session_journal(ctx_module, event_types):
+    """Write a session journal with one event per given type at the dir
+    get_session_dir() points at — the branch-3 witness's read location."""
+    session_dir = Path(ctx_module.get_session_dir())
+    session_dir.mkdir(parents=True, exist_ok=True)
+    lines = [
+        json.dumps({"v": 1, "type": event_type, "ts": "2026-08-24T00:00:00Z"})
+        for event_type in event_types
+    ]
+    (session_dir / "session-journal.jsonl").write_text(
+        "\n".join(lines) + "\n", encoding="utf-8"
+    )
+    return session_dir
+
+
+def _seed_census_candidate(teams_root, dir_name=NEW_UUID_DIR,
+                           lead_session_id=NEW_SID, *, mtime=None):
+    """Seed a census candidate: a team dir whose config carries a DIFFERENT
+    leadSessionId plus a live sibling tasks store."""
+    _seed_team_dir(teams_root, dir_name, lead_session_id=lead_session_id)
+    _seed_tasks_store(teams_root, dir_name, mtime=mtime)
+
+
+class TestBranch3ResumeCensus:
+    """Focused CODE-phase verification of the branch-3 census: trigger
+    conjuncts, unambiguous-only, and the witness's cold-start guard. The
+    comprehensive matrix (adversarial dead dirs, ordering, both-modes gate
+    legs, scratch roots) is TEST-phase work (test_resume_team_realign_1507)."""
+
+    def test_unique_live_candidate_realigns(self, ctx, monkeypatch, tmp_path):
+        """ALL trigger conjuncts true (identity-match missed; stale team's
+        config reaped; lived-session journal) + exactly ONE live candidate ->
+        the resolver UPGRADES to the re-provisioned team."""
+        ctx_module, teams_root = ctx
+        _seed_census_candidate(teams_root)
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name=STALE_TEAM, session_id=LEAD_SID)
+        _seed_session_journal(ctx_module, ["task_claimed", "variety_assessed"])
+        resolved = ctx_module._resolve_aligned_team_name(
+            LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
+        )
+        assert resolved == NEW_UUID_DIR
+
+    def test_witness_absence_census_never_fires(self, ctx, monkeypatch,
+                                                tmp_path):
+        """COLD-START GUARD — same FS substrate as the realign leg, but the
+        journal carries NO team-activity event (a fresh session's journal) ->
+        census stays off, fail-safe default returned. The paired default-half
+        that makes the realign leg's assertion attributable to the witness."""
+        ctx_module, teams_root = ctx
+        _seed_census_candidate(teams_root)
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name=STALE_TEAM, session_id=LEAD_SID)
+        # A real journal EVENT TYPE, but NOT an activity type.
+        _seed_session_journal(ctx_module, ["variety_assessed"])
+        resolved = ctx_module._resolve_aligned_team_name(
+            LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
+        )
+        assert resolved == STALE_TEAM
+
+    def test_absent_journal_census_never_fires(self, ctx, monkeypatch,
+                                               tmp_path):
+        """No journal FILE at all (fresh session before first journal write)
+        -> witness unprovable -> census inert -> fail-safe default."""
+        ctx_module, teams_root = ctx
+        _seed_census_candidate(teams_root)
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name=STALE_TEAM, session_id=LEAD_SID)
+        resolved = ctx_module._resolve_aligned_team_name(
+            LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
+        )
+        assert resolved == STALE_TEAM
+
+    def test_two_candidates_fail_safe(self, ctx, monkeypatch, tmp_path):
+        """Two live re-provisioned candidates (two simultaneous broken
+        resumes) -> AMBIGUOUS -> stale default, never a coin flip."""
+        ctx_module, teams_root = ctx
+        _seed_census_candidate(teams_root, dir_name=NEW_UUID_DIR)
+        _seed_census_candidate(
+            teams_root, dir_name="session-beefbeef",
+            lead_session_id="beefbeef-1111-4222-8333-444455556666",
+        )
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name=STALE_TEAM, session_id=LEAD_SID)
+        _seed_session_journal(ctx_module, ["task_claimed"])
+        resolved = ctx_module._resolve_aligned_team_name(
+            LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
+        )
+        assert resolved == STALE_TEAM
+
+    def test_stale_tasks_mtime_not_a_candidate(self, ctx, monkeypatch,
+                                               tmp_path):
+        """A candidate's config exists but its tasks store mtime is ANCIENT
+        (outside RESUME_CENSUS_RECENCY_SECONDS) -> zero candidates -> stale
+        default."""
+        ctx_module, teams_root = ctx
+        _seed_census_candidate(teams_root, mtime=ANCIENT_MTIME)
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name=STALE_TEAM, session_id=LEAD_SID)
+        _seed_session_journal(ctx_module, ["task_claimed"])
+        resolved = ctx_module._resolve_aligned_team_name(
+            LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
+        )
+        assert resolved == STALE_TEAM
+
+    def test_persisted_config_present_census_inert(self, ctx, monkeypatch,
+                                                   tmp_path):
+        """POST-CONVERGENCE STABILITY — the fallback team's OWN config EXISTS
+        (write-back already realigned; nothing reaped) -> trigger conjunct
+        false -> census inert even with a live foreign candidate present."""
+        ctx_module, teams_root = ctx
+        _seed_census_candidate(teams_root)
+        _seed_team_dir(teams_root, STALE_TEAM, lead_session_id=LEAD_SID)
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name=STALE_TEAM, session_id=LEAD_SID)
+        _seed_session_journal(ctx_module, ["task_claimed"])
+        resolved = ctx_module._resolve_aligned_team_name(
+            LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
+        )
+        assert resolved == STALE_TEAM
+
+    def test_census_winner_flows_through_get_team_name(self, ctx, monkeypatch,
+                                                       tmp_path):
+        """END-TO-END at the consumer seam: non-empty stale SSOT + census
+        inputs -> get_team_name() returns the census winner (lowercased)."""
+        ctx_module, teams_root = ctx
+        _seed_census_candidate(teams_root)
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name=STALE_TEAM, session_id=LEAD_SID)
+        _seed_session_journal(ctx_module, ["task_claimed"])
+        assert ctx_module.get_team_name() == NEW_UUID_DIR.lower()
+
+    def test_empty_ssot_census_unreachable(self, ctx, monkeypatch, tmp_path):
+        """SECURITY GATE — empty SSOT short-circuits to '' BEFORE the resolver
+        (and hence the census) runs, even when census inputs would otherwise
+        fire. The census is reachable only on the NON-empty path."""
+        ctx_module, teams_root = ctx
+        _seed_census_candidate(teams_root)
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name="", session_id=LEAD_SID)
+        _seed_session_journal(ctx_module, ["task_claimed"])
+        assert ctx_module.get_team_name() == ""

--- a/pact-plugin/tests/test_team_name_detect_align.py
+++ b/pact-plugin/tests/test_team_name_detect_align.py
@@ -1040,6 +1040,11 @@ STALE_TEAM = SESSION_ID8_DIR
 # A deterministic ANCIENT epoch for mtime-window tests (2001-09-09): far
 # outside RESUME_CENSUS_RECENCY_SECONDS on any conceivable clock.
 ANCIENT_MTIME = 1_000_000_000
+# Deterministic lead joinedAt (epoch MILLIS, 2026-08-24 evening UTC): AFTER
+# any seeded journal ts, so the birth-order strengthening never suppresses
+# a candidate a cell means to BIND (cells wanting suppression-by-birth-order
+# pass an explicit earlier joinedAt).
+LEAD_JOINED_AT_MS = 1_787_600_000_000
 
 
 def _seed_tasks_store(teams_root, dir_name, *, mtime=None):
@@ -1055,13 +1060,18 @@ def _seed_tasks_store(teams_root, dir_name, *, mtime=None):
 
 def _seed_session_journal(ctx_module, event_types):
     """Write a session journal with one event per given type at the dir
-    get_session_dir() points at — the branch-3 witness's read location."""
+    get_session_dir() points at — the branch-3 witness's read location.
+    `task_metadata_snapshot` is the ONLY task_* type a real hook emits
+    (`task_claimed` was fictional — review F6); its events carry the
+    schema-required task_id + metadata fields."""
     session_dir = Path(ctx_module.get_session_dir())
     session_dir.mkdir(parents=True, exist_ok=True)
-    lines = [
-        json.dumps({"v": 1, "type": event_type, "ts": "2026-08-24T00:00:00Z"})
-        for event_type in event_types
-    ]
+    lines = []
+    for event_type in event_types:
+        event = {"v": 1, "type": event_type, "ts": "2026-08-24T00:00:00Z"}
+        if event_type == "task_metadata_snapshot":
+            event.update({"task_id": "17", "metadata": {}})
+        lines.append(json.dumps(event))
     (session_dir / "session-journal.jsonl").write_text(
         "\n".join(lines) + "\n", encoding="utf-8"
     )
@@ -1069,10 +1079,34 @@ def _seed_session_journal(ctx_module, event_types):
 
 
 def _seed_census_candidate(teams_root, dir_name=NEW_UUID_DIR,
-                           lead_session_id=NEW_SID, *, mtime=None):
+                           lead_session_id=NEW_SID, *, mtime=None,
+                           lead_cwd="/foreign/launch/dir",
+                           lead_joined_at_ms=LEAD_JOINED_AT_MS):
     """Seed a census candidate: a team dir whose config carries a DIFFERENT
-    leadSessionId plus a live sibling tasks store."""
-    _seed_team_dir(teams_root, dir_name, lead_session_id=lead_session_id)
+    leadSessionId plus a live sibling tasks store. The config is
+    REAL-SHAPED (F1 corroboration fixture — a member-less config never
+    occurs on the real platform): leadAgentId plus the lead members entry
+    (found by agentId == leadAgentId, the platform invariant) carrying cwd
+    and joinedAt (epoch millis). lead_cwd DEFAULTS to a directory matching
+    NEITHER corroboration anchor, so a candidate BINDS only when a cell
+    explicitly passes the context's project_dir (or the live cwd) — an
+    unbound candidate suppresses."""
+    team_dir = _seed_team_dir(teams_root, dir_name, lead_session_id=lead_session_id)
+    lead_agent_id = f"team-lead@{dir_name}"
+    (team_dir / "config.json").write_text(
+        json.dumps({
+            "name": dir_name,
+            "leadSessionId": lead_session_id,
+            "leadAgentId": lead_agent_id,
+            "members": [{
+                "agentId": lead_agent_id,
+                "name": "team-lead",
+                "cwd": lead_cwd,
+                "joinedAt": lead_joined_at_ms,
+            }],
+        }),
+        encoding="utf-8",
+    )
     _seed_tasks_store(teams_root, dir_name, mtime=mtime)
 
 
@@ -1084,13 +1118,15 @@ class TestBranch3ResumeCensus:
 
     def test_unique_live_candidate_realigns(self, ctx, monkeypatch, tmp_path):
         """ALL trigger conjuncts true (identity-match missed; stale team's
-        config reaped; lived-session journal) + exactly ONE live candidate ->
-        the resolver UPGRADES to the re-provisioned team."""
+        config reaped; lived-session journal) + exactly ONE live candidate
+        that CORROBORATES (lead cwd == persisted project_dir) -> the
+        resolver UPGRADES to the re-provisioned team."""
         ctx_module, teams_root = ctx
-        _seed_census_candidate(teams_root)
+        _seed_census_candidate(teams_root, lead_cwd=str(tmp_path / "project"))
         _write_context_file(monkeypatch, ctx_module, tmp_path,
                             team_name=STALE_TEAM, session_id=LEAD_SID)
-        _seed_session_journal(ctx_module, ["task_claimed", "variety_assessed"])
+        _seed_session_journal(ctx_module,
+                              ["task_metadata_snapshot", "variety_assessed"])
         resolved = ctx_module._resolve_aligned_team_name(
             LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
         )
@@ -1098,12 +1134,13 @@ class TestBranch3ResumeCensus:
 
     def test_witness_absence_census_never_fires(self, ctx, monkeypatch,
                                                 tmp_path):
-        """COLD-START GUARD — same FS substrate as the realign leg, but the
-        journal carries NO team-activity event (a fresh session's journal) ->
-        census stays off, fail-safe default returned. The paired default-half
-        that makes the realign leg's assertion attributable to the witness."""
+        """COLD-START GUARD — same FS substrate as the realign leg (candidate
+        BINDS via lead cwd), but the journal carries NO team-activity event
+        (a fresh session's journal) -> census stays off, fail-safe default
+        returned. The paired default-half that makes the realign leg's
+        assertion attributable to the witness."""
         ctx_module, teams_root = ctx
-        _seed_census_candidate(teams_root)
+        _seed_census_candidate(teams_root, lead_cwd=str(tmp_path / "project"))
         _write_context_file(monkeypatch, ctx_module, tmp_path,
                             team_name=STALE_TEAM, session_id=LEAD_SID)
         # A real journal EVENT TYPE, but NOT an activity type.
@@ -1137,7 +1174,7 @@ class TestBranch3ResumeCensus:
         )
         _write_context_file(monkeypatch, ctx_module, tmp_path,
                             team_name=STALE_TEAM, session_id=LEAD_SID)
-        _seed_session_journal(ctx_module, ["task_claimed"])
+        _seed_session_journal(ctx_module, ["task_metadata_snapshot"])
         resolved = ctx_module._resolve_aligned_team_name(
             LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
         )
@@ -1152,7 +1189,7 @@ class TestBranch3ResumeCensus:
         _seed_census_candidate(teams_root, mtime=ANCIENT_MTIME)
         _write_context_file(monkeypatch, ctx_module, tmp_path,
                             team_name=STALE_TEAM, session_id=LEAD_SID)
-        _seed_session_journal(ctx_module, ["task_claimed"])
+        _seed_session_journal(ctx_module, ["task_metadata_snapshot"])
         resolved = ctx_module._resolve_aligned_team_name(
             LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
         )
@@ -1168,7 +1205,7 @@ class TestBranch3ResumeCensus:
         _seed_team_dir(teams_root, STALE_TEAM, lead_session_id=LEAD_SID)
         _write_context_file(monkeypatch, ctx_module, tmp_path,
                             team_name=STALE_TEAM, session_id=LEAD_SID)
-        _seed_session_journal(ctx_module, ["task_claimed"])
+        _seed_session_journal(ctx_module, ["task_metadata_snapshot"])
         resolved = ctx_module._resolve_aligned_team_name(
             LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
         )
@@ -1179,10 +1216,10 @@ class TestBranch3ResumeCensus:
         """END-TO-END at the consumer seam: non-empty stale SSOT + census
         inputs -> get_team_name() returns the census winner (lowercased)."""
         ctx_module, teams_root = ctx
-        _seed_census_candidate(teams_root)
+        _seed_census_candidate(teams_root, lead_cwd=str(tmp_path / "project"))
         _write_context_file(monkeypatch, ctx_module, tmp_path,
                             team_name=STALE_TEAM, session_id=LEAD_SID)
-        _seed_session_journal(ctx_module, ["task_claimed"])
+        _seed_session_journal(ctx_module, ["task_metadata_snapshot"])
         assert ctx_module.get_team_name() == NEW_UUID_DIR.lower()
 
     def test_empty_ssot_census_unreachable(self, ctx, monkeypatch, tmp_path):
@@ -1193,5 +1230,5 @@ class TestBranch3ResumeCensus:
         _seed_census_candidate(teams_root)
         _write_context_file(monkeypatch, ctx_module, tmp_path,
                             team_name="", session_id=LEAD_SID)
-        _seed_session_journal(ctx_module, ["task_claimed"])
+        _seed_session_journal(ctx_module, ["task_metadata_snapshot"])
         assert ctx_module.get_team_name() == ""


### PR DESCRIPTION
## Summary

After a session ends cleanly, `claude --resume <old-id>` provisions a NEW team and task store under a new platform id while every hook frame still carries the OLD session id. The old team's config is reaped, so #989's identity-match cannot align and `dispatch_gate` denied every spawn with a stale-team diagnosis pointing at an inert remedy.

Refs #1507. Follow-up: #1509 (guarded branch-2 census override for the unobserved Desktop-shaped dead-dir world).

## Verify-first premise — measured answer

**E1: the resume SessionStart stdin carried the OLD session id.** Evidence triad: (1) the journal anchor event's `session_id` is the stdin id verbatim and carries `a1dd211c`; (2) every hook event in the 17:12–17:53 window landed in the OLD session's journal; (3) zero `fdb323fe` artifacts exist anywhere (context file, transcript, dir) — a heal would have created its context file. Platform model: the OLD id remains the SESSION id (transcript + hooks); the NEW id is the TEAM provisioning id. Consequently **fork (a) (session_init stdin-wins) is code-refuted**: session_init persists the stdin id verbatim (no preference-order site exists; v4.6.41 ≡ v4.6.42 byte-identical on the three hook files).

## What landed (fork b: resolver-side census)

- **`pact_context.py`** — branch-3 census in `_resolve_aligned_team_name`, after branch-2: when identity-match failed, the persisted team's config is absent, and the session journal shows prior team activity (`task_*` / `dispatch_decision` / `session_end` / `session_consolidated`), enumerate `teams/*/config.json` for a single candidate with a foreign `leadSessionId` whose sibling `tasks/<dir>/` received writes within `RESUME_CENSUS_RECENCY_SECONDS = 900`. Exactly one candidate wins; zero or several fall back to today's byte-identical stale default. The journal-witness conjunct is load-bearing: it prevents a fresh cold-start session from cross-aligning to a concurrently active foreign session. Convergence persists via the existing `bootstrap_marker_writer` write-back (team_name only; session id and journal dir untouched), then goes inert (persisted team's config now exists).
- **`dispatch_gate.py`** — both stale-team remedy texts (`_CAUSE_ENUMERATION` cause 2 and `_STALE_REALIGN_HINT`) rewritten to name the measured working recovery: edit `pact-session-context.json` in the OLD session directory, set `team_name` to the LIVE team (newest `teams/session-*/config.json`), leave `session_id` and the journal dir untouched, re-dispatch. Base deny messages stay byte-identical; pin tests updated with coupled presence markers and falsified-phrase tripwires.
- **`tests/test_resume_team_realign_1507.py`** — 16-test contract-first matrix (cells i–xi): reaped-config realignment, ambiguous fail-safe, empty-SSOT fail-closed behind the short-circuit (DO-NOT-FLIP pin `:309` green unmodified), #989 same-id precedence, branch-2 ordering, cold-start journal-witness guard, post-convergence inertness, `CLAUDE_CONFIG_DIR` scratch-root isolation with a default-root decoy, both spawn-frame topologies, malformed-config stance, and composite-deny coherence. The dead Desktop-shaped remnant leg is `xfail(strict=True)` citing #1509.

## Verification

- Full suite from `pact-plugin` (no path argument): **14858 passed, 15 skipped, 1 xfailed, 0 failed, 0 errors** — baseline 14843 + exactly 16 new. Source-only revert probes tie each matrix cell to its slice (`pact_context` revert → 6 census cells red; `dispatch_gate` revert → ii+xi red).
- Concurrent CODE-phase audit: GREEN, structural ACs verified against committed numstat.
- Merge-blocking pre-merge gates (to run before merge): **live dogfood** (throwaway session: clean end-session → resume → first specialist spawn passes `dispatch_gate` with NO manual repoint, observed team ids + installed-version proof recorded here) and the **scratch-root smoke** (census reads only `CLAUDE_CONFIG_DIR` root).

---

## Review cycle 1 addendum (2026-08-24)

Four-lane review (architect contract pass / coverage / fresh-eyes backend / adversarial security) returned one **blocking** finding, independently reproduced by two lanes: the census proved nothing about ownership — the witness was armed by the gate's own denials (`dispatch_decision` journals on every decision) and uniqueness was satisfiable by a concurrently active sibling session's fresh store, with the marker-writer write-back making a wrong winner sticky. Reproduced hermetically, sandboxed end-to-end (a spawn ALLOWED against a foreign team's task), and accidentally live.

**Fix (`e0fb7c83`)** — the census winner is now bound to this session by mechanism, not uniqueness: the unique candidate must corroborate via lead-member cwd anchor (raw either-match against the live cwd or the persisted `project_dir`), `leadAgentId` self-consistency, and a lead `joinedAt` strictly after the journal's last end-marker; `dispatch_decision` is dropped from the witness exact-set. Uncorroborated, malformed, or ambiguous worlds suppress to today's byte-identical stale default; the write-back inherits the binding (corroboration lives inside the resolver path).

**Measured empirical (for the record):** first-dispatch frames are **POST-BIRTH** — the platform provisions the new team's config atomically (substrate incl. `config.json` at session birth), so the pre-birth window the original design feared does not occur in practice; suppression in it is therefore free, and corroboration is defense-in-depth.

**Pins (`adc904ba`)** — 30 cells incl. scenario-A and deny-armed-journal regressions, individually-pinned witness arms, the clock-stubbed 900 s boundary, honestly-pinned trust-boundary residuals (same-cwd sibling passes the anchor and aligns — documented boundary mirroring the #1509 family). Suite: 14873 passed / 15 skipped / 1 xfailed / 0 failed / 0 errors. Both finding-author lanes verify-resolved (security: all six items; backend: all items + 4-world instrumented run).

**Known bounded limitations (disclosed):** two-session post-birth worlds converge only when the sibling is idle >900 s or foreign-cwd (permanent ambiguity → honest deny + manual-recovery remedy); POSIX dir-mtime is a create/delete signal (TaskUpdate-only activity ages out — suppression-only); `joinedAt` type strictness fails closed.

**Merge gates in flight:** live dogfood (clean end-session → resume → first spawn passes with no manual repoint) **with a sibling-session leg**, plus the scratch-root smoke — evidence with observed team ids to follow before merge.


---

## Live merge gates — PASSED (observed, 2026-08-24)

Plugin 4.6.43 (worktree build) installed into a scratch root via the platform's own marketplace installer. Throwaway session `ef08652e` lived (task creates + spawns), ended cleanly (`session_end` 20:49:30Z, old team config reaped by the platform — not hand-deleted). **Resume at 20:55:59Z: first specialist spawn `dispatch_decision` WARN = PASS at 20:56:29Z with NO manual repoint** — the persisted context was never hand-edited. A **concurrent sibling session** (`1f116897`, fresh store, held open across the resume — the preferred shape) ran during the resume: **not aligned to**. A **decoy** config-bearing team planted under the default root (would-win-on-leakage) was **never read** — scratch-root isolation held. Clean end 20:56:52Z. Evidence: `docs/verification/1507-dogfood.md` (gitignored, local). Plugin-version proof: banner `PACT plugin: PACT 4.6.43`.

**Honest limitation:** the headless platform writes config-less bare-uuid teams and does not re-key the session id on resume, so the exact #1507 split world did not arise headlessly — resolution ran branch-2 to the correct store. The census's realign direction is therefore synthetic-verified (30 cells + instrumented 4-world runs: legit re-provision → aligns) and live-verified in the inert/no-misalignment direction (sibling ignored, decoy never read). Every realign-misfire direction is fail-safe (byte-identical stale default + honest remedy). The first real interactive resume-after-end in daily use is the natural live realign confirmation.

**Follow-ups filed:** #1511 (`_VALID_SOURCES` fork gap), #1512 (stale_session adjacent-remedies coherence), #1513 (`/tmp` vs `/private/tmp` canonicalization, observed in this dogfood), #1514 (leadAgentId substring-vs-suffix). Previously: #1509 (guarded branch-2 override for the unobserved Desktop dead-dir world).


---

## Review cycle 2 — deferred findings folded in (user preference)

Per review preference, the deferred findings landed in this PR rather than the backlog:

- **#1514** (`d059ba48`): leadAgentId self-consistency is now a suffix match — copied-config prefix collisions no longer corroborate.
- **M1 hardening** (`d059ba48`): a census candidate config must carry `leadSessionId` as a real string; missing/null no longer counts (stance flipped from pinned-not-endorsed to endorsed, cell re-semanticsed).
- **#1512** (`ee1f8340`): the staleness warning's rewrite claim scoped to the CLAUDE.md session records.
- **#1509** (`5f4ce5cb`): the guarded branch-2 override — a corroborated census winner preempts a dead Desktop-shaped branch-2 substrate. Security review's follow-on finding (N1) also folded: preemption additionally requires an **end marker** in the session's journal (only an ENDED substrate may be preempted), which restores exact pre-guard precedence for live-but-idle and crash-resumed sessions. The formerly `xfail(strict)` i-b cells are now hard assertions; the single-census-pass property instrument-verified.

Both finding-author lanes verify-clean through cycle 2 (security: no objection to merge, all acceptance-bar items met; backend: all worlds instrument-verified incl. the N1-restored world D). Final suite on the merged state: **14884 passed / 15 skipped / 0 failed / 0 xfailed**.

Fixes #1509. Fixes #1512. Fixes #1514. (#1511 and #1513 stay open — verify-first items: unobserved fork source payload; unreproduced path canonicalization.)

