### PR TITLE
fix(census): corroborate candidates before the uniqueness gate

### DIFF
--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -363,10 +363,16 @@ def get_pact_context() -> dict:
 # candidate team's tasks/<dir>/ store mtime must be within this window of
 # "now" to count as LIVE. RESUME_CENSUS_RECENCY_SECONDS = 900 (15 minutes)
 # — minutes-scale so a resume followed by a delayed dispatch still lands
-# inside the window, while aged stores fall out. The window is a NARROWING
-# parameter only: zero or >= 2 surviving candidates always fail safe to the
-# persisted default, so a mis-tuned window can only suppress the census,
-# never mis-align.
+# inside the window, while aged stores fall out. The window NARROWS the
+# candidate set only; it is never an ownership signal. Zero or >= 2
+# CORROBORATED survivors always fail safe to the persisted default, so a
+# mis-tuned window cannot admit anything that failed the ownership proof.
+# It is no longer purely suppressive, though: since the census corroborates
+# before counting, WIDENING the window can turn a zero-survivor world into
+# a one-survivor world, and if that survivor is the same-directory sibling
+# named in _resume_census_candidate_corroborated's residual note, a wider
+# window reaches it. Retune DOWNWARD freely; retune upward only with that
+# residual in mind.
 RESUME_CENSUS_RECENCY_SECONDS = 900
 
 # Journal event types proving prior TEAM ACTIVITY for the branch-3 census
