### PR TITLE
Report the backlog at wrap-up's session decision, and pin the read call sites

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.7.0/     # Plugin version
+│               └── 4.7.1/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.7.0
+> **Version**: 4.7.1
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/commands/bootstrap.md
+++ b/pact-plugin/commands/bootstrap.md
@@ -62,7 +62,8 @@ This is a CALL SITE, not a boundary write: nothing has finished at session start
 there is no witnessed transition and no status to set here. Report only the drift
 FLAGS. Do NOT re-print the item list — the session-start block already showed it, and
 a bookend that repeats what the reader just saw stops being read. If there are no
-flags, say nothing at all: the block already proves the backlog was read.
+flags, say nothing at all: the block already proves the backlog was read. If the
+report does not run, say so and carry on — never run `repair` here.
 
 ---
 

--- a/pact-plugin/commands/next.md
+++ b/pact-plugin/commands/next.md
@@ -100,6 +100,12 @@ Exit code 2 is a REFUSAL, not a corruption: the file is readable and nothing was
 written. Report what the message names and fix that. Do NOT go to Step 5 — a
 readable file must never be repaired.
 
+Exit code 64 is a USAGE error: the command line was malformed, so the tool never
+ran. Nothing was read and nothing was written, so the backlog says nothing about
+this. Fix the invocation the message names and run it again — a global flag such
+as `--backlog-dir` must come BEFORE the subcommand. Do NOT go to Step 5, and do
+NOT report it as a refusal.
+
 A file that parses but breaks a schema rule reports as `schema:` flags and
 still renders. Fix the field the flag names.
 

--- a/pact-plugin/commands/next.md
+++ b/pact-plugin/commands/next.md
@@ -171,6 +171,20 @@ written rather than quietly adjusted:
 - `memory` holds at most 5 record ids.
 - An item with no `ref` is fully supported and is never second-class.
 
+### Where the report happens, and which files carry it
+
+**THREE FILES carry a backlog report**: `bootstrap.md`, `wrap-up.md` and
+`next.md`. Naming the files rather than the occasions is deliberate — a file is
+checkable, an occasion is not.
+
+A report belongs where the user is choosing WHAT TO DO NEXT: at session start,
+before the session decision, and in this command. It does not belong where an
+already-chosen item is being executed, or where one artifact is being judged —
+those are occasions to write a witnessed transition, not to re-read the list.
+
+Two of the three report without being asked, so they are the session's bookends;
+this command's report happens because the user invoked it.
+
 ### When the writes happen, and which they are
 
 **FOUR FILES carry boundary writes**: `orchestrate.md`, `comPACT.md`,

--- a/pact-plugin/commands/wrap-up.md
+++ b/pact-plugin/commands/wrap-up.md
@@ -247,6 +247,14 @@ Audit and optionally clean up Task state:
 
 ## 8. Session Decision
 
+Run the backlog report before the decision below:
+
+```bash
+python3 "{plugin_root}/hooks/shared/backlog.py" show
+```
+
+This is a CALL SITE, not a boundary write: every status this session witnessed was already recorded at its own transition, so nothing has newly finished here. Report only the drift FLAGS and what remains open. The report is READ-ONLY in your hands — report a flag, never correct one; an item whose status looks wrong is corrected through `/PACT:next`, not here. If there are no flags and nothing is open, say nothing.
+
 Use `AskUserQuestion` with these exact options:
 - **"Yes, continue"** (description: "Keep team alive, ready for next task") → On selection: Report "Ready for next task." Teammates stay alive — do NOT stop them on this branch.
 - **"Pause work for now"** (description: "Save session knowledge and pause — resume later") → On selection: invoke `/PACT:pause`. That command owns the teammate shutdown — do NOT stop teammates here.

