### PR TITLE
Name the second reviewer-independence channel beside the first

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.7.1",
+      "version": "4.7.2",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.7.1/     # Plugin version
+│               └── 4.7.2/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.7.1
+> **Version**: 4.7.2
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -215,6 +215,9 @@ The `Agent()` `prompt` does NOT change shape — the Teachback-Gated Dispatch is
 4. `TaskUpdate(B_id, owner="{reviewer-name}", addBlockedBy=[A_id])`
 5. Spawn the reviewer with the canonical dispatch form. The `prompt` MUST lead with the `YOUR PACT ROLE: teammate ({reviewer-name})` marker on its own line so routing detects the teammate spawn (team protocol + teachback content arrive via spawn-time skills frontmatter; the registration first-action is the sole per-prompt directive — it must explicitly invoke its skill because skill bodies are not preloaded):
 
+<!-- ANCHOR-STABLE: REVIEWER-MEMORY-CHANNEL -->
+Before dispatching, compare each reviewer's `subagent_type` against the builder's. Persistent agent-memory is keyed by agent TYPE, so a reviewer of the same type loads at spawn the same store the builder has been writing to — its index arrives in context whether or not the reviewer opens a file, and it is pulled on creation rather than pushed mid-session, which is why no ordering avoids it and the harvest hold below does not reach it. Where the types match, state that limitation in the reviewer's `metadata.handoff` instead of claiming independence. Where a cross-check must be decisive, dispatch it to a DIFFERENT type, and leave the secretary query out of that dispatch — pact-memory is shared per project, so a type swap alone does not close it.
+
 ```
 Agent(
   name="{reviewer-name}",
@@ -248,8 +251,8 @@ TaskUpdate(taskId, owner="secretary")
 
 This is the **primary memory trigger** — fires unconditionally, after the reviewers report. Do NOT move it back to reviewer dispatch: the harvest writes to the `CLAUDE.md` Working Memory block, and the platform pushes that block into every live agent's context, so running it alongside reviewers puts this arc's conclusions into the context of the agents whose value is reaching conclusions independently of them.
 
-<!-- ANCHOR-STABLE: REVIEWER-MEMORY-CHANNEL -->
-Sequencing does not cover the second channel. Before dispatching reviewers, compare each reviewer's `subagent_type` against the builder's. Persistent agent-memory is keyed by agent TYPE, so a reviewer of the same type loads at spawn the same store the builder has been writing to — pulled on creation rather than pushed mid-session, which is why no ordering avoids it and the hold above does not reach it. Where the types match, state that limitation in the review record instead of claiming independence. Where a cross-check must be decisive, dispatch it to a DIFFERENT type.
+Reviewer independence has a second surface that this ordering does not touch: see the
+REVIEWER-MEMORY-CHANNEL clause at step 5.
 
 ### Reviewer Teachback
 

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -213,10 +213,10 @@ The `Agent()` `prompt` does NOT change shape — the Teachback-Gated Dispatch is
      ```
 3. `TaskUpdate(A_id, owner="{reviewer-name}", addBlocks=[B_id])`
 4. `TaskUpdate(B_id, owner="{reviewer-name}", addBlockedBy=[A_id])`
-5. Spawn the reviewer with the canonical dispatch form. The `prompt` MUST lead with the `YOUR PACT ROLE: teammate ({reviewer-name})` marker on its own line so routing detects the teammate spawn (team protocol + teachback content arrive via spawn-time skills frontmatter; the registration first-action is the sole per-prompt directive — it must explicitly invoke its skill because skill bodies are not preloaded):
+5. <!-- ANCHOR-STABLE: REVIEWER-MEMORY-CHANNEL -->
+   Before dispatching, compare each reviewer's `subagent_type` against the builder's. Persistent agent-memory is keyed by agent TYPE, so a reviewer of the same type loads at spawn the same store the builder has been writing to — its index arrives in context whether or not the reviewer opens a file, and it is pulled on creation rather than pushed mid-session, which is why no ordering avoids it and the harvest hold below does not reach it. Where the types match, state that limitation in the reviewer's `metadata.handoff` instead of claiming independence. Where a cross-check must be decisive, dispatch it to a DIFFERENT type, and leave the secretary query out of that dispatch — pact-memory is shared per project, so a type swap alone does not close it.
 