@@ -465,8 +471,9 @@ def _resume_census_candidate_corroborated(
 
     Set-uniqueness alone proves nothing (a sibling session's fresh store can
     be the unique candidate whenever this session's own team is unborn), so
-    the unique candidate must additionally corroborate as THIS session's
-    team, by mechanism:
+    EVERY candidate must corroborate as THIS session's team before the
+    census counts survivors at all (see _resume_census_unique_candidate's
+    ORDER IS LOAD-BEARING note), by mechanism:
 
       * LEAD ENTRY: the config's members[] entry whose agentId EQUALS the
         config's leadAgentId (the platform's first-class key — NOT a
@@ -495,6 +502,24 @@ def _resume_census_candidate_corroborated(
     is out of scope by construction. Residual hole: a sibling BORN between
     this session's end marker and its resume, running from the same
     directory.
+
+    REACHABILITY OF THAT RESIDUAL WIDENED when the census moved to
+    corroborate-then-count. It is the SAME hole — nothing that fails this
+    predicate is ever admitted — but it used to require the sibling to be
+    the census's ONLY candidate, and the raw-count rule was therefore
+    masking it whenever any other live team happened to exist. It no
+    longer is: a same-directory sibling that corroborates now wins while
+    other, non-corroborating candidates sit alongside it. That masking was
+    never a designed control (it is the same "environmental accident" this
+    docstring says proves nothing), so it was not load-bearing — but the
+    honest statement of the trade is that the fix bought realignment for
+    concurrent-session users at the cost of making this documented residual
+    reachable in more environments. Deliberately NOT closed by making
+    BIRTH ORDER mandatory: that gate is skipped when the journal has no end
+    marker precisely so crash-resumes still realign, and refusing them to
+    narrow this residual is the worse trade. Pinned by
+    test_f1_same_cwd_residual_is_pinned; flip that cell WITH any future
+    hardening.
 
     Never raises: any parse/compare failure corroborates nothing (False),
     which suppresses the census (fail-safe direction).
@@ -560,25 +585,50 @@ def _own_tasks_store_fresh(teams_root: Path, session_id: str) -> bool:
 
 
 def _resume_census_unique_candidate(teams_root: Path, session_id: str) -> str | None:
-    """Branch-3 census (#1507): the single LIVE re-provisioned team, if
-    unambiguous AND corroborated as this session's own.
+    """Branch-3 census (#1507): the single LIVE re-provisioned team that
+    CORROBORATES as this session's own — "unique" means unique among the
+    candidates that proved ownership, not unique on disk.
 
     Enumerates teams/*/config.json. A dir is a CANDIDATE iff its
     config.json carries a REAL string leadSessionId DIFFERENT from this
     session's id (a config missing/null on the field is malformed and
     never counts) AND its sibling tasks/<dir>/ store mtime falls within
-    RESUME_CENSUS_RECENCY_SECONDS of now (the "live team" signal). Returns
-    the dir name only when EXACTLY ONE candidate survives AND that
-    candidate corroborates as this session's team (see
-    _resume_census_candidate_corroborated — F1: uniqueness is an
-    environmental accident, never an ownership proof). None on zero, on
-    >= 2 (two simultaneous broken resumes -> stale default), on an
-    UNCORROBORATED unique candidate (pre-birth window / foreign sibling ->
-    fail-safe suppression), or on any error.
+    RESUME_CENSUS_RECENCY_SECONDS of now (the "live team" signal).
+    Corroboration is then applied to EVERY candidate (see
+    _resume_census_candidate_corroborated) and the dir name is returned
+    only when EXACTLY ONE candidate SURVIVES that proof. None on zero
+    survivors (pre-birth window / only foreign siblings -> fail-safe
+    suppression), on >= 2 survivors (genuinely ambiguous OWNERSHIP, e.g.
+    two simultaneous broken resumes -> stale default), or on any error.
+
+    ORDER IS LOAD-BEARING — corroborate, THEN count. Counting the RAW
+    candidate set first (the original #1507 shape) rejected the whole set
+    whenever a second team was merely alive, and a concurrently-live PEER
+    session's team is a candidate on exactly the same terms as this
+    session's own re-provisioned team. So the accident of how many
+    sessions happen to be running suppressed the predicate that
+    discriminates them, and no user running parallel sessions could ever
+    realign a resumed one. F1's point stands and is why the count is kept
+    at all: uniqueness is an environmental accident, never an ownership
+    proof — so it now bounds the PROOF (>= 2 candidates that each proved
+    ownership is a real ambiguity worth failing safe on) rather than the
+    accident.
+
+    For zero or one candidate this is IDENTICAL to counting first: the
+    survivor set is a subset of the candidate set, so a lone candidate
+    yields {} or {itself} on either order. The reorder is observable ONLY
+    when >= 2 candidates exist, where the old order always returned None.
+    It therefore admits nothing that fails the ownership proof; what it
+    widens is the REACHABILITY of the residual named in
+    _resume_census_candidate_corroborated's trust-boundary note (a
+    same-directory sibling can now win while other, non-corroborating
+    candidates sit alongside it, where before it had to be alone).
 
     The corroboration lives HERE, inside the get_team_name resolution path,
     so the marker-writer write-back (which calls get_team_name) can never
-    persist an uncorroborated winner.
+    persist an uncorroborated winner. Both callers inherit this: branch 3
+    AND branch 2's #1509 preemption guard (which layers its own stricter
+    conjuncts on top).
 
     Pure / FS-read-only / NEVER raises — same contract as the resolver that
     calls it. The tasks root is derived as the SIBLING of teams_root
@@ -619,15 +669,27 @@ def _resume_census_unique_candidate(teams_root: Path, session_id: str) -> str | 
                     AttributeError):
                 # Unreadable / malformed sibling — skip it, keep scanning.
                 continue
-        if len(candidates) != 1:
-            # Zero or >= 2: ambiguous -> fail-safe stale default.
+        # CORROBORATE FIRST, THEN count (#1507 follow-up). The ownership
+        # proof is applied to EVERY candidate before any count is taken,
+        # because the raw candidate count is an ENVIRONMENTAL ACCIDENT: a
+        # concurrently-live PEER session's team is a candidate on exactly the
+        # same terms as this session's own re-provisioned team, so counting
+        # first rejected BOTH on COUNT and never consulted the predicate that
+        # discriminates them. Measured: a resumed session with one peer
+        # session live returned the phantom persisted name, and PACT dispatch
+        # stayed dead for the whole session — the failure mode for anyone who
+        # runs two Claude sessions at once.
+        survivors = [
+            name for name, config in candidates
+            if _resume_census_candidate_corroborated(name, config)
+        ]
+        if len(survivors) != 1:
+            # Zero (nothing PROVED ownership: pre-birth window / only foreign
+            # siblings) or >= 2 (genuinely ambiguous OWNERSHIP, e.g. two
+            # simultaneous broken resumes): fail-safe stale default. The
+            # count now bounds the proof, not the accident.
             return None
-        winner_name, winner_config = candidates[0]
-        if not _resume_census_candidate_corroborated(winner_name, winner_config):
-            # Unique but UNBOUND to this session (pre-birth window / foreign
-            # sibling): suppress — never return a uniqueness-only winner.
-            return None
-        return winner_name
+        return survivors[0]
     except Exception:
         # Total fail-safe: the census is an upgrade path, never a new raise
         # source. Any unexpected error -> "no candidate" -> stale default.
@@ -664,17 +726,20 @@ def _resolve_aligned_team_name(
     the inline branch-2 comment) both miss, a RESUMED session
     (clean end-session reaped the old team config; a new team + task store
     was provisioned under a new id while hook frames still carry the OLD
-    session id) can still be realigned: census the teams root for the
-    single LIVE re-provisioned team (config leadSessionId != this session's
-    id, tasks store mtime within RESUME_CENSUS_RECENCY_SECONDS), and return
-    it only if it CORROBORATES as this session's team (lead member cwd
-    anchor + birth order — see _resume_census_candidate_corroborated; F1:
-    uniqueness alone is not an ownership proof). Gated by a journal
+    session id) can still be realigned: census the teams root for LIVE
+    re-provisioned teams (config leadSessionId != this session's id, tasks
+    store mtime within RESUME_CENSUS_RECENCY_SECONDS), require EVERY such
+    candidate to CORROBORATE as this session's team (lead member cwd anchor
+    + birth order — see _resume_census_candidate_corroborated; F1:
+    uniqueness alone is not an ownership proof), and return the winner only
+    when exactly ONE candidate survives that proof. Gated by a journal
     lived-session witness (prior team activity in THIS session's journal —
     kills cold-start concurrent-session cross-alignment) and by the
     fallback team's config being ABSENT (post-convergence the census goes
-    inert). UNAMBIGUOUS-only: exactly one candidate wins; zero, >= 2, or an
-    uncorroborated unique candidate fall to the fail-safe default. See the
+    inert). UNAMBIGUOUS-only, over the CORROBORATED set: zero or >= 2
+    survivors fall to the fail-safe default. Counting raw candidates first
+    (the original shape) meant any second live team — a peer session's,
+    not a rival claim to this one — suppressed the census entirely. See the
     inline branch-3 comment.
 
     FAIL-SAFE DEFAULT: on no identity match (the team dir is half-formed —
@@ -797,12 +862,23 @@ def _resolve_aligned_team_name(
         # default, never the dead dir). The census is consulted ONLY when
         # the witness holds and the own store is stale, and _resume_census_
         # unique_candidate already enforces the cycle-1 corroboration — an
-        # uncorroborated unique candidate returns None and CANNOT preempt,
-        # so the F1 hole cannot reopen through this path. In every
+        # uncorroborated candidate can never be a survivor and so CANNOT
+        # preempt, so the F1 hole cannot reopen through this path. In every
         # census-empty world (including every #989 fixture with an empty
         # teams root) this is byte-identical to the pre-guard branch-2.
         # Preemption additionally requires an END MARKER in this session's
         # journal (N1): only an ENDED substrate may be preempted.
+        #
+        # INHERITED (#1507 follow-up): the census now corroborates EVERY
+        # candidate before counting survivors, and this call site inherits
+        # that — a corroborated winner can preempt a dead-looking own
+        # substrate in worlds where a second, non-corroborating live team
+        # also exists, which the raw-count rule previously refused. The
+        # change is deliberate and not confined to branch 3: this branch was
+        # blind to exactly the same concurrent-session accident. Every
+        # branch-2-specific conjunct above is unchanged, so preemption still
+        # requires the substrate witness, a stale own store, an end marker,
+        # AND corroboration.
         census_winner: str | None = None
         if (
             is_safe_path_component(session_id)
@@ -851,8 +927,16 @@ def _resolve_aligned_team_name(
         #     cold-start concurrent-session cross-alignment: a fresh
         #     session's journal has no prior activity, so its census never
         #     fires even when another live session is the sole candidate.
-        # UNAMBIGUOUS-only: zero or >= 2 candidates -> fall through to the
-        # fail-safe default, byte-identical to today.
+        # UNAMBIGUOUS-only, over the CORROBORATED set (#1507 follow-up):
+        # every candidate is put through the ownership proof FIRST, and
+        # zero or >= 2 SURVIVORS fall through to the fail-safe default.
+        # Counting raw candidates first made a second live team — typically
+        # a peer session the user happens to be running, which claims
+        # nothing about this session — suppress the census wholesale, so a
+        # resumed session could never realign while any other session was
+        # alive. Nothing that fails the proof is admitted by the reorder;
+        # see _resume_census_unique_candidate for the order rationale and
+        # the residual-reachability trade it carries.
         if (
             fallback
             and is_safe_path_component(fallback)

--- a/pact-plugin/tests/test_resume_team_realign_1507.py
+++ b/pact-plugin/tests/test_resume_team_realign_1507.py
@@ -420,6 +420,48 @@ def test_ii_two_candidates_stale_default_and_new_remedy(tmp_path, monkeypatch,
 
 
 # ══════════════════════════════════════════════════════════════════════════════
+# (ii-b) CONCURRENT PEER SESSION — a live peer must not suppress the realign
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_ii_b_concurrent_peer_session_still_realigns(tmp_path, monkeypatch,
+                                                     capsys):
+    """CELL ii-b (#1507 follow-up) — the OTHER two-candidate world, and the
+    one that actually happens: this session's own re-provisioned team plus a
+    PEER session live in the same recency window from a DIFFERENT project
+    directory. Unlike cell ii these are not two ownership claims — the peer
+    fails the subject anchor — so the census must realign, not fail safe.
+
+    Counting the RAW candidate set first rejected both on COUNT before the
+    predicate ran, so every resumed session belonging to a user with a
+    second session open kept the phantom persisted team and the gate DENIED
+    every spawn. RED against corroborate-after-count, GREEN after.
+
+    NON-VACUITY (this file's convention): the owner's task is seeded ONLY
+    under the live team, so the ALLOW is reachable solely by resolving
+    there — a stale-default resolution reads an absent store and DENIES."""
+    _seed_census_world(monkeypatch, tmp_path, live_team=NEW_TEAM_ID8,
+                       live_lead_sid=NEW_SID,
+                       journal_events=["session_end", "task_metadata_snapshot"])
+    # The peer: live store inside the window, fully-formed binding fields,
+    # but its lead works in another project — corroborates nothing here.
+    _seed_team_store(tmp_path / ".claude", team_name=FOREIGN_TEAM,
+                     lead_session_id=FOREIGN_SID, members=(), tasks=(),
+                     corroborate=True,
+                     lead_cwd="/other/project/a-peer-session-lives-here")
+    import shared.pact_context as ctx_module
+    assert ctx_module.get_team_name() == NEW_TEAM_ID8, (
+        "a live peer session in another directory must not suppress the "
+        "census — this is the #1507 follow-up defect"
+    )
+    code, out = _run_dispatch(_make_spawn(team_name_arg="wrong-team"), capsys)
+    assert code == 0
+    assert out == _SUPPRESS_EXPECTED
+    assert (tmp_path / ".claude" / "tasks" / NEW_TEAM_ID8).exists()
+    assert not (tmp_path / ".claude" / "tasks" / OLD_TEAM).exists()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
 # (iii) EMPTY-SSOT SECURITY GATE — census must sit BEHIND the short-circuit
 # ══════════════════════════════════════════════════════════════════════════════
 

--- a/pact-plugin/tests/test_resume_team_realign_1507.py
+++ b/pact-plugin/tests/test_resume_team_realign_1507.py
@@ -403,11 +403,31 @@ def test_ii_two_candidates_stale_default_and_new_remedy(tmp_path, monkeypatch,
     naming the MEASURED recovery (edit pact-session-context.json); none of the
     falsified inert 'bootstrap ritual' phrases may appear (this leg has no
     CLAUDE.md, so the stale block is silent and the enumeration is the sole
-    appended diagnosis)."""
+    appended diagnosis).
+
+    FIXTURE REPAIRED (#1507 follow-up, corroborate-then-count): the AMBIG
+    candidate was seeded member-less, so it never corroborated and this
+    cell's TWO candidates were only ever ONE ownership claim. Once the
+    census corroborates before counting, that world resolves to the LIVE
+    team and this cell kept passing on its DENY alone — the empty task
+    store denies either way, so the assertion no longer observed the
+    ambiguity it names. Both candidates now carry the full binding fields
+    with THIS session's project_dir as the lead cwd, which is what makes
+    them a genuine ownership ambiguity and restores the cell's premise."""
     _seed_census_world(monkeypatch, tmp_path, live_team=NEW_TEAM_ID8,
                        live_lead_sid=NEW_SID, tasks=())  # stale store: no task
     _seed_team_store(tmp_path / ".claude", team_name=AMBIG_TEAM,
-                     lead_session_id=AMBIG_SID, members=(), tasks=())
+                     lead_session_id=AMBIG_SID, members=(), tasks=(),
+                     corroborate=True, lead_cwd=str(tmp_path / "project"))
+    import shared.pact_context as ctx_module
+    # Observe the RESOLUTION directly, not just the deny: an empty task
+    # store denies under EITHER resolution, so the deny alone cannot
+    # distinguish "failed safe" from "realigned to a candidate that happened
+    # to have no work". This is the assertion whose absence let the cell
+    # survive its own fixture going stale.
+    assert ctx_module.get_team_name() == OLD_TEAM, (
+        "two corroborated candidates must leave the stale default standing"
+    )
     code, out = _run_dispatch(_make_spawn(), capsys)
     assert code == 2, "ambiguous census must fail safe to a deny"
     reason = out["hookSpecificOutput"]["permissionDecisionReason"]
@@ -777,8 +797,15 @@ def test_xi_stale_block_and_working_recovery_coexist_scoped(tmp_path,
     was designed to fire) on top of the ambiguous-census stale world."""
     _seed_census_world(monkeypatch, tmp_path, live_team=NEW_TEAM_ID8,
                        live_lead_sid=NEW_SID, tasks=())
+    # Both candidates carry the full binding fields anchored on THIS
+    # session's project_dir, so the census sees a genuine OWNERSHIP
+    # ambiguity and falls to the stale default (see cell ii's FIXTURE
+    # REPAIRED note — a member-less AMBIG candidate stopped producing the
+    # ambiguous-census deny this cell composes its message from once the
+    # census began corroborating before counting).
     _seed_team_store(tmp_path / ".claude", team_name=AMBIG_TEAM,
-                     lead_session_id=AMBIG_SID, members=(), tasks=())
+                     lead_session_id=AMBIG_SID, members=(), tasks=(),
+                     corroborate=True, lead_cwd=str(tmp_path / "project"))
     # The stale-block trigger: project CLAUDE.md whose Resume line records a
     # PREVIOUS session id, with the acting frame carrying a different one.
     project_dir = tmp_path / "project"

--- a/pact-plugin/tests/test_team_name_detect_align.py
+++ b/pact-plugin/tests/test_team_name_detect_align.py
@@ -1168,7 +1168,12 @@ class TestBranch3ResumeCensus:
 
     def test_two_candidates_fail_safe(self, ctx, monkeypatch, tmp_path):
         """Two live re-provisioned candidates (two simultaneous broken
-        resumes) -> AMBIGUOUS -> stale default, never a coin flip."""
+        resumes) -> AMBIGUOUS -> stale default, never a coin flip. NOTE both
+        candidates carry the default NON-matching lead cwd, so post-
+        corroborate-then-count this cell exercises the ZERO-survivor arm;
+        the >= 2-SURVIVOR arm (the one the count rule actually exists for)
+        is pinned separately by test_two_corroborating_candidates_fail_safe
+        below."""
         ctx_module, teams_root = ctx
         _seed_census_candidate(teams_root, dir_name=NEW_UUID_DIR)
         _seed_census_candidate(
@@ -1182,6 +1187,82 @@ class TestBranch3ResumeCensus:
             LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
         )
         assert resolved == STALE_TEAM
+
+    def test_concurrent_peer_session_does_not_suppress_realign(
+        self, ctx, monkeypatch, tmp_path
+    ):
+        """REGRESSION (#1507 follow-up) — THE CONCURRENT-SESSION DEFECT. Two
+        LIVE candidates inside the recency window: this session's own
+        re-provisioned team (lead cwd == the persisted project_dir) and a
+        PEER session's team running from a DIFFERENT project directory. The
+        peer claims nothing about this session; the subject anchor
+        discriminates them perfectly. Counting the RAW candidate set first
+        rejected BOTH on COUNT and never consulted the predicate, so the
+        resolver returned the phantom stale default and PACT dispatch stayed
+        dead for the whole resumed session — the observed failure for anyone
+        running two Claude sessions at once. The census must corroborate
+        EVERY candidate first and return the single survivor.
+
+        RED against corroborate-after-count (resolves to STALE_TEAM); GREEN
+        against corroborate-then-count. The peer is seeded with the helper's
+        DEFAULT foreign lead cwd, which is exactly what fails the anchor."""
+        ctx_module, teams_root = ctx
+        # This session's real re-provisioned team: corroborates on cwd.
+        _seed_census_candidate(teams_root, dir_name=NEW_UUID_DIR,
+                               lead_cwd=str(tmp_path / "project"))
+        # The concurrent PEER session, live in the same window, working in
+        # another project — corroborates nothing.
+        _seed_census_candidate(
+            teams_root, dir_name="session-7c6ea94d",
+            lead_session_id="7c6ea94d-1111-4222-8333-444455556666",
+            lead_cwd="/other/project/a-peer-session-lives-here",
+        )
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name=STALE_TEAM, session_id=LEAD_SID)
+        # The clean-end-then-resume journal shape: an end marker (so BIRTH
+        # ORDER is active, not skipped) plus prior team activity.
+        _seed_session_journal(ctx_module,
+                              ["session_end", "task_metadata_snapshot"])
+        resolved = ctx_module._resolve_aligned_team_name(
+            LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
+        )
+        assert resolved == NEW_UUID_DIR, (
+            "a concurrently-live peer session must not suppress the census — "
+            f"resolved {resolved!r}"
+        )
+
+    def test_two_corroborating_candidates_fail_safe(self, ctx, monkeypatch,
+                                                    tmp_path):
+        """THE SAFETY PROPERTY the count rule exists for, restated over the
+        CORROBORATED set: two candidates that BOTH pass the full ownership
+        proof (both leads' cwd == this session's project_dir, both joined
+        after the end marker) are a genuine OWNERSHIP ambiguity -> stale
+        default, never a coin flip and never the sorted-first name.
+
+        This is the cell that must survive the reorder: it is green on both
+        orders (before, on the raw count; after, on the survivor count), so
+        it does NOT discriminate the fix — it is the guard-rail proving the
+        fix did not degrade >= 2 into a pick-one. Deleting the survivor
+        count reddens it; that is its job."""
+        ctx_module, teams_root = ctx
+        _seed_census_candidate(teams_root, dir_name=NEW_UUID_DIR,
+                               lead_cwd=str(tmp_path / "project"))
+        _seed_census_candidate(
+            teams_root, dir_name="session-beefbeef",
+            lead_session_id="beefbeef-1111-4222-8333-444455556666",
+            lead_cwd=str(tmp_path / "project"),
+        )
+        _write_context_file(monkeypatch, ctx_module, tmp_path,
+                            team_name=STALE_TEAM, session_id=LEAD_SID)
+        _seed_session_journal(ctx_module,
+                              ["session_end", "task_metadata_snapshot"])
+        resolved = ctx_module._resolve_aligned_team_name(
+            LEAD_SID, teams_dir=str(teams_root), default=STALE_TEAM
+        )
+        assert resolved == STALE_TEAM, (
+            "two CORROBORATED candidates are a real ambiguity and must fail "
+            f"safe — resolved {resolved!r}"
+        )
 
     def test_stale_tasks_mtime_not_a_candidate(self, ctx, monkeypatch,
                                                tmp_path):


### PR DESCRIPTION
## The bug

The branch-3 resume census cannot realign a resumed session whenever **another Claude session is live**, because it rejects candidates on COUNT before consulting the ownership proof.

`_resume_census_unique_candidate` builds its candidate set, then applies `if len(candidates) != 1: return None`. `_resume_census_candidate_corroborated` is only ever reached for an already-unique candidate, so its cwd subject anchor never gets the chance to discriminate. Two live team dirs inside `RESUME_CENSUS_RECENCY_SECONDS` are enough to kill the whole set.

Observed live, not inferred. `_resolve_aligned_team_name` returned the stale default while the census held exactly two candidates:

```
session-7c6ea94d  tasks mtime 143s  lead cwd = ".../Yulia - KB project"
session-b95ae762  tasks mtime  96s  lead cwd = ".../CS - Churn Dashboard"
```

The cwd anchor separates those perfectly. The resumed session was left pointing at a team that does not exist, so every `Agent` dispatch was denied by a gate citing a phantom team, with nothing indicating why. The recorded team also propagates to `pact-session-context.json`, the CLAUDE.md `- Team:` line and the hook's announced value, all from this one resolved name, so all three surfaces were wrong together.

Still reproduces at 4.7.2: `hooks/shared/pact_context.py` gates on `if len(candidates) != 1:` with no corroboration pass.

## The fix

Corroborate every candidate first, then require exactly one survivor. The count rule is kept rather than deleted, so it now bounds the proof rather than the accident.

## Safety

For `|C| <= 1` the two orders are **provably identical**, since the survivor set is a subset of the candidate set. Every existing zero-or-one-candidate fixture is byte-identical and the change is inert outside the `>= 2` case.

For `|C| >= 2` the old order always returned `None`, and the new one can only return a candidate passing the full ownership proof (lead entry by `leadAgentId`, agentId self-consistency against the dir name, cwd subject anchor, birth order). Nothing rejected on ownership grounds becomes admitted.

### Qualification, stated because it is a real cost

The raw-count rule was incidentally masking part of the residual that `_resume_census_candidate_corroborated` already documents: a sibling born between this session's end marker and its resume, running from the same directory. Today that sibling wins only as the sole candidate; after this change it can win alongside non-corroborating candidates.

**No new mis-alignment class, but a documented one becomes reachable in strictly more environments.** Recorded at the residual's own site in the source.

Deliberately NOT addressed by making birth order mandatory. That skip exists so realignment still works when the journal has no end marker, and removing it would refuse legitimate realignments to buy a narrow reduction in a known residual.

## Branch 2 inherits this

The `#1509` preemption guard calls the same helper (`pact_context.py:827`), so a corroborated winner can now preempt a dead-looking own substrate in a `>= 2` candidate world. That is intended. Branch 2 keeps its own stricter gates and any winner still has to corroborate. The alternative forks the census into two semantics and leaves branch 2 blind to the same defect.

## Also in commit 1

The `RESUME_CENSUS_RECENCY_SECONDS` comment claimed "a mis-tuned window can only suppress, never mis-align". That goes false here, since widening the window can convert a zero-survivor world into a one-survivor one. Comment rewritten; the constant is unchanged at 900.

## Second commit: two fixtures that never built ambiguity

Reviewed separately on purpose, since it is a different ask.

Cells ii and xi of `test_resume_team_realign_1507.py` both describe two live candidates resolving to the stale default, but seeded `AMBIG_TEAM` member-less (`_seed_team_store` defaults `corroborate=False`). That candidate carried no ownership claim, so the world contained one claim, not two. Neither cell composed the situation its own name describes.

The assertions could not have detected the difference either: `AMBIG_TEAM` has `tasks=()`, and an empty store denies under **either** resolution, so the deny is equally consistent with "failed safe" and "realigned onto a candidate that happens to have no work".

**Cell ii now bites** under a pick-first mutation of the survivor count, where on commit 1's tree it survived that same mutation.

**Cell xi does not newly bite**, and this is a premise correction rather than a new guard. Its assertions concern message composition and none of them discriminate which team resolved. No resolution assertion was added, since its subject is the composer rather than the resolver.

Both carry an in-cell `FIXTURE REPAIRED` note so a later reader does not restore the member-less seed as a simplification.

## Verification

- Baseline on clean `main`: 143 failed / 14610 passed / 449 skipped. All 143 are `tests/test_telegram_*` on a missing optional dependency, none near `pact_context`. Compared as a **set diff of failing node-ids**, not a count.
- After: 143 failed / 14613 passed. Zero new, zero fixed. The +3 are the new cells.
- Sabotage: reverting only `pact_context.py` turns both regression cells red, each resolving to the stale default.
- Reverse mutation: `len(survivors) != 1` to a pick-first turns the fail-safe cell red, proving it is not vacuous.