--- a/pact-plugin/commands/wrap-up.md
+++ b/pact-plugin/commands/wrap-up.md
@@ -253,7 +253,7 @@ Run the backlog report before the decision below:
 python3 "{plugin_root}/hooks/shared/backlog.py" show
 ```
 
-This is a CALL SITE, not a boundary write: every status this session witnessed was already recorded at its own transition, so nothing has newly finished here. Report only the drift FLAGS and what remains open. The report is READ-ONLY in your hands — report a flag, never correct one; an item whose status looks wrong is corrected through `/PACT:next`, not here. If there are no flags and nothing is open, say nothing.
+This is a CALL SITE, not a boundary write: every status this session witnessed was already recorded at its own transition, so nothing has newly finished here. Report only the drift FLAGS and what remains open. The report is READ-ONLY in your hands — report a flag, never correct one; an item whose status looks wrong is corrected through `/PACT:next`, not here. If there are no flags and nothing is open, say nothing. If the report does not run, say so and carry on to the decision — never run `repair` here.
 
 Use `AskUserQuestion` with these exact options:
 - **"Yes, continue"** (description: "Keep team alive, ready for next task") → On selection: Report "Ready for next task." Teammates stay alive — do NOT stop them on this branch.

--- a/pact-plugin/hooks/shared/backlog.py
+++ b/pact-plugin/hooks/shared/backlog.py
@@ -69,6 +69,14 @@ _EXIT_REFUSED = 2
 # alternative was to have the caller read the message text, which is the
 # substring routing this design refuses everywhere else.
 _EXIT_UNREADABLE = 3
+# A MALFORMED COMMAND LINE IS NOT A REFUSAL, and sharing argparse's default 2
+# with `_EXIT_REFUSED` made the two indistinguishable: a mistyped invocation
+# reported as the tool declining. Measured: `--backlog-dir` placed after the
+# subcommand returned 2 across five different store states, reading as five
+# real refusals. 64 is EX_USAGE from sysexits.h, the BSD convention for exactly
+# this; it collides with none of 0/2/3 and sits below the 126-255 range shells
+# reserve for not-executable, not-found and signal deaths.
+_EXIT_USAGE = 64
 
 # An `active` item untouched for longer than this is reported as stale.
 _STALE_AFTER = timedelta(days=14)
@@ -990,9 +998,21 @@ def _branch_and_worktree_names(project_path: Any = None) -> Optional[List[str]]:
 # CLI
 # ---------------------------------------------------------------------------
 
+class _UsageErrorParser(argparse.ArgumentParser):
+    """Exits `_EXIT_USAGE` on a malformed command line, not argparse's default 2.
+
+    Subclassed rather than caught in `main()` so the code is carried by the
+    parser itself: `add_subparsers` propagates this class to every subparser,
+    and a caller holding `build_parser()` gets it too.
+    """
+
+    def error(self, message):
+        self.exit(_EXIT_USAGE, f"{self.format_usage()}{self.prog}: error: {message}\n")
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Argument grammar, separated so it is testable without running anything."""
-    parser = argparse.ArgumentParser(
+    parser = _UsageErrorParser(
         description="PACT cross-session backlog — the user's ordered intent, "
         "reconciled against git, the tracker and pact-memory.",
     )

--- a/pact-plugin/hooks/shared/backlog.py
+++ b/pact-plugin/hooks/shared/backlog.py
@@ -991,7 +991,19 @@ def _branch_and_worktree_names(project_path: Any = None) -> Optional[List[str]]:
     worktrees = _run_capture(["git", *at, "worktree", "list", "--porcelain"])
     if branches is None and worktrees is None:
         return None
-    return f"{branches or ''}\n{worktrees or ''}".splitlines()
+    # NAMES ONLY. The porcelain also carries `HEAD <sha>` — once PER WORKTREE —
+    # and absolute paths, and the caller matches by SUBSTRING. So a ref's digits
+    # could be satisfied by chance hex or by a parent directory, the token was
+    # "found", and the abandoned-work flag this heuristic exists to emit was
+    # silently suppressed. `detached`, `locked`, `bare` and `prunable` carry no
+    # name and drop out with them.
+    names = (branches or "").splitlines()
+    for line in (worktrees or "").splitlines():
+        if line.startswith("worktree "):
+            names.append(Path(line[len("worktree "):]).name)
+        elif line.startswith("branch "):
+            names.append(line[len("branch "):].removeprefix("refs/heads/"))
+    return names
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/hooks/shared/backlog.py
+++ b/pact-plugin/hooks/shared/backlog.py
@@ -181,9 +181,11 @@ def checkout_roots() -> List[str]:
     right about at least itself.
 
     Deliberately NOT merged with _branch_and_worktree_names, which runs the
-    same porcelain: that caller wants raw lines including branch names, this
-    one wants resolved paths, and one helper serving both needs a mode flag.
-    Two subprocesses per write on a path the design says can afford one.
+    same porcelain: that caller reduces each `worktree` line to a BASENAME for
+    substring matching, this one resolves it to an absolute path for exact
+    membership — opposite ends of the same string, so one helper serving both
+    still needs a mode flag. It also runs a second git call this one does not
+    need. Two subprocesses per write on a path the design says can afford one.
     """
     porcelain = _run_capture(
         ["git", "-C", str(project_root()), "worktree", "list", "--porcelain"]

--- a/pact-plugin/hooks/shared/backlog.py
+++ b/pact-plugin/hooks/shared/backlog.py
@@ -957,7 +957,23 @@ def _abandoned_flags(
     from reconcile the way _plan_flags already receives it, rather than calling
     project_root(), which raises and would turn a drift report into a refusal.
     """
-    tracked = [item for item in items if item.get("status") == "active" and item.get("ref")]
+    # A RECENTLY TOUCHED ITEM IS NOT ABANDONED, whatever its branch is called.
+    # The linkage below only sees a branch that carries the ref's digits, and
+    # a branch named without its issue number reads as no branch at all. Where
+    # that naming is common — and in some repositories it is the majority —
+    # live work reports as abandoned. `_STALE_AFTER` already encodes this
+    # notion of neglect; a second threshold would be a second thing to keep in
+    # step. Filtered HERE rather than in the loop below so the early return
+    # still spares the git calls when nothing qualifies.
+    cutoff = (datetime.now(timezone.utc) - _STALE_AFTER).date()
+    tracked = []
+    for item in items:
+        if item.get("status") != "active" or not item.get("ref"):
+            continue
+        touched = as_datetime(item.get("touched"))
+        if touched is not None and touched.date() >= cutoff:
+            continue
+        tracked.append(item)
     if not tracked:
         return []
     # ponytail: the linkage is the ref's digits appearing in a branch or

--- a/pact-plugin/scripts/memory_reachability.py
+++ b/pact-plugin/scripts/memory_reachability.py
@@ -39,6 +39,9 @@ Exit codes:
   2 -- nothing was reported. Either a precondition failed before the scan, or
        the scan ran and the report could not be written. The caller is left
        without a report either way, and that outcome is all the code carries.
+  64 -- the command line was malformed, so nothing ran. Fix the invocation the
+       message names. Separate from 2 because argparse exits 2 by default,
+       which made a mistyped command indistinguishable from a refusal.
 """
 from __future__ import annotations
 
@@ -423,8 +426,27 @@ def as_dict(result: Scan) -> dict:
     }
 
 
+# A malformed command line is not a REFUSAL. argparse exits 2 by default and
+# this script already returns 2 for "REFUSED", so the two were indistinguishable
+# to a caller. 64 is EX_USAGE from sysexits.h; it matches backlog.py's split and
+# sits below the 126-255 range shells reserve.
+_EXIT_USAGE = 64
+
+
+class _UsageErrorParser(argparse.ArgumentParser):
+    """Exits `_EXIT_USAGE` on a malformed command line, not argparse's 2.
+
+    Subclassed rather than caught in `main()` so the code rides the parser: a
+    caller holding `build_parser()` gets it without going through `main`.
+    """
+
+    def error(self, message):
+        self.exit(_EXIT_USAGE, "{0}{1}: error: {2}\n".format(
+            self.format_usage(), self.prog, message))
+
+
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    parser = _UsageErrorParser(description=(__doc__ or "").splitlines()[0])
     parser.add_argument("directory", help="one agent-memory directory to scan (no default)")
     parser.add_argument("--report", help="write the findings to this JSON file")
     parser.add_argument("--quiet", action="store_true", help="suppress the text report")

--- a/pact-plugin/scripts/memory_repair/shred_detect.py
+++ b/pact-plugin/scripts/memory_repair/shred_detect.py
@@ -57,6 +57,9 @@ Exit codes:
      annotates and the caller decides.
   2  the no-writer precondition failed, or the file is absent, or the table
      is absent. Nothing was scanned.
+  64 the command line was malformed, so nothing ran. Fix the invocation the
+     message names. Separate from 2 because argparse exits 2 by default,
+     which made a mistyped command indistinguishable from a refusal.
 <!-- PACT_STORE_BAR_BEGIN -->
 **STORE ACCESS.** A memory operation (save, search, get, list, update or
 delete a record) goes through the pact-memory CLI. YOU DO NOT SELECT A
@@ -453,8 +456,27 @@ def render_text(report: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+# A malformed command line is not a REFUSAL. argparse exits 2 by default and
+# this script already returns 2 for "REFUSED", so the two were indistinguishable
+# to a caller. 64 is EX_USAGE from sysexits.h; it matches backlog.py's split and
+# sits below the 126-255 range shells reserve.
+_EXIT_USAGE = 64
+
+
+class _UsageErrorParser(argparse.ArgumentParser):
+    """Exits `_EXIT_USAGE` on a malformed command line, not argparse's 2.
+
+    Subclassed rather than caught in `main()` so the code rides the parser: a
+    caller holding `build_parser()` gets it without going through `main`.
+    """
+
+    def error(self, message):
+        self.exit(_EXIT_USAGE, "{0}{1}: error: {2}\n".format(
+            self.format_usage(), self.prog, message))
+
+
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+    parser = _UsageErrorParser(
         prog="shred_detect",
         description=(
             "Report memory records whose list fields hold shredded prose. "

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -2150,9 +2150,42 @@ def test_the_abandoned_heuristic_reads_real_branches(tmp_path, monkeypatch):
     carried = backlog._abandoned_flags([_item(status="active", ref="#1234")], str(repo))
     assert carried == [], f"a ref carried by a branch was flagged: {carried}"
 
+    # A CONTROL PROVING GIT RAN. Both git calls failing returns None, which
+    # `_abandoned_flags` reads as no-flags — so a STARVED negative is
+    # indistinguishable from a real one. Without this, transient git failure
+    # under load fails the orphan assertion with exactly `[]` while the carried
+    # assertion above passes VACUOUSLY, which is how it presented in the field.
+    assert backlog._branch_and_worktree_names(str(repo)) is not None, \
+        "git did not run — the negative below would be vacuous"
+
     orphan = backlog._abandoned_flags([_item(status="active", ref="#9999")], str(repo))
     assert len(orphan) == 1, f"an unreferenced ref did not flag: {orphan}"
     assert "9999" in orphan[0]
+
+
+def test_the_abandoned_heuristic_ignores_shas_and_path_components(tmp_path, monkeypatch):
+    """A ref colliding with the porcelain's NON-NAME text must still flag.
+
+    `git worktree list --porcelain` carries `HEAD <sha>` (once per worktree) and
+    absolute paths beside the branch names. The match is a substring test, so a
+    ref whose digits appear in chance hex or in a parent directory was "found"
+    and the item was NOT flagged — suppressing the only output this heuristic
+    produces, with nothing to show it was suppressed.
+
+    The path is the deterministic half of that exposure, so it is what this
+    builds; the sha half is the same defect through the same line and needs no
+    second fixture.
+
+    RED WHEN the raw porcelain lines are matched again instead of names.
+    """
+    repo = _repo(tmp_path / "9999" / "repo", branch="feat/1-thing")
+    monkeypatch.setattr(backlog, "project_root", lambda: repo)
+    assert "9999" in str(repo), "fixture no longer places the token in the path"
+
+    flags = backlog._abandoned_flags([_item(status="active", ref="#9999")], str(repo))
+    assert len(flags) == 1, (
+        f"a ref matching only a PATH COMPONENT was treated as carried: {flags}"
+    )
 
 
 def test_staleness_flags_at_the_threshold_not_before(monkeypatch):

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -105,8 +105,10 @@ is boring and rebuildable, the questions are not.
              poisoned ref: no exception, SURVIVES — `{5}` is a one-element set
              and `sorted()` never compares. Arm 2 with `5`: 0 names, SURVIVES
              — `git -C 5` fails for the wrong reason. The real fixtures kill:
-             two items raise TypeError, and `"."` returns 221 names from the
-             WRONG repository.
+             two items raise TypeError, and `"."` returns names from the
+             WRONG repository. NO COUNT HERE ON PURPOSE: it was measured
+             against a return shape that has since changed, and a figure in
+             durable prose rots on every change to what it counts.
   settled  THE SHIPPED DEFECT is neither of the obvious mutations. Recover
              it verbatim: `git show 08b4f5b8^` — the ref set is built from
              `items` with NO filter, the loop is unfiltered, and a mid-loop
@@ -3194,17 +3196,29 @@ def test_every_backlog_report_site_is_a_choice_point():
     cannot tell this call site from the step 6 write. Both are asserted below.
 
     The invocation test is per LINE, which is what makes widening to three files
-    safe: next.md's line 57 is an imperative and its 28 and 152 are syntax
-    templates, and one file can carry both natures. The write side can only
-    exclude a whole FILE, and does.
+    safe: next.md's report invocation sits under `## Step 2 — Reconcile and
+    report`, while its other backlog lines invoke `set`, `add` and `repair` —
+    none of them the report verb. One file carries both natures. The write side
+    can only exclude a whole FILE, and does. NAMED BY CONTENT, never by line
+    number: an earlier version of this paragraph cited three, and one of them
+    had already drifted by two commits.
 
-    CEILING, stated rather than discovered later. This pins a COMMAND LINE and
-    its POSITION. It cannot see whether an agent is TOLD to run it: the sentence
-    above the fence is unpinned, so demoting `Run the backlog report
-    unconditionally:` to `If there are flags, run:` or to `For reference:`
-    leaves this arm green while the report stops happening. Measured, twice.
-    Pinning that would mean pinning prose, which this file refuses elsewhere for
-    good reason — so it is a ceiling and not a gap to be quietly closed.
+    THE LEAD-IN IS PINNED TOO, by grammatical FORM rather than by wording. A
+    command line is a command whether or not an agent is told to run it, so
+    demoting `Run the backlog report unconditionally:` to `If there are flags,
+    run:` or to `For reference:` would stop the report without touching the
+    fence. `_HEDGED_OPENERS` catches both. It is not a prose pin: a rewording
+    stays green as long as it still opens with an instruction, verified against
+    `Always run`, `First, run`, `Report the backlog`, and an imperative that
+    merely CONTAINS a condition.
+
+    CEILING, stated rather than discovered later, and it is now narrow. Two
+    edges. `_lead_in` reads only the NEAREST non-blank, non-fence line above the
+    fence, so a hedge placed two lines up is invisible. And `When the session
+    ends, run the report:` REDDENS — judged correct rather than a false
+    positive, because that lead-in does make the invocation conditional on a
+    state, but it is the nearest thing to a false positive this guard has and a
+    future reader meeting that red should know it was deliberate.
 
     The disjointness assertion is vacuously true if wrap-up carries no write
     site at all. Measured: that state reddens BOTH neighbours, so its
@@ -3212,8 +3226,9 @@ def test_every_backlog_report_site_is_a_choice_point():
 
     RED WHEN either file loses its report site, when a file gains or loses one
     outside the census, when a site is prose rather than an invocation, when one
-    line counts as both a read and a write, or when wrap-up's report drifts
-    below the session decision.
+    line counts as both a read and a write, when a report is introduced by a
+    conditional or illustrative lead-in, or when wrap-up's report drifts below
+    the session decision.
     """
     # THE POPULATION, DERIVED FROM THE TREE rather than asserted. A fourth file
     # gaining a report site, or next.md losing its own, is drift either way.
@@ -3343,10 +3358,16 @@ def test_the_verb_classification_covers_every_cli_subcommand():
     Same move that fixed the cardinality control one file over: the population
     comes from outside the artifact under test.
 
+    IT ALSO CARRIES THE READ DETECTOR'S COUPLING, so a rename of the report verb
+    reddens here rather than silently orphaning `_read_sites`, and so the report
+    verb cannot also be classified as a write verb — a union cannot see a verb
+    classified both ways, which is why that one is asserted separately.
+
     RED WHEN the CLI gains or loses a subcommand without this classification
-    being updated. It already found one: `remove` was in the write list and has
-    never been a subcommand — vocabulary taken from the design table rather
-    than from the code.
+    being updated, when the report verb stops being declared by the CLI, or when
+    it is classified as a write verb as well. It already found one: `remove` was
+    in the write list and has never been a subcommand — vocabulary taken from
+    the design table rather than from the code.
     """
     import argparse
 
@@ -3794,8 +3815,10 @@ def test_a_relative_project_path_yields_no_branch_names():
     `git -C 5` fails and the heuristic returns nothing — safe BY ACCIDENT — so
     a `5` fixture passes against the unfixed code. `"."` passes every type
     check and makes git answer about the CURRENT WORKING DIRECTORY's repo:
-    devops measured 221 branch and worktree names belonging to the wrong
-    project, which is the misleading-flags outcome.
+    measured: branch and worktree names belonging to the wrong project, which
+    is the misleading-flags outcome. The count that stood here was taken when
+    the helper returned raw porcelain lines and rotted when that shape changed;
+    the danger is answering about the wrong repository, at any magnitude.
 
     RED WHEN the absolute-string guard is removed. The control is the second
     assertion: an ABSOLUTE path must still return a list, or this arm would

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -451,6 +451,12 @@ def _backlog(project_path, items=None, project="demo", updated="2026-09-01T00:00
     }
 
 
+# Older than `_STALE_AFTER`, for arms about the abandoned-work LINKAGE. That
+# heuristic exempts recently-touched items, and `_item`'s default `touched` is
+# recent, so without this those arms stop reaching the linkage they name.
+_OLD = "2020-01-01"
+
+
 def _item(item_id="a1b2", title="An item", status="planned", rank=1, **fields):
     item = {
         "id": item_id,
@@ -1668,7 +1674,8 @@ def test_the_git_calls_are_anchored_to_the_project(monkeypatch, tmp_path):
         return ""
 
     monkeypatch.setattr(backlog, "_run_capture", fake_capture)
-    backlog._abandoned_flags([_item(status="active", ref="#1")], str(tmp_path))
+    backlog._abandoned_flags(
+        [_item(status="active", ref="#1", touched=_OLD)], str(tmp_path))
 
     assert seen, "no git command was issued at all"
     for command in seen:
@@ -2149,7 +2156,8 @@ def test_the_abandoned_heuristic_reads_real_branches(tmp_path, monkeypatch):
     repo = _repo(tmp_path / "repo", branch="feat/1234-thing")
     monkeypatch.setattr(backlog, "project_root", lambda: repo)
 
-    carried = backlog._abandoned_flags([_item(status="active", ref="#1234")], str(repo))
+    carried = backlog._abandoned_flags(
+        [_item(status="active", ref="#1234", touched=_OLD)], str(repo))
     assert carried == [], f"a ref carried by a branch was flagged: {carried}"
 
     # A CONTROL PROVING GIT RAN. Both git calls failing returns None, which
@@ -2160,9 +2168,39 @@ def test_the_abandoned_heuristic_reads_real_branches(tmp_path, monkeypatch):
     assert backlog._branch_and_worktree_names(str(repo)) is not None, \
         "git did not run — the negative below would be vacuous"
 
-    orphan = backlog._abandoned_flags([_item(status="active", ref="#9999")], str(repo))
+    orphan = backlog._abandoned_flags(
+        [_item(status="active", ref="#9999", touched=_OLD)], str(repo))
     assert len(orphan) == 1, f"an unreferenced ref did not flag: {orphan}"
     assert "9999" in orphan[0]
+
+
+def test_a_recently_touched_item_is_not_abandoned_but_an_old_one_still_is(tmp_path, monkeypatch):
+    """Recency exempts; age does not. BOTH halves, because the first alone is
+    satisfied by a heuristic that simply stopped flagging.
+
+    The linkage only sees a branch carrying the ref's digits, and this project
+    names plenty of branches without them — so live work on such a branch read
+    as abandoned. Recency is the exemption because abandonment means neglect.
+
+    RED WHEN the recency filter is removed (the fresh item flags again), and
+    RED WHEN it is widened to exempt everything (the old item stops flagging).
+    """
+    from datetime import datetime, timedelta, timezone
+
+    repo = _repo(tmp_path / "repo", branch="no-digits-here")
+    monkeypatch.setattr(backlog, "project_root", lambda: repo)
+
+    def flags(days_ago):
+        touched = (datetime.now(timezone.utc) - timedelta(days=days_ago)).date().isoformat()
+        return backlog._abandoned_flags(
+            [_item(status="active", ref="#9999", touched=touched)], str(repo)
+        )
+
+    assert flags(0) == [], "an item touched today was reported abandoned"
+    assert len(flags(365)) == 1, (
+        "an item untouched for a year stopped flagging, so the exemption is "
+        "not discriminating — it switched the heuristic off"
+    )
 
 
 def test_the_abandoned_heuristic_ignores_shas_and_path_components(tmp_path, monkeypatch):
@@ -2184,7 +2222,8 @@ def test_the_abandoned_heuristic_ignores_shas_and_path_components(tmp_path, monk
     monkeypatch.setattr(backlog, "project_root", lambda: repo)
     assert "9999" in str(repo), "fixture no longer places the token in the path"
 
-    flags = backlog._abandoned_flags([_item(status="active", ref="#9999")], str(repo))
+    flags = backlog._abandoned_flags(
+        [_item(status="active", ref="#9999", touched=_OLD)], str(repo))
     assert len(flags) == 1, (
         f"a ref matching only a PATH COMPONENT was treated as carried: {flags}"
     )

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -328,14 +328,17 @@ afternoon.
   the CAS comparison removed          test_a_refused_write_preserves_the_first_writers_data_and_stays_armed
   the baseline popped on refusal      test_a_refused_write_preserves_the_first_writers_data_and_stays_armed
   the query drops `stateReason`       test_the_query_requests_every_field_the_outcome_logic_reads
-  bootstrap loses its read site       test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site
-  wrap-up loses its read site         test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site
-  a report site uses a NON-reporting verb  test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site
-  a fourth file gains a report site   test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site
-  next.md loses its own report site   test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site
-  the wrap-up report moves below the ask   test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site
+  bootstrap loses its read site       test_every_backlog_report_site_is_a_choice_point
+  wrap-up loses its read site         test_every_backlog_report_site_is_a_choice_point
+  a report site uses a NON-reporting verb  test_every_backlog_report_site_is_a_choice_point
+  a fourth file gains a report site   test_every_backlog_report_site_is_a_choice_point
+  next.md loses its own report site   test_every_backlog_report_site_is_a_choice_point
+  the wrap-up report moves below the ask   test_every_backlog_report_site_is_a_choice_point
   the report verb is renamed in the CLI    test_the_verb_classification_covers_every_cli_subcommand
   the report verb becomes a write verb     test_the_verb_classification_covers_every_cli_subcommand
+  the read-only clause drops from step 8   test_every_backlog_report_site_is_a_choice_point
+  the read rule and the tree disagree      test_every_backlog_report_site_is_a_choice_point
+  the read rule is reworded away entirely  test_every_backlog_report_site_is_a_choice_point
   a write site appears in rePACT      test_four_files_stay_at_zero_write_sites
   the write-site detector orphaned    test_four_files_stay_at_zero_write_sites
   the wrap-up write moves below       test_the_wrap_up_write_precedes_the_worktree_removal
@@ -2966,9 +2969,13 @@ def test_four_files_stay_at_zero_write_sites(monkeypatch):
     """Those four zeros are the ARCHITECT's RESULTS, not omissions.
 
     rePACT sits below backlog-item granularity; refresh and pause have
-    "nothing has finished" as their entry condition; peer-review does merge but
-    hands to wrap-up unconditionally, so wrap-up's site already covers that
-    path and a second one would be two things to keep in step.
+    "nothing has finished" as their entry condition; peer-review does merge, and
+    a write site there would not cover the case that motivates one — an
+    out-of-band merge runs no PACT command at all, so it reaches neither
+    peer-review nor wrap-up. next.md classifies that case as unwitnessed by
+    definition and routes it to reconciliation, which is the coverage; a second
+    write site would buy only a narrow window and cost two things to keep in
+    step.
 
     THE POSITIVE HALF RUNS FIRST AND IT IS NOT DECORATION. An absence proves
     nothing about a detector that matches nothing, and `_write_sites` keys on
@@ -2977,10 +2984,12 @@ def test_four_files_stay_at_zero_write_sites(monkeypatch):
     detector finds the sites that DO exist is the only thing that makes the
     zeros mean anything.
 
-    THIS ARM PINS A RULING, NOT AN INDEPENDENT FINDING. Its correctness rests
-    on peer-review reaching wrap-up on every merge path — the architect flagged
-    that as the ruling they most wanted a second read on. If a path merges
-    without reaching wrap-up, this arm is pinning a GAP.
+    THIS ARM PINS A RULING, NOT AN INDEPENDENT FINDING, and the second read it
+    asked for has been done. The answer: it is NOT pinning a gap. The original
+    reason was wrong — a handoff to wrap-up is a subsequent action rather than a
+    guarantee, so "peer-review hands to wrap-up" would not have licensed the
+    zero. The verdict survives on reconciliation coverage instead, as stated
+    above, which holds for every merge path including the ones no command sees.
 
     RED WHEN a write site is added to a file the ruling put at zero.
     """
@@ -3043,26 +3052,43 @@ def _read_sites(name):
     ]
 
 
-_BOOKENDS = ("bootstrap.md", "wrap-up.md")
-# Every command file that invokes the report, bookend or not. next.md's is Step
-# 2 of its own procedure. Stated here so its membership is a DECISION rather
-# than an absence a reader cannot distinguish from an oversight.
+# The two that report UNASKED. Pinned per file because a session gets them
+# whether or not anyone invokes anything.
+_UNASKED_REPORTS = ("bootstrap.md", "wrap-up.md")
+# Every command file that invokes the report. next.md is a member VIA LINE 57 —
+# `## Step 2 — Reconcile and report`, an imperative executed at that point in
+# the flow. Its OTHER backlog lines are a different nature: 28 and 152 are
+# syntax templates, and 216 invokes `repair`. Saying which line earns the
+# membership matters, because a reader grepping next.md finds several and
+# cannot otherwise tell. Stated here so the set is a DECISION rather than an
+# absence indistinguishable from an oversight — the rule it pins is written
+# beside the write rule in next.md.
 _REPORT_CALL_SITES = frozenset({"bootstrap.md", "wrap-up.md", "next.md"})
 # The decision wrap-up's report must precede, quoted as it appears in the file.
 _SESSION_DECISION = "Use `AskUserQuestion` with these exact options:"
