### PR TITLE
Add Cloud Agent development environment for PACT plugin

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "PACT Plugin",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for the PACT plugin test harness.
+#
+# Mirrors the CI dependency set in .github/workflows/tests.yml so that a local
+# green and a CI green are the same green. Installs into a repo-local venv
+# (.venv) to keep the system interpreter clean. Safe to run repeatedly.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# System packages required to build pysqlite3 from source and to create venvs.
+# These normally live in the base snapshot; the guard makes the script
+# self-healing on a fresh default image without paying apt cost on every run.
+if ! dpkg -s build-essential >/dev/null 2>&1 \
+  || ! dpkg -s libsqlite3-dev >/dev/null 2>&1 \
+  || ! dpkg -s python3-venv >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y --no-install-recommends \
+    build-essential libsqlite3-dev python3-venv
+fi
+
+if [ ! -x .venv/bin/python ]; then
+  python3 -m venv .venv
+fi
+
+# shellcheck disable=SC1091
+. .venv/bin/activate
+
+python -m pip install --upgrade pip
+
+# CI install line (kept in lockstep with .github/workflows/tests.yml):
+#   pytest hypothesis httpx pytest-asyncio pyyaml pysqlite3 sqlite-vec model2vec ruff
+python -m pip install \
+  pytest \
+  hypothesis \
+  httpx \
+  pytest-asyncio \
+  pyyaml \
+  pysqlite3 \
+  sqlite-vec \
+  model2vec \
+  ruff
+
+echo "PACT plugin environment ready. Activate with: source .venv/bin/activate"
+echo "Run the suite with: cd pact-plugin && python -m pytest -ra"

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -42,5 +42,27 @@ python -m pip install \
   model2vec \
   ruff
 
+# Claude Code CLI — enables the live end-to-end plugin smoke test
+# (.cursor/smoke-test.sh). Installed into a user-local npm prefix so no sudo is
+# needed; node/npm come from the base image. Idempotent: skipped when present.
+NPM_GLOBAL="$HOME/.npm-global"
+export PATH="$NPM_GLOBAL/bin:$PATH"
+if ! command -v claude >/dev/null 2>&1; then
+  if command -v npm >/dev/null 2>&1; then
+    mkdir -p "$NPM_GLOBAL"
+    npm install -g --prefix "$NPM_GLOBAL" @anthropic-ai/claude-code
+  else
+    echo "WARNING: npm not found; skipping Claude Code CLI install (live smoke test unavailable)." >&2
+  fi
+fi
+
+# Put the CLI on PATH for future interactive shells (idempotent).
+BASHRC="$HOME/.bashrc"
+LINE='export PATH="$HOME/.npm-global/bin:$PATH"'
+if [ -f "$BASHRC" ] && ! grep -Fqx "$LINE" "$BASHRC"; then
+  printf '\n# Claude Code CLI (installed by .cursor/install.sh)\n%s\n' "$LINE" >> "$BASHRC"
+fi
+
 echo "PACT plugin environment ready. Activate with: source .venv/bin/activate"
 echo "Run the suite with: cd pact-plugin && python -m pytest -ra"
+echo "Live plugin smoke test: bash .cursor/smoke-test.sh (needs ANTHROPIC_API_KEY for the live phase)"