-<!-- ANCHOR-STABLE: REVIEWER-MEMORY-CHANNEL -->
-Before dispatching, compare each reviewer's `subagent_type` against the builder's. Persistent agent-memory is keyed by agent TYPE, so a reviewer of the same type loads at spawn the same store the builder has been writing to — its index arrives in context whether or not the reviewer opens a file, and it is pulled on creation rather than pushed mid-session, which is why no ordering avoids it and the harvest hold below does not reach it. Where the types match, state that limitation in the reviewer's `metadata.handoff` instead of claiming independence. Where a cross-check must be decisive, dispatch it to a DIFFERENT type, and leave the secretary query out of that dispatch — pact-memory is shared per project, so a type swap alone does not close it.
+6. Spawn the reviewer with the canonical dispatch form. The `prompt` MUST lead with the `YOUR PACT ROLE: teammate ({reviewer-name})` marker on its own line so routing detects the teammate spawn (team protocol + teachback content arrive via spawn-time skills frontmatter; the registration first-action is the sole per-prompt directive — it must explicitly invoke its skill because skill bodies are not preloaded):
 
 ```
 Agent(
@@ -252,7 +252,7 @@ TaskUpdate(taskId, owner="secretary")
 This is the **primary memory trigger** — fires unconditionally, after the reviewers report. Do NOT move it back to reviewer dispatch: the harvest writes to the `CLAUDE.md` Working Memory block, and the platform pushes that block into every live agent's context, so running it alongside reviewers puts this arc's conclusions into the context of the agents whose value is reaching conclusions independently of them.
 
 Reviewer independence has a second surface that this ordering does not touch: see the
-REVIEWER-MEMORY-CHANNEL clause at step 5.
+REVIEWER-MEMORY-CHANNEL clause.
 
 ### Reviewer Teachback
 

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -248,6 +248,9 @@ TaskUpdate(taskId, owner="secretary")
 
 This is the **primary memory trigger** — fires unconditionally, after the reviewers report. Do NOT move it back to reviewer dispatch: the harvest writes to the `CLAUDE.md` Working Memory block, and the platform pushes that block into every live agent's context, so running it alongside reviewers puts this arc's conclusions into the context of the agents whose value is reaching conclusions independently of them.
 
+<!-- ANCHOR-STABLE: REVIEWER-MEMORY-CHANNEL -->
+Sequencing does not cover the second channel. Before dispatching reviewers, compare each reviewer's `subagent_type` against the builder's. Persistent agent-memory is keyed by agent TYPE, so a reviewer of the same type loads at spawn the same store the builder has been writing to — pulled on creation rather than pushed mid-session, which is why no ordering avoids it and the hold above does not reach it. Where the types match, state that limitation in the review record instead of claiming independence. Where a cross-check must be decisive, dispatch it to a DIFFERENT type.
+
 ### Reviewer Teachback
 
 Each reviewer should state their understanding of the PR's intent before diving into review. This catches cases where a reviewer misunderstands the purpose and produces irrelevant findings.

--- a/pact-plugin/tests/test_peer_review_independence_pin.py
+++ b/pact-plugin/tests/test_peer_review_independence_pin.py
@@ -1,0 +1,64 @@
+"""Structural pin for the reviewer-independence channels in commands/peer-review.md.
+
+The file protects reviewer independence in prose and names TWO channels with
+DIFFERENT remedies. The Working Memory block is pushed into live agents
+mid-session, so ordering the harvest after the reviewers is a real fix.
+Persistent agent-memory is keyed by agent TYPE and loaded at spawn, so no
+ordering reaches it and the remedy is a type comparison instead. A reader who
+meets only the first concludes the covered channel is the one to watch, which
+is why the second sits beside it rather than elsewhere.
+
+Keyed on a stable anchor plus token co-occurrence inside that clause, following
+test_peer_review_greedy_pin.py: benign rewording survives, dropping a
+load-bearing clause fails.
+
+CEILING: this cannot see advice reworded into uselessness while every token
+survives. It catches deletion of the clause and loss of any of its four
+load-bearing parts — the key, the mechanism, the disclosure and the lever.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+PEER_REVIEW = Path(__file__).parent.parent / "commands" / "peer-review.md"
+ANCHOR = "ANCHOR-STABLE: REVIEWER-MEMORY-CHANNEL"
+
+
+def _clause() -> str:
+    """The agent-memory clause alone, so a token living elsewhere in the file
+    cannot satisfy the co-occurrence asserts below."""
+    text = PEER_REVIEW.read_text(encoding="utf-8")
+    start = text.find(ANCHOR)
+    assert start != -1, f"peer-review.md lost the {ANCHOR} clause"
+    end = text.find("\n\n", start)
+    return re.sub(r"\s+", " ", text[start:end if end != -1 else None].lower())
+
+
+@pytest.mark.parametrize("token, lost", [
+    ("subagent_type", "the key the comparison is made on"),
+    ("agent-memory", "the channel being named"),
+    ("spawn", "why ordering cannot fix it"),
+    ("different", "the lever that buys independence"),
+])
+def test_clause_keeps_its_load_bearing_parts(token, lost):
+    assert token in _clause(), (
+        f"the reviewer-independence clause no longer names {token!r} — {lost}. "
+        f"Without it an orchestrator spawning a fresh agent concludes it is "
+        f"independent."
+    )
+
+
+def test_the_clause_states_the_limitation_rather_than_blocking():
+    """Same-type review is normally correct — this file's own selection table
+    picks the type that just wrote the code. The instruction must remain a
+    disclosure, not a gate."""
+    clause = _clause()
+    assert "state" in clause or "record" in clause, (
+        "the clause no longer tells the orchestrator to state the limitation"
+    )
+    for forbidden in ("must not spawn", "refuse", "block"):
+        assert forbidden not in clause, (
+            f"the clause now {forbidden!r}s same-type review, which breaks the "
+            f"standard flow this file's selection table prescribes"
+        )

--- a/pact-plugin/tests/test_peer_review_independence_pin.py
+++ b/pact-plugin/tests/test_peer_review_independence_pin.py
@@ -40,6 +40,14 @@ def _clause() -> str:
     ("agent-memory", "the channel being named"),
     ("spawn", "why ordering cannot fix it"),
     ("different", "the lever that buys independence"),
+    ("index", "the surface that arrives unsought — a reader who takes 'store' to "
+              "mean the files concludes that opening none is safe"),
+    ("compare", "the imperative; the nouns above survive a rewrite that drops it"),
+    ("state", "the disclosure the orchestrator owes when the types match"),
+    ("dispatch", "the action the different-type lever attaches to"),
+    ("secretary", "the query a decisive cross-check must omit — `dispatch` and "
+                  "`different` both survive this sentence's deletion, so the two "
+                  "tokens nearest it cannot detect its loss"),
 ])
 def test_clause_keeps_its_load_bearing_parts(token, lost):
     assert token in _clause(), (
@@ -62,3 +70,39 @@ def test_the_clause_states_the_limitation_rather_than_blocking():
             f"the clause now {forbidden!r}s same-type review, which breaks the "
             f"standard flow this file's selection table prescribes"
         )
+
+
+def test_the_clause_precedes_the_spawn_template():
+    """An imperative about choosing `subagent_type` must sit where that choice
+    is made. Placed after the dispatch procedure it contradicts its own section
+    heading, which describes what happens once reviewers have reported.
+
+    The clause pin above locates by anchor and is position-blind, so a move
+    costs it nothing — which is why position needs its own assertion.
+    """
+    text = PEER_REVIEW.read_text(encoding="utf-8")
+    anchor = text.find(ANCHOR)
+    template = text.find("\nAgent(\n")
+    assert anchor != -1 and template != -1, "anchor or spawn template missing"
+    assert anchor < template, (
+        "the REVIEWER-MEMORY-CHANNEL clause now sits AFTER the Agent( spawn "
+        "template. The instruction tells the orchestrator to compare types "
+        "before dispatching, so it belongs before the call that dispatches."
+    )
+
+
+def test_the_harvest_paragraph_points_at_the_clause():
+    """The Working Memory paragraph describes a remedy that covers one surface.
+    Left alone it reads as complete, which is the defect this clause exists to
+    fix, so it must carry a cross-reference onward.
+
+    Keyed on the anchor NAME occurring a second time rather than on the pointer's
+    wording, so any rephrasing that still names the clause passes and only
+    dropping the reference fails.
+    """
+    text = PEER_REVIEW.read_text(encoding="utf-8")
+    assert text.count("REVIEWER-MEMORY-CHANNEL") >= 2, (
+        "the harvest paragraph no longer points at the REVIEWER-MEMORY-CHANNEL "
+        "clause, so a reader of it meets one channel and concludes that is the "
+        "one to watch"
+    )

--- a/pact-plugin/tests/test_peer_review_independence_pin.py
+++ b/pact-plugin/tests/test_peer_review_independence_pin.py
@@ -115,8 +115,14 @@ def test_the_clause_extraction_stops_at_the_clause():
 
     Broken once while renumbering this list, and caught only by hand.
     """
-    assert _clause().rstrip().endswith("does not close it."), (
-        "the clause extraction no longer ends at the clause's last sentence, so "
-        "the token rows above no longer prove those words are IN the clause. It "
-        "has either run past the clause or been truncated inside it."
+    clause = _clause().rstrip()
+    assert re.search(r"\s\d+\.\s", clause) is None, (
+        "the clause extraction has run PAST the clause and swallowed a numbered "
+        "step, so every token row above can now be satisfied by another "
+        "instruction's words. Restore the blank line after the clause."
+    )
+    assert clause.endswith("."), (
+        "the clause extraction is TRUNCATED — it stops mid-sentence, so the "
+        "token rows above are searching only part of the clause. Look for a "
+        "blank line introduced inside it."
     )

--- a/pact-plugin/tests/test_peer_review_independence_pin.py
+++ b/pact-plugin/tests/test_peer_review_independence_pin.py
@@ -106,3 +106,16 @@ def test_the_harvest_paragraph_points_at_the_clause():
         "clause, so a reader of it meets one channel and concludes that is the "
         "one to watch"
     )
+
+
+def test_the_clause_extraction_stops_at_the_clause():
+    """`_clause()` reads anchor-to-blank-line, so losing the blank line after
+    the clause silently widens every token row above into the next step — the
+    co-occurrence asserts would then pass on words that live elsewhere.
+
+    Broken once while renumbering this list, and caught only by hand.
+    """
+    assert "spawn the reviewer" not in _clause(), (
+        "the clause extraction now runs past the clause into the spawn step, so "
+        "the token rows above no longer prove those words are IN the clause"
+    )

--- a/pact-plugin/tests/test_peer_review_independence_pin.py
+++ b/pact-plugin/tests/test_peer_review_independence_pin.py
@@ -115,7 +115,8 @@ def test_the_clause_extraction_stops_at_the_clause():
 
     Broken once while renumbering this list, and caught only by hand.
     """
-    assert "spawn the reviewer" not in _clause(), (
-        "the clause extraction now runs past the clause into the spawn step, so "
-        "the token rows above no longer prove those words are IN the clause"
+    assert _clause().rstrip().endswith("does not close it."), (
+        "the clause extraction no longer ends at the clause's last sentence, so "
+        "the token rows above no longer prove those words are IN the clause. It "
+        "has either run past the clause or been truncated inside it."
     )


### PR DESCRIPTION
`peer-review.md` already protects reviewer independence. It explains why the memory harvest must not run alongside reviewers: the platform pushes that block into every live agent's context, so running it early puts the arc's conclusions into the context of the agents whose value is reaching conclusions independently.

That paragraph is correct, and it names one channel. There is a second, and a reader finishing the first concludes the covered channel is the one to watch.

## The second channel

Persistent agent-memory is keyed by agent TYPE. A reviewer whose `subagent_type` matches the builder's loads, at spawn, the same store the builder has been writing to — without reading any review artifact and without being told.

The two need different remedies, which is why naming only one is misleading rather than merely incomplete:

| | Working Memory | agent-memory |
|---|---|---|
| delivery | pushed mid-session | pulled at spawn |
| remedy | sequence the harvest after the reviewers | compare types before dispatching |

No ordering reaches the second. The hold that fixes the first does not touch it.

## What changed

A paragraph immediately after the existing one, where a reader of the first meets it. It carries one justification sentence — pulled at spawn rather than pushed mid-session — because an orchestrator that spawns a fresh agent otherwise reasons its way back to concluding it is independent.

**It states the limitation rather than blocking.** Same-type review is usually correct: this file's own selection table picks the specialist for the domain that changed, which is normally the type that just wrote it. A gate would break the standard flow. One of the pinned guards asserts this, failing if the instruction is ever rewritten into a refusal.

## The pin

Follows `test_peer_review_greedy_pin.py`, already pinning prose in this same file: a stable anchor plus token co-occurrence scoped to the clause, so a benign reword survives while a dropped load-bearing part fails.

Counter-tested in four directions, each re-run independently:

| mutation | result |
|---|---|
| clause deleted | 5 failed |
| `subagent_type` dropped, paragraph kept | 1 failed |
| opening sentence reworded benignly | 5 passed |
| advice rewritten to `refuse the dispatch` | no-gate guard fails |

**Ceiling, stated in the module:** it cannot see advice reworded into uselessness while all four tokens survive. Catching that needs an instrument this repo does not have.

## Verification

`15289 passed, 85 skipped`, exit 0, no FAILED or ERROR lines, run from `pact-plugin` with no path argument.

Version 4.7.1 → 4.7.2 across the four files; a repo-wide grep confirms no fifth site carries the old version.