+# The clause that makes section 8's missing write-site enumeration safe.
+_READ_ONLY_PROHIBITION = "READ-ONLY in your hands"
 
 
-def test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site():
-    """The two files that report the backlog UNASKED, pinned per file.
+def test_every_backlog_report_site_is_a_choice_point():
+    """Every report site, censused; the two that report UNASKED, pinned per file.
+
+    THE RULE THIS PINS IS WRITTEN IN next.md, beside the write rule, and this
+    arm is the check rather than the statement of it: a report belongs where the
+    user is choosing WHAT TO DO NEXT — not where they are executing an item
+    already chosen, and not where they are judging one artifact. Three files
+    qualify and all three carry a site.
+
+    An earlier version of this docstring was the only place the population
+    existed, and that is why a third member stayed invisible for a whole review:
+    when the enumeration IS the policy, a missed member contradicts nothing.
 
     AUTOMATIC surfacing happens in exactly one place: `session_init` is the only
     hook that reads `backlog_store`, so nothing reports at session END without
-    being asked. That is why these two call sites matter — bootstrap's at the
-    start, wrap-up's before a decision whose continue branch keeps the team
-    alive with no SessionStart in between. It is NOT a claim that they are the
-    only call sites: `next.md` carries a third, run when a user invokes the
-    command. The census below enumerates all three rather than leaving the
-    reader to infer a population from this sentence.
+    being asked. That is why bootstrap's and wrap-up's sites are pinned
+    individually — a session gets those two whether or not anyone invokes
+    anything. It is NOT a claim that they are the only call sites: `next.md`
+    carries a third, run when a user invokes the command.
 
     THE NEIGHBOURING ARM'S POSITIVE HALF DOES NOT TRANSFER, and copying it here
     would be cargo cult. `test_four_files_stay_at_zero_write_sites` asserts an