--- a/.cursor/smoke-test.sh
+++ b/.cursor/smoke-test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Live end-to-end smoke test: load the PACT plugin into a real Claude Code
+# session and confirm the orchestrator persona is active and the plugin's
+# structure validates.
+#
+# Two phases:
+#   1. Offline: `claude plugin validate` on the plugin + marketplace (no auth).
+#   2. Live:    a single headless `-p` turn with the plugin loaded and the
+#               orchestrator persona selected. Requires ANTHROPIC_API_KEY.
+#
+# The live phase is skipped (not failed) when ANTHROPIC_API_KEY is absent, so
+# the offline phase still runs in environments without the secret.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLUGIN_DIR="$REPO_ROOT/pact-plugin"
+
+# Resolve the claude CLI (user-local npm prefix from install.sh, or PATH).
+export PATH="$HOME/.npm-global/bin:$PATH"
+if ! command -v claude >/dev/null 2>&1; then
+  echo "FAIL: claude CLI not found. Run .cursor/install.sh first." >&2
+  exit 1
+fi
+echo "claude version: $(claude --version)"
+
+echo
+echo "== Phase 1: offline plugin + marketplace validation =="
+claude plugin validate "$PLUGIN_DIR"
+claude plugin validate "$REPO_ROOT"
+
+echo
+echo "== Phase 2: live headless session =="
+if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "SKIP: ANTHROPIC_API_KEY not set — offline validation passed; skipping live model call."
+  exit 0
+fi
+
+# Prerequisites the plugin documents for agent operation.
+export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+export CLAUDE_CODE_ENABLE_TODO_TOOLS=1
+
+MARKER="PACT_SMOKE_OK"
+PROMPT="You are running as the PACT orchestrator persona loaded from a plugin. \
+Do NOT spawn any agents, do NOT use any tools, and do NOT start an orchestration. \
+Reply with exactly one line: the token ${MARKER} followed by a comma-separated \
+list of the PACT specialist agent roles you coordinate."
+
+set +e
+OUT="$(claude \
+  --plugin-dir "$PLUGIN_DIR" \
+  --agent PACT:pact-orchestrator \
+  --permission-mode bypassPermissions \
+  --model sonnet \
+  --output-format text \
+  -p "$PROMPT" 2>&1)"
+RC=$?
+set -e
+
+echo "---- model output ----"
+echo "$OUT"
+echo "----------------------"
+
+if [ $RC -ne 0 ]; then
+  echo "FAIL: claude exited with code $RC" >&2
+  exit 1
+fi
+
+if echo "$OUT" | grep -q "$MARKER"; then
+  echo "PASS: plugin loaded, orchestrator persona active, model round-trip succeeded."
+  exit 0
+fi
+
+echo "FAIL: expected marker '$MARKER' not found in model output." >&2
+exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,8 @@ __pycache__/
 CLAUDE.md
 .worktrees/
 
+# Cloud Agent bootstrap venv (created by .cursor/install.sh)
+.venv/
+
 # Sidecar lock files created by file_lock() helper
 .*.lock


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cloud Agent development environment so the PACT plugin repository is fully usable in Cursor Cloud Agents. The setup mirrors the CI dependency set in `.github/workflows/tests.yml` so a local green and a CI green are the same green.

## What was added

- `.cursor/environment.json` — declares the environment `name` and an idempotent `install` command.
- `.cursor/install.sh` — idempotent bootstrap that installs the system packages needed to build `pysqlite3` (`build-essential`, `libsqlite3-dev`, `python3-venv`, guarded so apt is skipped when already present), creates a repo-local `.venv`, and installs the exact CI dependency set (`pytest hypothesis httpx pytest-asyncio pyyaml pysqlite3 sqlite-vec model2vec ruff`).
- `.gitignore` — ignore the bootstrap `.venv/`.

There is no long-running service to run: PACT is a Claude Code plugin/test harness, so the development experience is the pytest suite, the ruff import-hygiene lint, and the pact-memory CLI.

## Validation

- Import-hygiene lint (`ruff check --select F401,F821 --target-version py39 pact-plugin/`, both legs): passed.
- Full suite (`cd pact-plugin && python -m pytest -ra`): **14797 passed, 453 skipped, 0 failed**. Skips are the documented intentional carve-outs (baked-SHA differentials unreachable in this clone, live-tmux probes, the Python 3.9 interpreter probe).
- pact-memory CLI end-to-end: `setup` → `save` → semantic `search` retrieved the saved memory by meaning (`search_mode: semantic`, model2vec embeddings over sqlite-vec).
- Install idempotence: ran the install command twice; the second run recreated nothing.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae2c299f-4af7-4de1-854c-c720ea9fc338?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae2c299f-4af7-4de1-854c-c720ea9fc338&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