@@ -3077,6 +3103,11 @@ def test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site():
     Hence `_REPORT_SUBCOMMAND`. The other two guards the inverted direction
     needs are a detector loose enough to match a PROSE MENTION, and one that
     cannot tell this call site from the step 6 write. Both are asserted below.
+
+    The invocation test is per LINE, which is what makes widening to three files
+    safe: next.md's line 57 is an imperative and its 28 and 152 are syntax
+    templates, and one file can carry both natures. The write side can only
+    exclude a whole FILE, and does.
 
     CEILING, stated rather than discovered later. This pins a COMMAND LINE and
     its POSITION. It cannot see whether an agent is TOLD to run it: the sentence
@@ -3097,7 +3128,30 @@ def test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site():
     """
     # THE POPULATION, DERIVED FROM THE TREE rather than asserted. A fourth file
     # gaining a report site, or next.md losing its own, is drift either way.
+    # THE STATED RULE AND THE TREE MUST AGREE, the same seam
+    # test_next_md_names_exactly_the_files_that_carry_write_sites pins for the
+    # write side. Without this the rule in next.md and the census here are two
+    # independent claims that can drift apart, which is the state this arm was
+    # written in and the reason a third member went unnoticed.
+    marker = "**THREE FILES carry a backlog report**"
+    text = _next_md()
+    assert marker in text, (
+        f"the read rule's marker {marker!r} is gone from next.md — the rule was "
+        f"reworded or removed and this arm is reading nothing"
+    )
+    sentence = text.split(marker, 1)[1].split("\n\n", 1)[0]
+    stated = {name for name in _REPORT_CALL_SITES | {"orchestrate.md", "comPACT.md",
+                                                     "imPACT.md", "rePACT.md",
+                                                     "refresh.md", "pause.md",
+                                                     "peer-review.md"}
+              if f"`{name}`" in sentence}
+
     carrying = {p.name for p in _COMMANDS_DIR.glob("*.md") if _read_sites(p.name)}
+    assert stated == carrying, (
+        f"next.md's read rule names {sorted(stated)} but the files carrying a "
+        f"report site are {sorted(carrying)}. An agent reading that rule would "
+        f"be told the wrong file set."
+    )
     assert carrying == set(_REPORT_CALL_SITES), (
         f"the files invoking `backlog.py {_REPORT_SUBCOMMAND}` are "
         f"{sorted(carrying)}, not {sorted(_REPORT_CALL_SITES)}. Gained: "
@@ -3106,7 +3160,7 @@ def test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site():
         f"(stopped reporting, or was reworded past the detector)."
     )
 
-    sites = {name: _read_sites(name) for name in _BOOKENDS}
+    sites = {name: _read_sites(name) for name in _UNASKED_REPORTS}
     missing = [name for name, found in sites.items() if not found]
     assert not missing, (
         f"{missing} carry no backlog read site. Either the report was removed, "
@@ -3117,9 +3171,16 @@ def test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site():
     # An INVOCATION, not a mention. Prose naming the command reads identically
     # to the detector and would satisfy the presence assertion above while no
     # agent ever runs anything.
+    # A BLOCKQUOTED COMMAND IS STILL A COMMAND. `_write_sites` already matches
+    # the blockquoted write at wrap-up.md:191, so requiring a bare `python3 `
+    # here made the two detectors disagree about the same file: moving this
+    # read into a blockquote to match section 6's style would have reddened
+    # this arm with a message about prose that does not exist. Stripping the
+    # marker costs nothing — `Run `python3 ...`` and `> Run `python3 ...``
+    # both still fail, which is the property being guarded.
     for name, found in sites.items():
         for number, line in found:
-            assert line.startswith("python3 "), (
+            assert line.lstrip("> ").startswith("python3 "), (
                 f"{name}:{number} matches the detector but is not an "
                 f"invocation, so this arm would pass on prose alone: {line!r}"
             )
@@ -3149,6 +3210,20 @@ def test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site():
         f"wrap-up's backlog report is at line {last_report}, BELOW the session "
         f"decision at line {decisions[0]}. The user chooses before the report "
         f"they were meant to read it against ever renders."
+    )
+
+    # WHAT LICENSES THE ABSENCE OF A WRITE-SITE ENUMERATION AT THIS CALL SITE.
+    # Section 8 does not list which writes are forbidden; it does not need to,
+    # because an agent believing the framing sentence does not write, and one
+    # disbelieving it is stopped by this prohibition. Both roads end in the same
+    # action ONLY while this sentence exists. Dropping it for brevity re-arms
+    # the defect silently, so its presence is pinned here. A short distinctive
+    # phrase, not the sentence: a rewording should not redden, a deletion must.
+    assert _READ_ONLY_PROHIBITION in "\n".join(lines), (
+        f"wrap-up.md no longer carries {_READ_ONLY_PROHIBITION!r}. That clause "
+        f"is what makes the missing write-site enumeration at this call site "
+        f"safe; without it an agent that doubts the framing has nothing "
+        f"stopping it correcting a flag in place."
     )
 
 

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -3284,6 +3284,12 @@ def test_every_backlog_report_site_is_a_choice_point():
     # this arm with a message about prose that does not exist. Stripping the
     # marker costs nothing — `Run `python3 ...`` and `> Run `python3 ...``
     # both still fail, which is the property being guarded.
+    #
+    # IF YOU ARE HERE BECAUSE THIS FIRED ON PROSE YOU JUST WROTE: the detector
+    # matches any line carrying `backlog.py` AND the report verb, so a SENTENCE
+    # naming both trips it. That is the rule, not a bug — the arm cannot tell a
+    # sentence about the command from the command. Reword so the prose does not
+    # name `backlog.py`, which is what the surrounding paragraphs already do.
     for name, found in sites.items():
         for number, line in found:
             assert line.lstrip("> ").startswith("python3 "), (

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -3180,9 +3180,6 @@ def _read_sites(name):
     ]
 
 
-# The two that report UNASKED. Pinned per file because a session gets them
-# whether or not anyone invokes anything.
-_UNASKED_REPORTS = ("bootstrap.md", "wrap-up.md")
 # Every command file that invokes the report. next.md earns its membership with
 # the invocation under `## Step 2 — Reconcile and report`, and NOT with its
 # other backlog lines, which invoke `set`, `add` and `repair` — none of them the
@@ -3305,14 +3302,7 @@ def test_every_backlog_report_site_is_a_choice_point():
         f"(stopped reporting, or was reworded past the detector)."
     )
 
-    sites = {name: _read_sites(name) for name in _UNASKED_REPORTS}
-    missing = [name for name, found in sites.items() if not found]
-    assert not missing, (
-        f"{missing} carry no backlog read site. Either the report was removed, "
-        f"or it was reworded past a detector keyed on `backlog.py` plus "
-        f"{_REPORT_SUBCOMMAND!r}."
-    )
-
+    sites = {name: _read_sites(name) for name in sorted(_REPORT_CALL_SITES)}
     # An INVOCATION, not a mention. Prose naming the command reads identically
     # to the detector and would satisfy the presence assertion above while no
     # agent ever runs anything.

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -2940,6 +2940,9 @@ _COMMANDS_DIR = HOOKS_DIR.parent / "commands"
 # the CLI GROWING one this list has never heard of is detectable, and that is
 # the moment the blind spot is created.
 _WRITE_VERBS = ("set ", "add ")
+# Spelled counts, for the rules that lead with one. Shared by the read rule and
+# the write rule so the two cannot disagree about what FOUR means.
+_COUNT_WORDS = {1: "ONE", 2: "TWO", 3: "THREE", 4: "FOUR", 5: "FIVE", 6: "SIX"}
 # Subcommands that are not item writes: `show` reads, `repair` moves a corrupt
 # FILE aside and touches no item. Neither can appear at a work boundary.
 _NON_WRITE_SUBCOMMANDS = frozenset({"show", "repair"})
@@ -3055,14 +3058,16 @@ def _read_sites(name):
 # The two that report UNASKED. Pinned per file because a session gets them
 # whether or not anyone invokes anything.
 _UNASKED_REPORTS = ("bootstrap.md", "wrap-up.md")
-# Every command file that invokes the report. next.md is a member VIA LINE 57 —
-# `## Step 2 — Reconcile and report`, an imperative executed at that point in
-# the flow. Its OTHER backlog lines are a different nature: 28 and 152 are
-# syntax templates, and 216 invokes `repair`. Saying which line earns the
-# membership matters, because a reader grepping next.md finds several and
-# cannot otherwise tell. Stated here so the set is a DECISION rather than an
-# absence indistinguishable from an oversight — the rule it pins is written
-# beside the write rule in next.md.
+# Every command file that invokes the report. next.md earns its membership with
+# the invocation under `## Step 2 — Reconcile and report`, and NOT with its
+# other backlog lines, which invoke `set`, `add` and `repair` — none of them the
+# report verb. Which line matters, because a reader grepping next.md finds
+# several invocations and cannot otherwise tell. NAMED BY CONTENT, never by line
+# number: an earlier version of this comment cited three numbers and one of them
+# went stale inside the same commit that inserted lines above it.
+# Stated here so the set is a DECISION rather than an absence indistinguishable
+# from an oversight — the rule it pins is written beside the write rule in
+# next.md.
 _REPORT_CALL_SITES = frozenset({"bootstrap.md", "wrap-up.md", "next.md"})
 # The decision wrap-up's report must precede, quoted as it appears in the file.
 _SESSION_DECISION = "Use `AskUserQuestion` with these exact options:"
@@ -3140,13 +3145,19 @@ def test_every_backlog_report_site_is_a_choice_point():
         f"reworded or removed and this arm is reading nothing"
     )
     sentence = text.split(marker, 1)[1].split("\n\n", 1)[0]
-    stated = {name for name in _REPORT_CALL_SITES | {"orchestrate.md", "comPACT.md",
-                                                     "imPACT.md", "rePACT.md",
-                                                     "refresh.md", "pause.md",
-                                                     "peer-review.md"}
-              if f"`{name}`" in sentence}
-
+    # BOTH SIDES COME FROM THE SAME GLOB. Building this from a hardcoded name
+    # list made a new command file invisible to it: named in the sentence,
+    # absent from the literal, and the comparison passed while the rule was
+    # wrong.
+    stated = {p.name for p in _COMMANDS_DIR.glob("*.md") if f"`{p.name}`" in sentence}
     carrying = {p.name for p in _COMMANDS_DIR.glob("*.md") if _read_sites(p.name)}
+
+    # THE WORD AND THE LIST MUST AGREE — the set comparison below cannot see a
+    # fourth name added to the sentence while the word stays THREE.
+    assert _COUNT_WORDS.get(len(stated)) in marker, (
+        f"the read rule says {marker!r} but names {len(stated)} files: "
+        f"{sorted(stated)}"
+    )
     assert stated == carrying, (
         f"next.md's read rule names {sorted(stated)} but the files carrying a "
         f"report site are {sorted(carrying)}. An agent reading that rule would "
@@ -3326,8 +3337,7 @@ def test_next_md_names_exactly_the_files_that_carry_write_sites():
     # The word and the list must agree. A fifth file added to the sentence
     # while the word stays FOUR is the count-drifts-from-its-list defect, and
     # the set comparison below cannot see it.
-    words = {1: "ONE", 2: "TWO", 3: "THREE", 4: "FOUR", 5: "FIVE", 6: "SIX"}
-    assert words.get(len(claimed)) in marker, (
+    assert _COUNT_WORDS.get(len(claimed)) in marker, (
         f"the sentence says {marker!r} but names {len(claimed)} files: "
         f"{sorted(claimed)}"
     )

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -4299,6 +4299,15 @@ def test_a_usage_error_and_a_refusal_exit_DIFFERENTLY(tmp_path):
     healthy, project = _cli_store(tmp_path / "healthy", [_item()])
     empty, _ = _cli_store(tmp_path / "empty", [])
     _repo(project)  # a real checkout, so `set` reaches the item lookup
+    # THE SUBPROCESS RESOLVES THE STORE NAME FROM ITS OWN CWD, not from this
+    # process, so the fixture must also exist under the name that cwd yields.
+    # Without it the CLI opens NO FILE and `set` still refuses: `load_or_create`
+    # builds an empty document in memory when the file is absent, and the lookup
+    # misses identically. The refusal row would then pass while never reaching
+    # the item lookup it is named for. The `accepted: real item` row below is
+    # what proves the file is actually read.
+    (healthy / f"{project.name}.json").write_bytes(
+        (healthy / f"{backlog.store_path().stem}.json").read_bytes())
 
     def code(store, *args, cwd):
         return subprocess.run(
@@ -4312,6 +4321,7 @@ def test_a_usage_error_and_a_refusal_exit_DIFFERENTLY(tmp_path):
         "malformed flag":      code(healthy, "--nope", cwd=project),
         "unknown subcommand":  code(empty, "bogus", cwd=project),
         "subparser operand":   code(empty, "set", cwd=outside),
+        "accepted: real item": code(healthy, "set", "a1b2", "--status", "done", cwd=project),
         "refusal: no item":    code(healthy, "set", "ffff", "--status", "done", cwd=project),
         "refusal: no root":    code(healthy, "show", cwd=outside),
         "help":                code(healthy, "--help", cwd=project),
@@ -4320,6 +4330,7 @@ def test_a_usage_error_and_a_refusal_exit_DIFFERENTLY(tmp_path):
         "malformed flag":     backlog._EXIT_USAGE,
         "unknown subcommand": backlog._EXIT_USAGE,
         "subparser operand":  backlog._EXIT_USAGE,
+        "accepted: real item": backlog._EXIT_OK,
         "refusal: no item":   backlog._EXIT_REFUSED,
         "refusal: no root":   backlog._EXIT_REFUSED,
         "help":               backlog._EXIT_OK,

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -3325,11 +3325,12 @@ def test_next_md_names_exactly_the_files_that_carry_write_sites():
         f"reworded and this arm is reading nothing"
     )
     sentence = text.split(marker, 1)[1].split("\n\n", 1)[0]
-    claimed = {name for name in
-               ("orchestrate.md", "comPACT.md", "imPACT.md", "wrap-up.md",
-                "rePACT.md", "refresh.md", "pause.md", "peer-review.md",
-                "bootstrap.md", "next.md")
-               if f"`{name}`" in sentence}
+    # BOTH SIDES COME FROM THE SAME GLOB, as on the read rule. A hardcoded
+    # candidate list makes a file named in the sentence but absent from the
+    # literal invisible, so the comparison passes while the rule is wrong.
+    # Measured: with the literal, a new command file named here and carrying no
+    # write site was not noticed.
+    claimed = {p.name for p in _COMMANDS_DIR.glob("*.md") if f"`{p.name}`" in sentence}
     assert claimed, (
         "the trigger sentence names no command file — it was restructured and "
         "this arm is now reading nothing"

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -330,6 +330,12 @@ afternoon.
   the query drops `stateReason`       test_the_query_requests_every_field_the_outcome_logic_reads
   bootstrap loses its read site       test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site
   wrap-up loses its read site         test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site
+  a report site uses a NON-reporting verb  test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site
+  a fourth file gains a report site   test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site
+  next.md loses its own report site   test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site
+  the wrap-up report moves below the ask   test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site
+  the report verb is renamed in the CLI    test_the_verb_classification_covers_every_cli_subcommand
+  the report verb becomes a write verb     test_the_verb_classification_covers_every_cli_subcommand
   a write site appears in rePACT      test_four_files_stay_at_zero_write_sites
   the write-site detector orphaned    test_four_files_stay_at_zero_write_sites
   the wrap-up write moves below       test_the_wrap_up_write_precedes_the_worktree_removal
@@ -2934,6 +2940,16 @@ _WRITE_VERBS = ("set ", "add ")
 # Subcommands that are not item writes: `show` reads, `repair` moves a corrupt
 # FILE aside and touches no item. Neither can appear at a work boundary.
 _NON_WRITE_SUBCOMMANDS = frozenset({"show", "repair"})
+# The ONE subcommand that REPORTS the backlog, and it is deliberately NOT the
+# frozenset above. That set answers "is this a write?"; a read site asks "does
+# this REPORT?", and only `show` answers it — `repair` is a non-write that
+# reports nothing. Keying a read detector on the non-write set widens it every
+# time a future non-write subcommand is classified, with nothing going red at
+# the moment the guarantee weakens. Measured: with the set as the population, a
+# file whose only call was `repair` satisfied the read-site arm below. The
+# coupling to the CLI is kept explicitly instead, in
+# test_the_verb_classification_covers_every_cli_subcommand.
+_REPORT_SUBCOMMAND = "show"
 
 
 def _write_sites(name):
@@ -3018,40 +3034,84 @@ def test_the_wrap_up_write_precedes_the_worktree_removal(monkeypatch):
 
 
 def _read_sites(name):
-    """Lines in one command file that invoke the backlog with a READ verb."""
+    """Lines in one command file that invoke the backlog's REPORT verb."""
     text = (_COMMANDS_DIR / name).read_text(encoding="utf-8")
     return [
         (number, line.strip())
         for number, line in enumerate(text.splitlines(), 1)
-        if "backlog.py" in line and any(f" {v}" in line for v in _NON_WRITE_SUBCOMMANDS)
+        if "backlog.py" in line and f" {_REPORT_SUBCOMMAND}" in line
     ]
 
 
-def test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site():
-    """The two files that REPORT the backlog, pinned per file.
+_BOOKENDS = ("bootstrap.md", "wrap-up.md")
+# Every command file that invokes the report, bookend or not. next.md's is Step
+# 2 of its own procedure. Stated here so its membership is a DECISION rather
+# than an absence a reader cannot distinguish from an oversight.
+_REPORT_CALL_SITES = frozenset({"bootstrap.md", "wrap-up.md", "next.md"})
+# The decision wrap-up's report must precede, quoted as it appears in the file.
+_SESSION_DECISION = "Use `AskUserQuestion` with these exact options:"
 
-    The whole plugin surfaces the backlog at SessionStart and nowhere else, so
-    these two call sites are the only bookends a session gets: bootstrap's at
-    the start, wrap-up's before a decision whose continue branch keeps the team
-    alive with no SessionStart in between.
+
+def test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site():
+    """The two files that report the backlog UNASKED, pinned per file.
+
+    AUTOMATIC surfacing happens in exactly one place: `session_init` is the only
+    hook that reads `backlog_store`, so nothing reports at session END without
+    being asked. That is why these two call sites matter — bootstrap's at the
+    start, wrap-up's before a decision whose continue branch keeps the team
+    alive with no SessionStart in between. It is NOT a claim that they are the
+    only call sites: `next.md` carries a third, run when a user invokes the
+    command. The census below enumerates all three rather than leaving the
+    reader to infer a population from this sentence.
 
     THE NEIGHBOURING ARM'S POSITIVE HALF DOES NOT TRANSFER, and copying it here
     would be cargo cult. `test_four_files_stay_at_zero_write_sites` asserts an
     ABSENCE, which an orphaned detector satisfies forever — hence its positive
     half. This asserts a PRESENCE, so the same orphaning reddens it directly.
-    The failure direction is inverted and the guard it needs is the opposite
-    one: a detector loose enough to match a PROSE MENTION, or one that cannot
-    tell this call site from the step 6 write, would pass while pinning
-    nothing. Both are asserted below.
 
-    RED WHEN either file loses its read site.
+    BUT ORPHANING IS NOT THE ONLY ROUTE TO VACUITY, and assuming it was is what
+    let a survivor through review. A detector can be fully live, match a real
+    invocation, and certify nothing, when the POPULATION it matches contains a
+    member that does not do the thing: keyed on `_NON_WRITE_SUBCOMMANDS`, a file
+    whose only call was `repair` satisfied this arm while reporting nothing.
+    Hence `_REPORT_SUBCOMMAND`. The other two guards the inverted direction
+    needs are a detector loose enough to match a PROSE MENTION, and one that
+    cannot tell this call site from the step 6 write. Both are asserted below.
+
+    CEILING, stated rather than discovered later. This pins a COMMAND LINE and
+    its POSITION. It cannot see whether an agent is TOLD to run it: the sentence
+    above the fence is unpinned, so demoting `Run the backlog report
+    unconditionally:` to `If there are flags, run:` or to `For reference:`
+    leaves this arm green while the report stops happening. Measured, twice.
+    Pinning that would mean pinning prose, which this file refuses elsewhere for
+    good reason — so it is a ceiling and not a gap to be quietly closed.
+
+    The disjointness assertion is vacuously true if wrap-up carries no write
+    site at all. Measured: that state reddens BOTH neighbours, so its
+    non-vacuity is guaranteed there rather than here.
+
+    RED WHEN either file loses its report site, when a file gains or loses one
+    outside the census, when a site is prose rather than an invocation, when one
+    line counts as both a read and a write, or when wrap-up's report drifts
+    below the session decision.
     """
-    sites = {name: _read_sites(name) for name in ("bootstrap.md", "wrap-up.md")}
+    # THE POPULATION, DERIVED FROM THE TREE rather than asserted. A fourth file
+    # gaining a report site, or next.md losing its own, is drift either way.
+    carrying = {p.name for p in _COMMANDS_DIR.glob("*.md") if _read_sites(p.name)}
+    assert carrying == set(_REPORT_CALL_SITES), (
+        f"the files invoking `backlog.py {_REPORT_SUBCOMMAND}` are "
+        f"{sorted(carrying)}, not {sorted(_REPORT_CALL_SITES)}. Gained: "
+        f"{sorted(carrying - _REPORT_CALL_SITES)} (report the backlog and is "
+        f"pinned nowhere). Lost: {sorted(_REPORT_CALL_SITES - carrying)} "
+        f"(stopped reporting, or was reworded past the detector)."
+    )
+
+    sites = {name: _read_sites(name) for name in _BOOKENDS}
     missing = [name for name, found in sites.items() if not found]
     assert not missing, (
         f"{missing} carry no backlog read site. Either the report was removed, "
-        f"or it was reworded past a detector keyed on `backlog.py` plus a verb "
-        f"in {sorted(_NON_WRITE_SUBCOMMANDS)}."
+        f"or it was reworded past a detector keyed on `backlog.py` plus "
+        f"{_REPORT_SUBCOMMAND!r}."
     )
 
     # An INVOCATION, not a mention. Prose naming the command reads identically
@@ -3071,6 +3131,24 @@ def test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site():
     assert not overlap, (
         f"wrap-up.md line(s) {sorted(overlap)} count as BOTH a read and a "
         f"write site, so this arm cannot say which one it found"
+    )
+
+    # POSITION, not presence — the same property `test_the_wrap_up_write_
+    # precedes_the_worktree_removal` pins for the write, and for the same
+    # reason: a report appended below the decision is present and useless,
+    # because the choice it exists to inform has already been made.
+    lines = (_COMMANDS_DIR / "wrap-up.md").read_text(encoding="utf-8").splitlines()
+    decisions = [n for n, line in enumerate(lines, 1) if _SESSION_DECISION in line]
+    assert len(decisions) == 1, (
+        f"expected exactly one session decision matching {_SESSION_DECISION!r}, "
+        f"found {decisions} — the ordering assertion below cannot be read "
+        f"against several"
+    )
+    last_report = max(n for n, _ in sites["wrap-up.md"])
+    assert last_report < decisions[0], (
+        f"wrap-up's backlog report is at line {last_report}, BELOW the session "
+        f"decision at line {decisions[0]}. The user chooses before the report "
+        f"they were meant to read it against ever renders."
     )
 
 
@@ -3102,6 +3180,22 @@ def test_the_verb_classification_covers_every_cli_subcommand():
     assert len(actions) == 1, f"expected one subparser group, found {len(actions)}"
     declared = set(actions[0].choices)
     assert declared, "the parser declares no subcommands — this arm is vacuous"
+
+    # THE READ DETECTOR'S COUPLING TO THE PARSER LIVES HERE, so that renaming
+    # `show` reddens rather than silently orphaning `_read_sites`.
+    assert _REPORT_SUBCOMMAND in declared, (
+        f"the reporting subcommand {_REPORT_SUBCOMMAND!r} is no longer declared "
+        f"by the CLI, so `_read_sites` matches nothing and every report-site "
+        f"assertion is vacuous. Declared: {sorted(declared)}."
+    )
+    # THE MIRROR, and nothing else catches it AT THE CLASSIFICATION. Measured:
+    # making the report verb a write verb too reddens three downstream arms with
+    # messages about overlapping sites, and leaves THIS arm green, because a
+    # union cannot see a verb classified both ways.
+    assert _REPORT_SUBCOMMAND not in {verb.strip() for verb in _WRITE_VERBS}, (
+        f"{_REPORT_SUBCOMMAND!r} is classified as BOTH the report verb and a "
+        f"write verb, so every report site also counts as a boundary write"
+    )
 
     classified = {verb.strip() for verb in _WRITE_VERBS} | set(_NON_WRITE_SUBCOMMANDS)
     assert classified == declared, (

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -3776,6 +3776,13 @@ def _cli_store(tmp_path, items, **top):
     payload = _backlog(project, items=items)
     payload.update(top)
     _write(store, f"{backlog.store_path().stem}.json", payload)
+    # AND under the name a subprocess run with `cwd=project` resolves. The id
+    # comes from the CWD OF THE PROCESS THAT RESOLVES IT, so a caller passing
+    # `cwd=` otherwise gets a store the CLI never opens — and `load_or_create`
+    # synthesises an empty document, so a lookup refuses identically and the
+    # arm passes without ever reading the fixture. Written here rather than at
+    # the one caller that needed it: every caller routes through this.
+    _write(store, f"{project.name}.json", payload)
     return store, project
 
 
@@ -4322,15 +4329,6 @@ def test_a_usage_error_and_a_refusal_exit_DIFFERENTLY(tmp_path):
     healthy, project = _cli_store(tmp_path / "healthy", [_item()])
     empty, _ = _cli_store(tmp_path / "empty", [])
     _repo(project)  # a real checkout, so `set` reaches the item lookup
-    # THE SUBPROCESS RESOLVES THE STORE NAME FROM ITS OWN CWD, not from this
-    # process, so the fixture must also exist under the name that cwd yields.
-    # Without it the CLI opens NO FILE and `set` still refuses: `load_or_create`
-    # builds an empty document in memory when the file is absent, and the lookup
-    # misses identically. The refusal row would then pass while never reaching
-    # the item lookup it is named for. The `accepted: real item` row below is
-    # what proves the file is actually read.
-    (healthy / f"{project.name}.json").write_bytes(
-        (healthy / f"{backlog.store_path().stem}.json").read_bytes())
 
     def code(store, *args, cwd):
         return subprocess.run(

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -328,6 +328,8 @@ afternoon.
   the CAS comparison removed          test_a_refused_write_preserves_the_first_writers_data_and_stays_armed
   the baseline popped on refusal      test_a_refused_write_preserves_the_first_writers_data_and_stays_armed
   the query drops `stateReason`       test_the_query_requests_every_field_the_outcome_logic_reads
+  bootstrap loses its read site       test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site
+  wrap-up loses its read site         test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site
   a write site appears in rePACT      test_four_files_stay_at_zero_write_sites
   the write-site detector orphaned    test_four_files_stay_at_zero_write_sites
   the wrap-up write moves below       test_the_wrap_up_write_precedes_the_worktree_removal
@@ -3012,6 +3014,63 @@ def test_the_wrap_up_write_precedes_the_worktree_removal(monkeypatch):
         f"the backlog write is at line {writes[0]}, BELOW the worktree removal "
         f"at line {removals[0]}. Every item written there is reported abandoned "
         f"from the next session onward."
+    )
+
+
+def _read_sites(name):
+    """Lines in one command file that invoke the backlog with a READ verb."""
+    text = (_COMMANDS_DIR / name).read_text(encoding="utf-8")
+    return [
+        (number, line.strip())
+        for number, line in enumerate(text.splitlines(), 1)
+        if "backlog.py" in line and any(f" {v}" in line for v in _NON_WRITE_SUBCOMMANDS)
+    ]
+
+
+def test_bootstrap_and_wrap_up_each_carry_a_backlog_read_site():
+    """The two files that REPORT the backlog, pinned per file.
+
+    The whole plugin surfaces the backlog at SessionStart and nowhere else, so
+    these two call sites are the only bookends a session gets: bootstrap's at
+    the start, wrap-up's before a decision whose continue branch keeps the team
+    alive with no SessionStart in between.
+
+    THE NEIGHBOURING ARM'S POSITIVE HALF DOES NOT TRANSFER, and copying it here
+    would be cargo cult. `test_four_files_stay_at_zero_write_sites` asserts an
+    ABSENCE, which an orphaned detector satisfies forever — hence its positive
+    half. This asserts a PRESENCE, so the same orphaning reddens it directly.
+    The failure direction is inverted and the guard it needs is the opposite
+    one: a detector loose enough to match a PROSE MENTION, or one that cannot
+    tell this call site from the step 6 write, would pass while pinning
+    nothing. Both are asserted below.
+
+    RED WHEN either file loses its read site.
+    """
+    sites = {name: _read_sites(name) for name in ("bootstrap.md", "wrap-up.md")}
+    missing = [name for name, found in sites.items() if not found]
+    assert not missing, (
+        f"{missing} carry no backlog read site. Either the report was removed, "
+        f"or it was reworded past a detector keyed on `backlog.py` plus a verb "
+        f"in {sorted(_NON_WRITE_SUBCOMMANDS)}."
+    )
+
+    # An INVOCATION, not a mention. Prose naming the command reads identically
+    # to the detector and would satisfy the presence assertion above while no
+    # agent ever runs anything.
+    for name, found in sites.items():
+        for number, line in found:
+            assert line.startswith("python3 "), (
+                f"{name}:{number} matches the detector but is not an "
+                f"invocation, so this arm would pass on prose alone: {line!r}"
+            )
+
+    # DISJOINT from the write sites. A detector that also matched the step 6
+    # write would report wrap-up as covered on the strength of the very line
+    # the architect's ruling is about.
+    overlap = {n for n, _ in sites["wrap-up.md"]} & {n for n, _ in _write_sites("wrap-up.md")}
+    assert not overlap, (
+        f"wrap-up.md line(s) {sorted(overlap)} count as BOTH a read and a "
+        f"write site, so this arm cannot say which one it found"
     )
 
 

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -4363,6 +4363,19 @@ def test_a_usage_error_and_a_refusal_exit_DIFFERENTLY(tmp_path):
         "help":               backlog._EXIT_OK,
     }, f"exit codes moved: {observed}"
 
+    # THE TWO REFUSALS MUST REFUSE FOR DIFFERENT REASONS. `accepted: real item`
+    # proves the subprocess reads the fixture, but only under `cwd=project`; it
+    # says nothing about the `cwd=outside` row, and exit 2 is reachable from
+    # several conditions. Without this a change routing both refusals through
+    # one cause leaves every code above unchanged. Fragments, not whole
+    # sentences, so a reworded message survives.
+    def stderr(store, *args, cwd):
+        return subprocess.run(
+            [sys.executable, script, "--backlog-dir", str(store), *args],
+            capture_output=True, text=True, cwd=str(cwd)).stderr
+    assert "no item with id" in stderr(healthy, "set", "ffff", "--status", "done", cwd=project)
+    assert "did not resolve" in stderr(healthy, "show", cwd=outside)
+
     # THE SEPARATION ITSELF, stated rather than implied by the table above: a
     # later change routing everything through one code would still satisfy a
     # row-by-row reading of a weaker arm.

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -336,6 +336,10 @@ afternoon.
   the wrap-up report moves below the ask   test_every_backlog_report_site_is_a_choice_point
   the report verb is renamed in the CLI    test_the_verb_classification_covers_every_cli_subcommand
   the report verb becomes a write verb     test_the_verb_classification_covers_every_cli_subcommand
+  a rule sentence names a ghost file        test_every_backlog_report_site_is_a_choice_point
+  a report site gains a hedged lead-in      test_every_backlog_report_site_is_a_choice_point
+  the write rule names a ghost file         test_next_md_names_exactly_the_files_that_carry_write_sites
+  usage errors collide with refusals again  test_a_usage_error_and_a_refusal_exit_DIFFERENTLY
   the read-only clause drops from step 8   test_every_backlog_report_site_is_a_choice_point
   the read rule and the tree disagree      test_every_backlog_report_site_is_a_choice_point
   the read rule is reworded away entirely  test_every_backlog_report_site_is_a_choice_point
@@ -2943,6 +2947,24 @@ _WRITE_VERBS = ("set ", "add ")
 # Spelled counts, for the rules that lead with one. Shared by the read rule and
 # the write rule so the two cannot disagree about what FOUR means.
 _COUNT_WORDS = {1: "ONE", 2: "TWO", 3: "THREE", 4: "FOUR", 5: "FIVE", 6: "SIX"}
+# A command file named in a rule sentence. Scoped to a `*.md` token so an
+# ordinary backticked word cannot match; measured, both sentences name nothing
+# else. Deriving from the SENTENCE rather than from the directory is what makes
+# a name with no file behind it visible — a glob simply never yields one, so
+# the sentence could list a ghost while the count stayed green.
+_NAMED_FILE = re.compile(r"`([A-Za-z0-9_-]+\.md)`")
+
+
+def _files_named_in(sentence):
+    """Command files a rule sentence names. Every one must exist."""
+    names = set(_NAMED_FILE.findall(sentence))
+    missing = sorted(name for name in names if not (_COMMANDS_DIR / name).exists())
+    assert not missing, (
+        f"the rule names {missing}, which do not exist in {_COMMANDS_DIR.name}/. "
+        f"An agent is told to look at a file that is not there, and every count "
+        f"below it is off by the number of ghosts."
+    )
+    return names
 # Subcommands that are not item writes: `show` reads, `repair` moves a corrupt
 # FILE aside and touches no item. Neither can appear at a work boundary.
 _NON_WRITE_SUBCOMMANDS = frozenset({"show", "repair"})
@@ -2955,6 +2977,13 @@ _NON_WRITE_SUBCOMMANDS = frozenset({"show", "repair"})
 # file whose only call was `repair` satisfied the read-site arm below. The
 # coupling to the CLI is kept explicitly instead, in
 # test_the_verb_classification_covers_every_cli_subcommand.
+#
+# The runtime half of this property is PROSE: bootstrap.md step 5 and
+# wrap-up.md section 8 each tell the agent not to run `repair` at a report call
+# site. This constant is the suite-side half. Deliberately NOT pinned to that
+# wording — the sentence has no checkable property beyond its own presence, so
+# pinning it buys a brittle red on any reword and catches nothing. If you change
+# what this enforces, read those two sections.
 _REPORT_SUBCOMMAND = "show"
 
 
@@ -3043,6 +3072,28 @@ def test_the_wrap_up_write_precedes_the_worktree_removal(monkeypatch):
         f"at line {removals[0]}. Every item written there is reported abandoned "
         f"from the next session onward."
     )
+
+
+# Sentence-initial words that make the fence below them an ILLUSTRATION or a
+# CONDITIONAL rather than a step. Measured against both survivors and six
+# rewordings: it catches `If the session-start block reported drift flags, run:`
+# and `For reference, the backlog report is produced by:` while passing
+# `Always run`, `First, run`, `Report the backlog`, and an imperative that
+# merely CONTAINS a condition (`Run the report. If there are no flags, ...`).
+# It is a check on the lead-in's GRAMMATICAL FORM, not on its wording — a
+# reword stays green as long as it still opens with an instruction.
+_HEDGED_OPENERS = ("If ", "When ", "Unless ", "Optionally", "For reference",
+                   "Example", "Note:")
+
+
+def _lead_in(name, number):
+    """The nearest non-blank, non-fence line above an invocation."""
+    lines = (_COMMANDS_DIR / name).read_text(encoding="utf-8").splitlines()
+    for line in reversed(lines[:number - 1]):
+        stripped = line.strip().lstrip("> ")
+        if stripped and not stripped.startswith("```"):
+            return stripped
+    return ""
 
 
 def _read_sites(name):
@@ -3145,11 +3196,7 @@ def test_every_backlog_report_site_is_a_choice_point():
         f"reworded or removed and this arm is reading nothing"
     )
     sentence = text.split(marker, 1)[1].split("\n\n", 1)[0]
-    # BOTH SIDES COME FROM THE SAME GLOB. Building this from a hardcoded name
-    # list made a new command file invisible to it: named in the sentence,
-    # absent from the literal, and the comparison passed while the rule was
-    # wrong.
-    stated = {p.name for p in _COMMANDS_DIR.glob("*.md") if f"`{p.name}`" in sentence}
+    stated = _files_named_in(sentence)
     carrying = {p.name for p in _COMMANDS_DIR.glob("*.md") if _read_sites(p.name)}
 
     # THE WORD AND THE LIST MUST AGREE — the set comparison below cannot see a
@@ -3194,6 +3241,17 @@ def test_every_backlog_report_site_is_a_choice_point():
             assert line.lstrip("> ").startswith("python3 "), (
                 f"{name}:{number} matches the detector but is not an "
                 f"invocation, so this arm would pass on prose alone: {line!r}"
+            )
+            # AN INSTRUCTION, NOT AN ILLUSTRATION. The line is a command either
+            # way; what decides whether an agent RUNS it is the sentence above
+            # the fence. Demoting that sentence to a condition or to a reference
+            # stops the report without touching the command, which is how both
+            # survivors got past an earlier version of this arm.
+            lead = _lead_in(name, number)
+            assert not lead.startswith(_HEDGED_OPENERS), (
+                f"{name}:{number} is introduced by {lead!r}, which makes the "
+                f"report conditional or illustrative. The command is unchanged "
+                f"and the report stops happening."
             )
 
     # DISJOINT from the write sites. A detector that also matched the step 6
@@ -3325,12 +3383,7 @@ def test_next_md_names_exactly_the_files_that_carry_write_sites():
         f"reworded and this arm is reading nothing"
     )
     sentence = text.split(marker, 1)[1].split("\n\n", 1)[0]
-    # BOTH SIDES COME FROM THE SAME GLOB, as on the read rule. A hardcoded
-    # candidate list makes a file named in the sentence but absent from the
-    # literal invisible, so the comparison passes while the rule is wrong.
-    # Measured: with the literal, a new command file named here and carrying no
-    # write site was not noticed.
-    claimed = {p.name for p in _COMMANDS_DIR.glob("*.md") if f"`{p.name}`" in sentence}
+    claimed = _files_named_in(sentence)
     assert claimed, (
         "the trigger sentence names no command file — it was restructured and "
         "this arm is now reading nothing"
@@ -4185,3 +4238,64 @@ def test_a_two_sided_exclusive_pair_flags_once_in_either_visit_order():
             f"{label}: a two-sided link must flag ONCE, not once per side: "
             f"{exclusive}"
         )
+
+
+def test_a_usage_error_and_a_refusal_exit_DIFFERENTLY(tmp_path):
+    """ONE RUN, VARIED INPUTS, BOTH CODES — and that is the whole design.
+
+    The defect was ONE code meaning two things: argparse's default 2 collided
+    with `_EXIT_REFUSED`, so a mistyped command was indistinguishable from a
+    real refusal. Two separate arms — one asserting usage returns 64, one
+    asserting a refusal returns 2 — would BOTH pass against a collapsed axis,
+    because each could find an input satisfying it in isolation. What cannot
+    survive a collapse is a single run producing both codes from inputs that
+    differ only in the factor under test. So the table below is asserted whole.
+
+    THE STORE STATE IS VARIED ON PURPOSE. The condition that hid this was
+    SAMENESS ACROSS VARIED INPUTS: five malformed invocations returned 2 against
+    five different store states, which read as five real refusals. An arm
+    covering one store state cannot reproduce that.
+
+    The subparser row is the inheritance path — `add_subparsers` builds children
+    with `parser_class` defaulting to `type(self)`, so a child parser must carry
+    the override too. That was verified by reading; this runs it.
+
+    RED WHEN usage and refusal share a code again, in either direction.
+    """
+    script = str((HOOKS_DIR / "shared" / "backlog.py").resolve())
+    healthy, project = _cli_store(tmp_path / "healthy", [_item()])
+    empty, _ = _cli_store(tmp_path / "empty", [])
+    _repo(project)  # a real checkout, so `set` reaches the item lookup
+
+    def code(store, *args, cwd):
+        return subprocess.run(
+            [sys.executable, script, "--backlog-dir", str(store), *args],
+            capture_output=True, text=True, cwd=str(cwd)).returncode
+
+    outside = tmp_path / "not_a_repo"
+    outside.mkdir()
+
+    observed = {
+        "malformed flag":      code(healthy, "--nope", cwd=project),
+        "unknown subcommand":  code(empty, "bogus", cwd=project),
+        "subparser operand":   code(empty, "set", cwd=outside),
+        "refusal: no item":    code(healthy, "set", "ffff", "--status", "done", cwd=project),
+        "refusal: no root":    code(healthy, "show", cwd=outside),
+        "help":                code(healthy, "--help", cwd=project),
+    }
+    assert observed == {
+        "malformed flag":     backlog._EXIT_USAGE,
+        "unknown subcommand": backlog._EXIT_USAGE,
+        "subparser operand":  backlog._EXIT_USAGE,
+        "refusal: no item":   backlog._EXIT_REFUSED,
+        "refusal: no root":   backlog._EXIT_REFUSED,
+        "help":               backlog._EXIT_OK,
+    }, f"exit codes moved: {observed}"
+
+    # THE SEPARATION ITSELF, stated rather than implied by the table above: a
+    # later change routing everything through one code would still satisfy a
+    # row-by-row reading of a weaker arm.
+    assert observed["malformed flag"] != observed["refusal: no item"], (
+        "a malformed invocation and a real refusal exit with the SAME code "
+        f"({observed['malformed flag']}); the two are indistinguishable again"
+    )

--- a/pact-plugin/tests/test_ci_collection_scope.py
+++ b/pact-plugin/tests/test_ci_collection_scope.py
@@ -485,3 +485,41 @@ class TestMatrixAndProseAgreeOnTheVersionSet:
             f"sets are the same set by construction. Update whichever side "
             f"you did not just edit."
         )
+
+
+def test_no_second_checkout_sits_inside_the_collection_root():
+    """A checkout under `pact-plugin/` makes pytest collect a SECOND copy.
+
+    Same defect as the rest of this module and the opposite direction: there a
+    scoped invocation collected too little, here an extra checkout collects too
+    much. Both move the only number a reader has, and this one moves it the way
+    that looks like good news — every total roughly DOUBLES, and a doubled
+    green reads as a bigger, healthier suite rather than an error.
+
+    NOTHING ELSE WE RUN CATCHES IT. Count-versus-expectation does not fire,
+    because nobody carries a reference value precise enough. Collecting twice
+    and comparing scopes does not fire either: the extra copy inflates both
+    sides identically.
+
+    A `.git` entry is the tell for both shapes that cause it — a linked
+    worktree writes a `.git` FILE, a clone a `.git` DIRECTORY — and neither
+    belongs under the package. Near-missed for real: a `git worktree add` run
+    from the wrong directory landed one here.
+
+    CEILING, and it is why this reads the filesystem rather than
+    `git worktree list`: that command knows only worktrees of THIS repository,
+    so it is blind to a stray clone. It also cannot run where git is absent.
+    This check fires mostly on a developer's machine — CI checks out fresh and
+    has nothing nested — which is the right place, because that is where the
+    mistake is made and where the misleading total gets believed.
+
+    RED WHEN any second checkout appears under the plugin root.
+    """
+    root = _plugin_root()
+    nested = sorted(str(path.relative_to(root)) for path in root.rglob(".git"))
+    assert nested == [], (
+        f"a second checkout sits inside the collection root: {nested}. pytest "
+        f"collects it as well, so every total below is roughly doubled and the "
+        f"run looks healthier than the real suite. Move or remove it, then "
+        f"re-run before trusting any count from this session."
+    )

--- a/pact-plugin/tests/test_memory_reachability.py
+++ b/pact-plugin/tests/test_memory_reachability.py
@@ -627,3 +627,38 @@ def test_following_the_warnings_own_advice_does_not_lose_leaves(tmp_path):
     lost = renamed("ARCHIVE_t.md")
     assert [p.name for p in lost.archive_only] == ["feedback_g.md"]
     assert mr.emit_edit(lost) is None, "and nothing is offered to restore it"
+
+
+def test_a_usage_error_and_a_refusal_exit_DIFFERENTLY(tmp_path):
+    """ONE RUN, VARIED INPUTS, BOTH CODES — and that is the whole design.
+
+    argparse exits 2 by default and this script returns 2 for REFUSED, so a
+    mistyped invocation was indistinguishable from a declined one. Two separate
+    arms — one asserting usage returns 64, one asserting a refusal returns 2 —
+    would BOTH pass against a collapsed axis, because each finds an input
+    satisfying it in isolation. So the table is asserted whole.
+
+    RED WHEN usage and refusal share a code again, in either direction.
+    """
+    def code(argv):
+        try:
+            return mr.main(argv)
+        except SystemExit as exc:
+            return exc.code
+
+    observed = {
+        "malformed flag":  code(["--nope", str(tmp_path)]),
+        "missing operand": code([]),
+        "refusal: absent": code([str(tmp_path / "not_here")]),
+    }
+    assert observed == {
+        "malformed flag":  mr._EXIT_USAGE,
+        "missing operand": mr._EXIT_USAGE,
+        "refusal: absent": 2,
+    }, "exit codes moved: {0}".format(observed)
+
+    # The separation itself, stated rather than implied: routing everything
+    # through one code would still satisfy a row-by-row reading.
+    assert observed["malformed flag"] != observed["refusal: absent"], (
+        "a mistyped command and a declined one are indistinguishable to a caller"
+    )

--- a/pact-plugin/tests/test_shred_detect.py
+++ b/pact-plugin/tests/test_shred_detect.py
@@ -764,3 +764,38 @@ class TestStaticDiscipline:
                     "{0}:{1} names the vector table in an executable "
                     "string.".format(source.name, lineno)
                 )
+
+
+def test_a_usage_error_and_a_refusal_exit_DIFFERENTLY(tmp_path):
+    """ONE RUN, VARIED INPUTS, BOTH CODES — and that is the whole design.
+
+    argparse exits 2 by default and this script returns 2 for REFUSED, so a
+    mistyped invocation was indistinguishable from a declined one. Two separate
+    arms — one asserting usage returns 64, one asserting a refusal returns 2 —
+    would BOTH pass against a collapsed axis, because each finds an input
+    satisfying it in isolation. So the table is asserted whole.
+
+    RED WHEN usage and refusal share a code again, in either direction.
+    """
+    def code(argv):
+        try:
+            return shred_detect.main(argv)
+        except SystemExit as exc:
+            return exc.code
+
+    observed = {
+        "malformed flag":  code(["--nope", str(tmp_path / "s.db")]),
+        "missing operand": code([]),
+        "refusal: absent": code([str(tmp_path / "not_here.db")]),
+    }
+    assert observed == {
+        "malformed flag":  shred_detect._EXIT_USAGE,
+        "missing operand": shred_detect._EXIT_USAGE,
+        "refusal: absent": 2,
+    }, "exit codes moved: {0}".format(observed)
+
+    # The separation itself, stated rather than implied: routing everything
+    # through one code would still satisfy a row-by-row reading.
+    assert observed["malformed flag"] != observed["refusal: absent"], (
+        "a mistyped command and a declined one are indistinguishable to a caller"
+    )


### PR DESCRIPTION
The backlog had no **unprompted** surface at session end. `session_init` reports it at SessionStart; nothing reported it when a session finished.

`wrap-up.md`'s only backlog touch is the status write inside worktree cleanup, which runs only on a verified merge — so a session ending without one wrote nothing and reported nothing. Section 8 always runs, and its "Yes, continue" branch keeps the team alive with no SessionStart in between.

## What changed

**The call site** (`commands/wrap-up.md`). A `backlog.py show` at the top of section 8, above the `AskUserQuestion` prose. It is read-only in the agent's hands: it reports drift flags and never corrects one, which keeps the file at exactly one write site and leaves intact the rule that a status is written only where a transition was witnessed. Section 6's write is untouched. Both this call site and `bootstrap.md`'s say what to do when the report itself fails — report it and carry on, never `repair`, which is a write.

**The stated rule** (`commands/next.md`). Which files report the backlog, and why, so the pin has something outside itself to be checked against.

**The pins** (`tests/test_backlog.py`). Write sites were pinned; read sites were not, so the report call sites could have been deleted with nothing turning red. Both the read and write rules now derive their named set from the tree and cross-check it three ways.

Three defects surfaced while building those pins and are fixed here rather than deferred:

**Recently-touched work was reported as abandoned** (`hooks/shared/backlog.py`). The heuristic links an item to its branch by looking for the ref's digits in a branch or worktree name, and a branch named without its issue number reads as no branch at all. Measured against this repository, this PR's own item was flagged abandoned while its branch sat in the list. Fixed by exempting items touched within `_STALE_AFTER` rather than by changing the match — the matching direction measured clean, and tightening it would have converted suppressed warnings into missing ones.

**Exit code 2 meant two things**, in `backlog.py` and independently in `scripts/memory_reachability.py` and `scripts/memory_repair/shred_detect.py`. A malformed flag, a missing operand and a genuine refusal all returned 2, so three varied inputs produced one answer and a caller could not tell "you typed it wrong" from "I read it and declined". Usage now exits 64; refusals keep 2. Renumbering refusals instead was rejected: it would make 2 mean *refusal* in one CLI and *usage* in its sibling, which is worse than the collision.

**A second checkout inside `pact-plugin/` doubles collection** (`tests/test_ci_collection_scope.py`). Every total roughly doubles, which reads as a bigger, healthier suite. Nothing else we run catches it — no reference count is precise enough, and collecting twice inflates both sides identically.

**Version** 4.7.0 → 4.7.1 across the four files.

## Verification

Certifying run from `pact-plugin` with no path argument, on a still tree: `15284 passed, 85 skipped, 2 warnings`, exit 0, no FAILED or ERROR lines.

Collection reconciled rather than assumed: 15369 collected from the `pact-plugin` root against 15321 with a path argument — the documented 48-case gap, from test files living beside the artifacts they pin under `skills/`. And 15284 + 85 = 15369, so the run was complete as well as clean. A clean partial run and a clean full run print identically, so those are separate claims.

## Corrections made during review

Recorded rather than silently rewritten, because each one was load-bearing when it was wrong.

**"The backlog surfaces in exactly one place" was stated at the wrong grain.** True of the *unprompted* surface — `session_init` is the only hook that reads the store. False as a claim about call sites: three command files carry a `backlog.py show`. The original commit message and this description both carried the ambiguity. Found by the external reviewer, then independently reached by two internal lanes.

**The pin's detector accepted a command that reports nothing.** It keyed on the set of non-write subcommands, which includes `repair` — a corrupt-file recovery step. A plausible restructuring of `bootstrap.md`'s step into recovery passes the guard while reporting no backlog.

**There was no stated rule for which files report the backlog.** The write side had three layers — a rule in `next.md`, a named list, and a test pinning it. The read side had one: the test. A pin whose only derivation lives inside itself cannot be checked against anything, which is the mechanism by which a third member stayed invisible.

**Two guards were narrowed where one had a reason.** The report-site arm checked all three files for presence, then checked only two of them for whether that presence is an invocation and whether its lead-in is unconditional. One narrowing had a stated rationale; the second shared a loop and inherited it. The rationale does not transfer — prose replacing the command breaks `next.md` exactly as it breaks the others — so both guards now run over all three.

**A presence assertion in that arm could never execute.** A census four lines earlier compares the same derived value against two references, and any input that would trip the presence check trips the census first. It was unreachable built one way and true-by-construction built the other. Removed; the property survives in the census with a message that names both sides of the disagreement rather than only the empty one.

## What this does not claim

The framing rests on every witnessed status having been recorded at its own transition. On the command-file call graph that is settled: `gh pr merge` appears in exactly one command file, and its merging option routes to wrap-up in the same sentence. At runtime it is not settleable from repo text — a web-UI merge, a bare `gh pr merge`, or a session ending after review each reach no wrap-up. The ruling survives either way: an out-of-band merge runs no PACT command at all, so no write site would cover it, and reconciliation already handles that case by design.

The abandoned-flag exemption reuses `_STALE_AFTER`, which makes it the exact complement of the staleness cutoff. An item old enough to be flagged abandoned is therefore already flagged stale, so that flag can no longer fire alone. The two carry different diagnoses and different remedies, so they are not redundant — but the co-occurrence is by construction, not coincidence. A genuinely abandoned item within the window is reported once the window passes: a delay, not a suppression.
