### PR TITLE
Let the backlog key on a workspace umbrella with no git root

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.7.5",
+      "version": "4.7.6",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.7.5/     # Plugin version
+│               └── 4.7.6/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.7.5",
+  "version": "4.7.6",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.7.5
+> **Version**: 4.7.6
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/session_end.py
+++ b/pact-plugin/hooks/session_end.py
@@ -393,9 +393,15 @@ def cleanup_old_sessions(
     sessions_dir: str | None = None,
     max_age_days: int = _SESSION_MAX_AGE_DAYS,
     paused_max_age_days: int = _PAUSED_SESSION_MAX_AGE_DAYS,
+    old_slug: str | None = None,
 ) -> None:
     """
     Remove stale session directories, applying a dual TTL.
+
+    Sweeps the slug directory for ``project_slug`` and, when ``old_slug``
+    differs from it, that directory too with the same TTL and carrier guard:
+    a project launched through a symlink wrote earlier sessions under the
+    unresolved name, and those age out beside the resolved one.
 
     Each candidate session directory is checked against a TTL selected per
     entry: checkpointed sessions (those whose journal contains any
@@ -429,6 +435,8 @@ def cleanup_old_sessions(
         paused_max_age_days: TTL for paused sessions in days (default: 180).
             Exposed as a kwarg so tests can inject smaller values for
             boundary verification; production call sites use the default.
+        old_slug: The unresolved project basename; swept as well when it
+            differs from ``project_slug``.
     """
     if not project_slug or not current_session_id:
         return
@@ -436,7 +444,26 @@ def cleanup_old_sessions(
     if sessions_dir is None:
         sessions_dir = str(get_claude_config_dir() / "pact-sessions")
 
-    slug_dir = Path(sessions_dir) / project_slug
+    slugs = [project_slug]
+    if old_slug and old_slug != project_slug:
+        slugs.append(old_slug)
+    for slug in slugs:
+        _reap_slug_dir(
+            Path(sessions_dir) / slug,
+            current_session_id,
+            max_age_days,
+            paused_max_age_days,
+        )
+
+
+def _reap_slug_dir(
+    slug_dir: Path,
+    current_session_id: str,
+    max_age_days: int,
+    paused_max_age_days: int,
+) -> None:
+    """Sweep one slug directory on the cleanup_old_sessions contract. Never
+    raises."""
     if not slug_dir.exists():
         return
 
@@ -976,6 +1003,7 @@ def main():
         cleanup_old_sessions(
             project_slug=project_slug,
             current_session_id=current_session_id,
+            old_slug=Path(get_project_dir()).name,
         )
 
         # Clean up stale ~/.claude/teams/ and ~/.claude/tasks/ (#412 Fix B).

--- a/pact-plugin/hooks/session_end.py
+++ b/pact-plugin/hooks/session_end.py
@@ -36,6 +36,7 @@ from shared.error_output import hook_error_json
 from shared import check_pr_state
 import shared.pact_context as pact_context
 from shared.pact_context import (
+    _UNSAFE_SLUG_CHARS_RE,
     get_project_dir,
     get_session_id,
     get_team_name,
@@ -401,7 +402,9 @@ def cleanup_old_sessions(
     Sweeps the slug directory for ``project_slug`` and, when ``old_slug``
     differs from it, that directory too with the same TTL and carrier guard:
     a project launched through a symlink wrote earlier sessions under the
-    unresolved name, and those age out beside the resolved one.
+    unresolved name, and those age out beside the resolved one. Both slugs
+    pass through the writers' sanitiser first, so a raw name reaches the
+    directory the writers created and cannot name a path outside the root.
 
     Each candidate session directory is checked against a TTL selected per
     entry: checkpointed sessions (those whose journal contains any
@@ -444,9 +447,11 @@ def cleanup_old_sessions(
     if sessions_dir is None:
         sessions_dir = str(get_claude_config_dir() / "pact-sessions")
 
-    slugs = [project_slug]
-    if old_slug and old_slug != project_slug:
-        slugs.append(old_slug)
+    slugs = [_UNSAFE_SLUG_CHARS_RE.sub("_", project_slug)]
+    if old_slug:
+        safe_old = _UNSAFE_SLUG_CHARS_RE.sub("_", old_slug)
+        if safe_old != slugs[0]:
+            slugs.append(safe_old)
     for slug in slugs:
         _reap_slug_dir(
             Path(sessions_dir) / slug,

--- a/pact-plugin/hooks/session_end.py
+++ b/pact-plugin/hooks/session_end.py
@@ -35,7 +35,12 @@ if str(_hooks_dir) not in sys.path:
 from shared.error_output import hook_error_json
 from shared import check_pr_state
 import shared.pact_context as pact_context
-from shared.pact_context import get_project_dir, get_session_id, get_team_name
+from shared.pact_context import (
+    get_project_dir,
+    get_session_id,
+    get_team_name,
+    project_slug,
+)
 from shared.session_journal import (
     append_event,
     make_event,
@@ -53,11 +58,9 @@ _SUPPRESS_OUTPUT = json.dumps({"suppressOutput": True})
 
 
 def get_project_slug() -> str:
-    """Derive project slug from session context (basename of project_dir)."""
-    project_dir = get_project_dir()
-    if project_dir:
-        return Path(project_dir).name
-    return ""
+    """Derive project slug from session context (resolved basename of
+    project_dir, via the shared derivation every session path uses)."""
+    return project_slug(get_project_dir())
 
 
 def check_unpaused_pr(

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -576,10 +576,10 @@ def _extract_prev_session_dir(project_dir: str) -> str | None:
         )
         if resume_match:
             session_id = resume_match.group(1)
-            # Same slug derivation as every session path: the resolved dir.
-            slug = project_slug(project_dir)
+            # Same slug derivation and sanitisation as every session path,
+            # so the fallback lands on the directory the writers used.
             derived = str(
-                get_claude_config_dir() / "pact-sessions" / slug / session_id
+                build_session_path(project_slug(project_dir), session_id)
             )
             return _validate_under_pact_sessions(derived)
 

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -776,6 +776,44 @@ def _clear_bootstrap_marker(session_path: Path) -> None:
         pass  # Fail-open: don't block session init for marker cleanup
 
 
+def _adopt_old_slug_session_dir(session_id: str, project_dir: str) -> bool:
+    """Move a session dir keyed under the UNRESOLVED project basename to the
+    slug every session path now derives, so a session launched through a
+    symlink keeps its journal across the slug change.
+
+    Runs before any writer creates the new-slug dir. Adopts only when the
+    two slugs differ, the old path is a real directory (not a symlink), and
+    the new path is absent or an empty directory. An existing non-empty
+    directory, file or symlink at the new path is left alone, never
+    clobbered or merged: the state there is what every reader already
+    trusts, and the old dir stays where the old readers can still find it.
+    Fail-open: any OSError leaves both paths as they were. Returns True iff
+    the directory moved.
+    """
+    if not session_id or not project_dir:
+        return False
+    old_slug = Path(project_dir).name
+    if not old_slug:
+        return False
+    old = build_session_path(old_slug, str(session_id))
+    new = build_session_path(project_slug(project_dir), str(session_id))
+    if old == new:
+        return False
+    try:
+        if old.is_symlink() or not old.is_dir():
+            return False
+        if new.is_symlink():
+            return False
+        if new.exists() and not (new.is_dir() and not any(new.iterdir())):
+            return False
+        new.parent.mkdir(parents=True, exist_ok=True)
+        os.rename(old, new)
+    except OSError:
+        return False
+    print(f"session_init: adopted session dir {old} -> {new}", file=sys.stderr)
+    return True
+
+
 # Root-drained artifact prefix: what _archive_stale_compact_summary names
 # the moved ROOT-singleton bytes when it drains them into a session dir.
 # Distinct from every real archive name the plugin writes, but KEEPING the
@@ -1186,6 +1224,10 @@ def main():
         # cleared, for the same reason as before, but the previous code cleared
         # it BY DESTROYING the bytes, and those are the only copy. See
         # _archive_stale_compact_summary and _archive_own_dir_stale_summary.
+        # Adopt a session dir written under the unresolved project basename
+        # BEFORE any writer below can create the resolved-slug dir.
+        _adopt_old_slug_session_dir(input_data.get("session_id", ""), project_dir)
+
         if source != "compact":
             _archive_stale_compact_summary(
                 input_data.get("session_id", ""), project_dir

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -495,8 +495,10 @@ def _extract_prev_session_dir(project_dir: str) -> str | None:
     ($project_dir/.claude/CLAUDE.md preferred, $project_dir/CLAUDE.md legacy).
 
     Falls back to deriving the path from the Resume line's session_id +
-    project root basename if the Session dir line is absent (backward compat
-    with sessions that wrote team name but not session dir).
+    the resolved project slug if the Session dir line is absent (backward
+    compat with sessions that wrote team name but not session dir) or names
+    a directory that is no longer there (the line was written before the
+    directory moved to the resolved slug).
 
     Both extracted paths (primary and fallback) are validated against the
     canonical pact-sessions prefix via _validate_under_pact_sessions before
@@ -547,20 +549,25 @@ def _extract_prev_session_dir(project_dir: str) -> str | None:
                 expanded = str(Path.home() / raw[2:])
             else:
                 expanded = raw
-            return _validate_under_pact_sessions(expanded)
-
-        # The primary regex missed even though CLAUDE.md is on disk. This is
-        # usually benign (older sessions wrote only the Resume line, not the
-        # Session dir line — handled by the fallback just below), but it is
-        # also how a silent format regression would present. Log a one-line
-        # stderr warning so future drift in the SESSION_START block surfaces
-        # during testing instead of silently degrading to the fallback.
-        print(
-            "session_init: _extract_prev_session_dir regex failed on existing "
-            "CLAUDE.md, falling back to Resume-line; file may have unexpected "
-            "format",
-            file=sys.stderr,
-        )
+            validated = _validate_under_pact_sessions(expanded)
+            # A validated line naming a directory that is gone falls through
+            # to the derivation below; a rejected line still returns None.
+            if validated is None or Path(validated).is_dir():
+                return validated
+        else:
+            # The primary regex missed even though CLAUDE.md is on disk. This
+            # is usually benign (older sessions wrote only the Resume line,
+            # not the Session dir line — handled by the fallback just below),
+            # but it is also how a silent format regression would present.
+            # Log a one-line stderr warning so future drift in the
+            # SESSION_START block surfaces during testing instead of silently
+            # degrading to the fallback.
+            print(
+                "session_init: _extract_prev_session_dir regex failed on "
+                "existing CLAUDE.md, falling back to Resume-line; file may "
+                "have unexpected format",
+                file=sys.stderr,
+            )
 
         # Fallback: derive from Resume line session_id + project root basename.
         # Resume line format: "- Resume: `claude --resume <session_id>`"

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -78,7 +78,12 @@ from pin_caps import (  # noqa: F401
     parse_pins,
 )
 
-from shared import BOOTSTRAP_MARKER_NAME, SESSION_ID_CONTROL_CHARS_RE, build_session_path
+from shared import (
+    BOOTSTRAP_MARKER_NAME,
+    SESSION_ID_CONTROL_CHARS_RE,
+    build_session_path,
+    project_slug,
+)
 from shared.constants import (
     COMPACT_SUMMARY_ARCHIVE_PREFIX,
     COMPACT_SUMMARY_NAME,
@@ -564,8 +569,8 @@ def _extract_prev_session_dir(project_dir: str) -> str | None:
         )
         if resume_match:
             session_id = resume_match.group(1)
-            # Use project root basename (not worktree) for slug
-            slug = Path(project_dir).name
+            # Same slug derivation as every session path: the resolved dir.
+            slug = project_slug(project_dir)
             derived = str(
                 get_claude_config_dir() / "pact-sessions" / slug / session_id
             )
@@ -803,7 +808,7 @@ def _stale_summary_destination(session_id: str, project_dir: str) -> Path:
     """
     if session_id and project_dir:
         stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
-        return build_session_path(Path(project_dir).name, str(session_id)) / (
+        return build_session_path(project_slug(project_dir), str(session_id)) / (
             f"{_ROOT_DRAINED_SUMMARY_PREFIX}{stamp}.txt"
         )
     return get_compact_summary_path().parent / COMPACT_SUMMARY_ORPHAN_NAME
@@ -866,7 +871,7 @@ def _archive_own_dir_stale_summary(session_id: str, project_dir: str) -> None:
         return
     try:
         summary = (
-            build_session_path(Path(project_dir).name, str(session_id))
+            build_session_path(project_slug(project_dir), str(session_id))
             / COMPACT_SUMMARY_NAME
         )
         if not summary.exists():
@@ -1202,7 +1207,7 @@ def main():
         if is_marker_reset:
             reset_session_id = input_data.get("session_id", "")
             if reset_session_id and project_dir:
-                slug = Path(project_dir).name
+                slug = project_slug(project_dir)
                 session_path = build_session_path(slug, str(reset_session_id))
                 _clear_bootstrap_marker(session_path)
 

--- a/pact-plugin/hooks/shared/__init__.py
+++ b/pact-plugin/hooks/shared/__init__.py
@@ -108,6 +108,7 @@ BOOTSTRAP_MARKER_NAME = "bootstrap-complete"
 # shared.pact_context, but these re-exports allow `from shared import get_team_name`.
 from .pact_context import (
     _build_session_path as build_session_path,
+    project_slug,
     get_pact_context,
     get_team_name,
     get_session_id,
@@ -173,6 +174,7 @@ __all__ = [
     "OVERRIDE_COMMENT_RE",
     "BOOTSTRAP_MARKER_NAME",
     "build_session_path",
+    "project_slug",
     "get_pact_context",
     "get_team_name",
     "get_session_id",

--- a/pact-plugin/hooks/shared/backlog.py
+++ b/pact-plugin/hooks/shared/backlog.py
@@ -50,6 +50,7 @@ from shared.backlog_store import (  # noqa: E402  # follows the sys.path bootstr
     STATUSES,
     BacklogFileError,
     BacklogUnreadableError,
+    _enclosing_checkout,
     as_datetime,
     file_local_flags,
     read_json,
@@ -153,11 +154,16 @@ def project_root() -> Path:
        this project in one place: the read path is deliberately git-free and
        cannot perform this resolution itself, so the writer does it and
        records the result.
-    2. Git resolves nothing and CLAUDE_PROJECT_DIR names an existing
-       directory: that directory, resolved. This is a workspace umbrella —
-       a directory whose children are separate repositories, itself under no
-       `.git` — and it is a stable project key in its own right.
-    3. Otherwise refuse. A default would write a backlog nobody can find.
+    2. Git resolves nothing, CLAUDE_PROJECT_DIR names an existing directory,
+       and no `.git` sits at or above it: that directory, resolved. This is
+       a workspace umbrella — a directory whose children are separate
+       repositories, itself under no `.git` — and it is a stable project key
+       in its own right.
+    3. Otherwise refuse: the variable is unset, names no directory, or names
+       a directory inside a repository git could not read. Writing under a
+       checkout git failed to resolve would key a second backlog on a
+       subdirectory or worktree that every git-present session keys on the
+       main root; a default would write a backlog nobody can find.
 
     ANCHORED ON CLAUDE_PROJECT_DIR, NOT THE PROCESS CWD. Unanchored, a write run
     from another repository resolved THAT repo's root, so `checkout_roots()`
@@ -174,12 +180,21 @@ def project_root() -> Path:
     if root is not None:
         return root
     if project_dir and Path(project_dir).is_dir():
-        return Path(project_dir).resolve()
+        if _enclosing_checkout(Path(project_dir).resolve()) is None:
+            return Path(project_dir).resolve()
+        why = (
+            f"CLAUDE_PROJECT_DIR={project_dir!r} sits inside a repository git "
+            f"could not read"
+        )
+    elif project_dir:
+        why = f"CLAUDE_PROJECT_DIR={project_dir!r} does not name an existing directory"
+    else:
+        why = "CLAUDE_PROJECT_DIR is unset"
     raise BacklogWriteError(
-        "the main repository root did not resolve and CLAUDE_PROJECT_DIR does "
-        "not name an existing directory, so project_path would be wrong or "
-        "empty. Nothing was written. Set CLAUDE_PROJECT_DIR to the project "
-        "directory; a directory with no repository of its own is accepted."
+        f"the main repository root did not resolve and {why}, so project_path "
+        f"would be wrong or empty. Nothing was written. Set CLAUDE_PROJECT_DIR "
+        f"to the project directory; a directory with no repository of its own "
+        f"or above it is accepted."
     )
 
 
@@ -191,8 +206,8 @@ def checkout_roots() -> List[str]:
     another project's session. A missing entry costs that checkout a loud
     resolution failure UNLESS it sits inside a checkout that IS recorded, in
     which case the read path's enclosing-checkout rung still matches it. The
-    fallback when git cannot answer is the main root alone, which is always
-    right about at least itself.
+    fallback when git cannot answer is the project root alone, which is
+    always right about at least itself.
 
     Deliberately NOT merged with _branch_and_worktree_names, which runs the
     same porcelain: that caller reduces each `worktree` line to a BASENAME for
@@ -258,7 +273,7 @@ def load_or_create(path: Path) -> Dict[str, Any]:
         "version": SCHEMA_VERSION,
         "project": path.stem,
         # project_path stays a SIBLING of roots, not roots[0]: three consumers
-        # need the main root specifically (_plan_flags, the _abandoned_flags
+        # need the project root specifically (_plan_flags, the _abandoned_flags
         # git -C, and rename detection), and roots[0] would tie them to
         # porcelain ordering.
         "project_path": str(project_root()),

--- a/pact-plugin/hooks/shared/backlog.py
+++ b/pact-plugin/hooks/shared/backlog.py
@@ -51,6 +51,7 @@ from shared.backlog_store import (  # noqa: E402  # follows the sys.path bootstr
     BacklogFileError,
     BacklogUnreadableError,
     _enclosing_checkout,
+    _resolved,
     as_datetime,
     file_local_flags,
     read_json,
@@ -170,18 +171,22 @@ def project_root() -> Path:
     stored the other project's worktrees into this project's backlog — after
     which this project's sessions stop matching their own file and the other
     project's sessions can claim it. That is the cross-project bleed the
-    disambiguator exists to prevent, arriving through the writer. Same
-    precedence `_detect_project_id` uses, including the umbrella fallback, so
-    the stored name and the stored paths cannot disagree about which project
-    this is.
+    disambiguator exists to prevent, arriving through the writer. Every input
+    this function ACCEPTS is one `_detect_project_id` names from the same
+    resolved directory, so the stored name and the stored paths agree; the
+    inputs on which the two would diverge are the ones this function refuses,
+    and a refusal writes nothing.
     """
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
     root = _memory_api().main_repo_root(project_dir)
     if root is not None:
         return root
     if project_dir and Path(project_dir).is_dir():
-        if _enclosing_checkout(Path(project_dir).resolve()) is None:
-            return Path(project_dir).resolve()
+        # _resolved never raises: an unresolvable directory falls back to its
+        # unresolved path, the same fallback the detector takes for the name.
+        resolved = _resolved(Path(project_dir))
+        if _enclosing_checkout(resolved) is None:
+            return resolved
         why = (
             f"CLAUDE_PROJECT_DIR={project_dir!r} sits inside a repository git "
             f"could not read"

--- a/pact-plugin/hooks/shared/backlog.py
+++ b/pact-plugin/hooks/shared/backlog.py
@@ -145,11 +145,19 @@ def store_path(backlog_dir: Optional[Path] = None) -> Path:
 
 
 def project_root() -> Path:
-    """The MAIN repo root, which is what a backlog stores as project_path.
+    """The path a backlog stores as project_path, resolved in this order:
 
-    Normalising to the main root is what puts every checkout of this project in
-    one place: the read path is deliberately git-free and cannot perform this
-    resolution itself, so the writer does it and records the result.
+    1. Git resolves a MAIN repo root from CLAUDE_PROJECT_DIR: that root. A
+       repo root, a subdirectory below one and a linked worktree all
+       normalise to the same main root, which is what puts every checkout of
+       this project in one place: the read path is deliberately git-free and
+       cannot perform this resolution itself, so the writer does it and
+       records the result.
+    2. Git resolves nothing and CLAUDE_PROJECT_DIR names an existing
+       directory: that directory, resolved. This is a workspace umbrella —
+       a directory whose children are separate repositories, itself under no
+       `.git` — and it is a stable project key in its own right.
+    3. Otherwise refuse. A default would write a backlog nobody can find.
 
     ANCHORED ON CLAUDE_PROJECT_DIR, NOT THE PROCESS CWD. Unanchored, a write run
     from another repository resolved THAT repo's root, so `checkout_roots()`
@@ -157,16 +165,22 @@ def project_root() -> Path:
     which this project's sessions stop matching their own file and the other
     project's sessions can claim it. That is the cross-project bleed the
     disambiguator exists to prevent, arriving through the writer. Same
-    precedence `_detect_project_id` uses, so the stored name and the stored
-    paths cannot disagree about which project this is.
+    precedence `_detect_project_id` uses, including the umbrella fallback, so
+    the stored name and the stored paths cannot disagree about which project
+    this is.
     """
-    root = _memory_api().main_repo_root(os.environ.get("CLAUDE_PROJECT_DIR"))
-    if root is None:
-        raise BacklogWriteError(
-            "the main repository root did not resolve, so project_path would be "
-            "wrong or empty. Nothing was written."
-        )
-    return root
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
+    root = _memory_api().main_repo_root(project_dir)
+    if root is not None:
+        return root
+    if project_dir and Path(project_dir).is_dir():
+        return Path(project_dir).resolve()
+    raise BacklogWriteError(
+        "the main repository root did not resolve and CLAUDE_PROJECT_DIR does "
+        "not name an existing directory, so project_path would be wrong or "
+        "empty. Nothing was written. Set CLAUDE_PROJECT_DIR to the project "
+        "directory; a directory with no repository of its own is accepted."
+    )
 
 
 def checkout_roots() -> List[str]:

--- a/pact-plugin/hooks/shared/backlog_store.py
+++ b/pact-plugin/hooks/shared/backlog_store.py
@@ -815,9 +815,9 @@ def session_block(
                 f"PACT backlog: {len(entries)} backlog file(s) under {root}, and "
                 f"none records {project_dir} as a checkout root. This is a "
                 f"resolution failure, NOT an empty backlog — do not treat this "
-                f"project as having no backlog. A checkout created since the "
-                f"last write is not yet recorded; /PACT:next writes, which "
-                f"records it."
+                f"project as having no backlog. Either a checkout created since "
+                f"the last write is not yet recorded, or this project has never "
+                f"held a backlog; /PACT:next writes, which records it."
             )
 
         # NON-CONFORMANCE IS NOT CORRUPTION. Corruption is "I cannot understand

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -46,9 +46,8 @@ _UNSAFE_SLUG_CHARS_RE = re.compile(r"[^A-Za-z0-9_-]+")
 
 # Session-scoped context file path, set by init().
 # When None, get_pact_context() returns _EMPTY_CONTEXT (no file to read).
-# Note: pact_session.py (in skills/pact-memory/scripts/) mirrors this logic
-# with a dynamic _context_file_path() function because skill scripts can't
-# import from hooks/shared/.
+# Note: pact_session.py (in skills/pact-memory/scripts/) composes the same
+# path in its own _context_file_path(), importing project_slug from here.
 _context_path: Path | None = None
 
 # Module-level cache: populated on first get_pact_context() call.
@@ -181,6 +180,31 @@ def _build_session_path(slug: str, session_id: str) -> Path:
     return candidate
 
 
+def project_slug(project_dir: str) -> str:
+    """Return the session slug for ``project_dir``: the basename of the
+    RESOLVED directory, so a project launched through a symlink takes its
+    target's name.
+
+    Single derivation for every session-scoped path (``init``,
+    ``get_session_dir``, ``reconstruct_session_dir``,
+    ``resolve_compact_summary_path``, ``build_context_cache``, and the
+    session_init / session_end / pact_session callers). The pact-memory
+    project id and the backlog key resolve the same way, so the three names
+    for one project agree.
+
+    Empty input returns "" (``Path("").resolve()`` is the CWD, and the slug
+    of no project must not become the CWD's name). When ``resolve()``
+    raises, fall back to the unresolved basename so an unresolvable path
+    keeps its previous slug. Never raises.
+    """
+    if not project_dir:
+        return ""
+    try:
+        return Path(project_dir).resolve().name
+    except (OSError, RuntimeError):
+        return Path(project_dir).name
+
+
 def resolve_compact_summary_path(input_data: dict) -> Path:
     """Where this frame's compact summary is written. TOTAL.
 
@@ -190,7 +214,7 @@ def resolve_compact_summary_path(input_data: dict) -> Path:
     never None: whoever loses the bytes loses the only copy, so degradation
     must re-home them, not drop them.
 
-    Composes ``_build_session_path(Path(project_dir).name, session_id)``
+    Composes ``_build_session_path(project_slug(project_dir), session_id)``
     (inheriting slug sanitization + traversal guard) with
     ``COMPACT_SUMMARY_NAME``; falls back to ``get_compact_summary_path()``.
     Reads ``CLAUDE_PROJECT_DIR`` from env inside the function, mirroring
@@ -208,7 +232,7 @@ def resolve_compact_summary_path(input_data: dict) -> Path:
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
     if session_id and project_dir:
         return (
-            _build_session_path(Path(project_dir).name, str(session_id))
+            _build_session_path(project_slug(project_dir), str(session_id))
             / COMPACT_SUMMARY_NAME
         )
     return get_compact_summary_path()
@@ -246,7 +270,8 @@ def init(input_data: dict) -> None:
     session-scoped context file path:
         ~/.claude/pact-sessions/{project-slug}/{session-id}/pact-session-context.json
 
-    Where project-slug is Path(project_dir).name (e.g., "PACT-Plugin").
+    Where project-slug is project_slug(project_dir): the resolved
+    directory's basename (e.g., "PACT-Plugin").
 
     If session_id or project_dir is unavailable, leaves _context_path as None.
     Readers will return _EMPTY_CONTEXT without attempting any file I/O.
@@ -283,7 +308,7 @@ def init(input_data: dict) -> None:
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
 
     if session_id and project_dir:
-        slug = Path(project_dir).name
+        slug = project_slug(project_dir)
         _context_path = (
             _build_session_path(slug, session_id) / "pact-session-context.json"
         )
@@ -977,7 +1002,7 @@ def get_session_dir() -> str:
     project_dir = get_project_dir()
     if not session_id or not project_dir:
         return ""
-    slug = Path(project_dir).name
+    slug = project_slug(project_dir)
     return str(_build_session_path(slug, session_id))
 
 
@@ -996,7 +1021,7 @@ def reconstruct_session_dir(project_dir: str, session_id: str) -> str:
 
       - session_id: sanitized via _UNSAFE_SLUG_CHARS_RE (mirrors the substitution
         init() applies to the id before building the context path).
-      - slug: derived as Path(project_dir).name and sanitized + traversal-guarded
+      - slug: derived by project_slug() and sanitized + traversal-guarded
         inside _build_session_path (the single source of truth for the slug leg).
 
     Routing BOTH axes through the writer's derivation (the regex for the id, the
@@ -1018,7 +1043,7 @@ def reconstruct_session_dir(project_dir: str, session_id: str) -> str:
     if not project_dir or not session_id:
         return ""
     safe_id = _UNSAFE_SLUG_CHARS_RE.sub("_", str(session_id))
-    slug = Path(project_dir).name
+    slug = project_slug(project_dir)
     return str(_build_session_path(slug, safe_id))
 
 
@@ -1540,7 +1565,7 @@ def build_context_cache(
     if _context_path is not None:
         target = _context_path
     elif session_id and project_dir:
-        slug = Path(project_dir).name
+        slug = project_slug(project_dir)
         target = (
             _build_session_path(slug, session_id) / "pact-session-context.json"
         )

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -181,16 +181,19 @@ def _build_session_path(slug: str, session_id: str) -> Path:
 
 
 def project_slug(project_dir: str) -> str:
-    """Return the session slug for ``project_dir``: the basename of the
-    RESOLVED directory, so a project launched through a symlink takes its
-    target's name.
+    """Return the session slug for ``project_dir``: the resolved basename of
+    the directory CLAUDE_PROJECT_DIR names, so a project launched through a
+    symlink takes its target's name, as the pact-memory project id and the
+    backlog key do.
 
     Single derivation for every session-scoped path (``init``,
     ``get_session_dir``, ``reconstruct_session_dir``,
     ``resolve_compact_summary_path``, ``build_context_cache``, and the
     session_init / session_end / pact_session callers). The pact-memory
-    project id and the backlog key resolve the same way, so the three names
-    for one project agree.
+    project id and the backlog key resolve a symlink the same way and share
+    the fallback below, but the slug never normalises to a repository's main
+    root: a worktree or in-repo subdirectory session keeps its own session
+    directory.
 
     Empty input returns "" (``Path("").resolve()`` is the CWD, and the slug
     of no project must not become the CWD's name). When ``resolve()``

--- a/pact-plugin/skills/pact-memory/scripts/memory_api.py
+++ b/pact-plugin/skills/pact-memory/scripts/memory_api.py
@@ -333,31 +333,35 @@ class PACTMemory:
             # repo root. The rewrite fires when git resolves a main repo whose
             # root differs from the env path; only a repo-root env path or a
             # non-git path (where the main anchor equals, or cannot be resolved
-            # from, the env path) keeps the original basename.
+            # from, the env path) keeps the env basename — RESOLVED, so a
+            # symlinked project dir names its target, which is the path the
+            # git branch above and the backlog writer already record. A path
+            # that will not resolve keeps its unresolved basename.
             # The local name is env_main_root, NOT main_repo_root: rebinding
             # the module-level helper's own name inside this method would make
             # it local for the whole method and raise UnboundLocalError on the
             # call itself.
+            try:
+                env_root = Path(project_dir).resolve()
+            except (OSError, RuntimeError):
+                env_root = None
             env_main_root = main_repo_root(project_dir)
-            if env_main_root is not None:
-                try:
-                    # Compare via normcase so a case-insensitive filesystem does
-                    # not fire the rewrite for paths that differ only in case
-                    # (a no-op on case-sensitive systems, where normcase is
-                    # identity).
-                    env_root = Path(project_dir).resolve()
-                except OSError:
-                    env_root = None
-                if env_root is not None and os.path.normcase(
-                    str(env_main_root)
-                ) != os.path.normcase(str(env_root)):
-                    logger.debug(
-                        "project_id detected from CLAUDE_PROJECT_DIR worktree main repo: %s",
-                        env_main_root.name,
-                    )
-                    return env_main_root.name
-            logger.debug("project_id detected from CLAUDE_PROJECT_DIR: %s", Path(project_dir).name)
-            return Path(project_dir).name
+            # Compare via normcase so a case-insensitive filesystem does not
+            # fire the rewrite for paths that differ only in case (a no-op on
+            # case-sensitive systems, where normcase is identity).
+            if (
+                env_main_root is not None
+                and env_root is not None
+                and os.path.normcase(str(env_main_root)) != os.path.normcase(str(env_root))
+            ):
+                logger.debug(
+                    "project_id detected from CLAUDE_PROJECT_DIR worktree main repo: %s",
+                    env_main_root.name,
+                )
+                return env_main_root.name
+            project_name = (env_root or Path(project_dir)).name
+            logger.debug("project_id detected from CLAUDE_PROJECT_DIR: %s", project_name)
+            return project_name
 
         # Strategy 2: Git repository root (worktree-safe)
         # main_repo_root() carries the --git-common-dir resolution and the

--- a/pact-plugin/skills/pact-memory/scripts/pact_session.py
+++ b/pact-plugin/skills/pact-memory/scripts/pact_session.py
@@ -38,7 +38,11 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[3] / "hooks"))
 
 from shared.paths import get_claude_config_dir  # noqa: E402  # requires the sys.path bootstrap above
-from shared.pact_context import project_slug  # noqa: E402  # requires the sys.path bootstrap above
+from shared.pact_context import (  # noqa: E402  # requires the sys.path bootstrap above
+    _UNSAFE_SLUG_CHARS_RE,
+    _build_session_path,
+    project_slug,
+)
 
 
 def _context_file_path(session_id: str, project_dir: str) -> Path | None:
@@ -49,9 +53,9 @@ def _context_file_path(session_id: str, project_dir: str) -> Path | None:
 
     Returns the session-scoped path when both identifiers are provided:
         <config-root>/pact-sessions/{project-slug}/{session-id}/pact-session-context.json
-    where the config root is resolved by get_claude_config_dir() and project-slug
-    is project_slug(project_dir), the resolved directory's basename
-    (e.g., "PACT-Plugin").
+    built by the writers' own _build_session_path, so the slug
+    (project_slug(project_dir), the resolved directory's basename) and the
+    session id carry the same sanitisation the writer applied.
 
     Returns None when either identifier is missing — callers should treat
     this as "no context file available" and return a safe default.
@@ -62,10 +66,9 @@ def _context_file_path(session_id: str, project_dir: str) -> Path | None:
     same purpose (testable there because hooks call init() after parsing stdin).
     """
     if session_id and project_dir:
-        slug = project_slug(project_dir)
         return (
-            get_claude_config_dir() / "pact-sessions"
-            / slug / session_id / "pact-session-context.json"
+            _build_session_path(project_slug(project_dir), session_id)
+            / "pact-session-context.json"
         )
     return None
 
@@ -87,7 +90,9 @@ def _resolve_context_on_disk(env_session: str) -> str:
     """
     try:
         sessions_root = get_claude_config_dir() / "pact-sessions"
-        matches = list(sessions_root.glob(f"*/{env_session}/pact-session-context.json"))
+        # The writers collapsed unsafe characters in the id; match that name.
+        safe_session = _UNSAFE_SLUG_CHARS_RE.sub("_", env_session)
+        matches = list(sessions_root.glob(f"*/{safe_session}/pact-session-context.json"))
     except OSError:
         return ""
 

--- a/pact-plugin/skills/pact-memory/scripts/pact_session.py
+++ b/pact-plugin/skills/pact-memory/scripts/pact_session.py
@@ -10,8 +10,8 @@ The context file is written once per session by session_init.py and
 read by all subsequent hooks and skill scripts.
 
 Note: hooks/shared/pact_context.py has the authoritative implementation.
-This module mirrors the Path(project_dir).name slug logic, and IMPORTS the
-config-root resolver rather than re-implementing it (see the bootstrap below).
+This module IMPORTS the slug derivation and the config-root resolver rather
+than re-implementing them (see the bootstrap below).
 """
 
 from __future__ import annotations
@@ -38,6 +38,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[3] / "hooks"))
 
 from shared.paths import get_claude_config_dir  # noqa: E402  # requires the sys.path bootstrap above
+from shared.pact_context import project_slug  # noqa: E402  # requires the sys.path bootstrap above
 
 
 def _context_file_path(session_id: str, project_dir: str) -> Path | None:
@@ -49,7 +50,8 @@ def _context_file_path(session_id: str, project_dir: str) -> Path | None:
     Returns the session-scoped path when both identifiers are provided:
         <config-root>/pact-sessions/{project-slug}/{session-id}/pact-session-context.json
     where the config root is resolved by get_claude_config_dir() and project-slug
-    is Path(project_dir).name (e.g., "PACT-Plugin").
+    is project_slug(project_dir), the resolved directory's basename
+    (e.g., "PACT-Plugin").
 
     Returns None when either identifier is missing — callers should treat
     this as "no context file available" and return a safe default.
@@ -60,7 +62,7 @@ def _context_file_path(session_id: str, project_dir: str) -> Path | None:
     same purpose (testable there because hooks call init() after parsing stdin).
     """
     if session_id and project_dir:
-        slug = Path(project_dir).name
+        slug = project_slug(project_dir)
         return (
             get_claude_config_dir() / "pact-sessions"
             / slug / session_id / "pact-session-context.json"

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -4432,6 +4432,10 @@ def _umbrella(tmp_path, name="umbrella"):
         f"the tmp dir resolves to a repository, so it cannot stand in for an "
         f"umbrella: {path}"
     )
+    assert backlog_store._enclosing_checkout(path.resolve()) is None, (
+        f"a `.git` sits at or above the tmp dir, so it cannot stand in for an "
+        f"umbrella: {path}"
+    )
     return path
 
 
@@ -4517,6 +4521,7 @@ def test_an_unset_or_non_directory_project_dir_still_refuses(tmp_path, monkeypat
         backlog.project_root()
     except backlog.BacklogWriteError as exc:
         assert "CLAUDE_PROJECT_DIR" in str(exc), "the refusal names no remedy"
+        assert "unset" in str(exc), "the refusal does not say the variable is unset"
     else:
         raise AssertionError("an unset CLAUDE_PROJECT_DIR resolved a root")
 
@@ -4527,8 +4532,8 @@ def test_an_unset_or_non_directory_project_dir_still_refuses(tmp_path, monkeypat
     monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(not_a_dir))
     try:
         backlog.project_root()
-    except backlog.BacklogWriteError:
-        pass
+    except backlog.BacklogWriteError as exc:
+        assert str(not_a_dir) in str(exc), "the refusal does not echo the rejected value"
     else:
         raise AssertionError("a non-directory CLAUDE_PROJECT_DIR resolved a root")
     assert backlog.main(["--backlog-dir", str(store), "add", "x"]) == 2
@@ -4539,10 +4544,9 @@ def test_an_umbrella_backlog_is_found_again_by_the_read_path(tmp_path, monkeypat
     """Round trip: a backlog written from an umbrella is the one the git-free
     read path selects for that umbrella, and NOT for a sibling umbrella.
 
-    The control is load-bearing. The read path also admits a subdirectory of
-    a recorded checkout through its enclosing-checkout rung, so a match
-    alone could be that rung rather than exact membership; a sibling that
-    must NOT match pins the mechanism.
+    The control is load-bearing. A reader that matched every file would pass
+    the positive half; a sibling that must NOT match pins that the match is
+    on this umbrella's recorded root and not on the store having one file.
 
     RED WHEN the writer stores a form of the path the reader does not
     resolve to, or when the reader stops matching a git-less root.
@@ -4563,3 +4567,97 @@ def test_an_umbrella_backlog_is_found_again_by_the_read_path(tmp_path, monkeypat
 
     miss, _ = backlog_store.find_for(str(sibling), store)
     assert miss is None, f"a sibling umbrella claimed the backlog: {miss}"
+
+
+def test_a_directory_inside_a_repository_git_cannot_read_still_refuses(tmp_path, monkeypatch):
+    """When git resolves nothing but a `.git` sits at or above the env path,
+    the write path refuses rather than keying a backlog on a subdirectory or
+    a linked worktree. A git outage must not mint a second identity for a
+    project that every git-present session keys on its main root.
+
+    RED WHEN the fallback accepts any existing directory once git is silent.
+    """
+    main = _repo(tmp_path / "main")
+    sub = main / "pact-plugin" / "hooks"
+    sub.mkdir(parents=True)
+    linked = tmp_path / "wt"
+    subprocess.run(["git", "-C", str(main), "worktree", "add", "-q", str(linked), "-b", "wt"],
+                   check=True, capture_output=True)
+    store = tmp_path / "store"
+    store.mkdir()
+    real = backlog._memory_api()
+
+    class _NoGit:
+        PACTMemory = real.PACTMemory
+
+        @staticmethod
+        def main_repo_root(start=None):
+            return None
+
+    monkeypatch.setattr(backlog, "_memory_api", lambda: _NoGit)
+    for env_path in (sub, linked):
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(env_path))
+        try:
+            root = backlog.project_root()
+        except backlog.BacklogWriteError as exc:
+            assert str(env_path) in str(exc), "the refusal does not echo the path"
+            assert "repository" in str(exc)
+        else:
+            raise AssertionError(f"{env_path} did not refuse; it resolved {root}")
+        assert backlog.main(["--backlog-dir", str(store), "add", "x"]) == 2
+        assert list(store.iterdir()) == [], f"a refused write left a file: {list(store.iterdir())}"
+
+
+def test_a_symlinked_umbrella_stores_its_resolved_path(tmp_path, monkeypatch):
+    """project_path is the RESOLVED directory, never the link the session
+    opened it through, so the same umbrella reached by two names keys one
+    file on the path side.
+
+    RED WHEN the fallback stores the env path unresolved.
+    """
+    umbrella = _umbrella(tmp_path)
+    link = tmp_path / "link"
+    link.symlink_to(umbrella)
+    store = tmp_path / "store"
+    store.mkdir()
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(link))
+
+    assert backlog.main(["--backlog-dir", str(store), "add", "Via the link"]) == 0
+    written = list(store.glob("*.json"))
+    assert len(written) == 1, written
+    data = json.loads(written[0].read_text(encoding="utf-8"))
+    assert data["project_path"] == str(umbrella.resolve())
+    assert data["roots"] == [str(umbrella.resolve())]
+
+
+def test_a_git_less_subdirectory_of_an_umbrella_is_its_own_project(tmp_path, monkeypatch):
+    """A git-less subdirectory of an umbrella keys as ITS OWN project on both
+    sides: the detector names it by its basename, the writer stores it as
+    project_path, and the read path opened there does not match the
+    umbrella's file. A containment reader would bind the subdirectory to the
+    umbrella on the path side while the name side still keyed it alone.
+    """
+    umbrella = _umbrella(tmp_path)
+    sub = umbrella / "notes"
+    sub.mkdir()
+    store = tmp_path / "store"
+    store.mkdir()
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(umbrella))
+    assert backlog.main(["--backlog-dir", str(store), "add", "Umbrella item"]) == 0
+    umbrella_file = store / f"{umbrella.name}.json"
+
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(sub))
+    assert backlog._memory_api().PACTMemory._detect_project_id() == sub.name
+    match, _ = backlog_store.find_for(str(sub), store)
+    assert match is None, f"the subdirectory matched the umbrella's file: {match}"
+
+    assert backlog.main(["--backlog-dir", str(store), "add", "Subdirectory item"]) == 0
+    own = store / f"{sub.name}.json"
+    assert own.exists(), list(store.iterdir())
+    data = json.loads(own.read_text(encoding="utf-8"))
+    assert data["project_path"] == str(sub.resolve())
+    assert data["roots"] == [str(sub.resolve())]
+    match, _ = backlog_store.find_for(str(sub), store)
+    assert match == own
+    match, _ = backlog_store.find_for(str(umbrella), store)
+    assert match == umbrella_file

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -4683,3 +4683,36 @@ def test_a_symlinked_umbrella_is_named_after_its_resolved_path(tmp_path, monkeyp
     assert [p.name for p in store.iterdir()] == [written.name], list(store.iterdir())
     data = json.loads(written.read_text(encoding="utf-8"))
     assert data["project"] == Path(data["project_path"]).name
+
+
+def test_an_unresolvable_project_dir_falls_back_to_its_unresolved_path(tmp_path, monkeypatch):
+    """When the env path cannot be resolved, the writer stores it UNRESOLVED
+    and still exits 0, the same fallback the detector and the session-slug
+    derivation take. A raise here would traceback the CLI instead of exiting 2.
+
+    The env path is a symlink so the unresolved and resolved strings differ;
+    on a plain tmp path they are identical and the value assertion is empty.
+
+    RED WHEN rung 2 resolves without a guard.
+    """
+    umbrella = _umbrella(tmp_path)
+    link = tmp_path / "link"
+    link.symlink_to(umbrella)
+    store = tmp_path / "store"
+    store.mkdir()
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(link))
+    original = Path.resolve
+
+    def resolve(self, *args, **kwargs):
+        if str(self) == str(link):
+            raise OSError("simulated unresolvable path")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", resolve)
+
+    assert backlog.main(["--backlog-dir", str(store), "add", "x"]) == 0
+    written = list(store.glob("*.json"))
+    assert len(written) == 1, written
+    data = json.loads(written[0].read_text(encoding="utf-8"))
+    assert data["project_path"] == str(link)
+    assert data["roots"] == [str(link)]

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -4412,3 +4412,154 @@ def test_a_usage_error_and_a_refusal_exit_DIFFERENTLY(tmp_path):
         "a malformed invocation and a real refusal exit with the SAME code "
         f"({observed['malformed flag']}); the two are indistinguishable again"
     )
+
+
+# ---------------------------------------------------------------------------
+# project_root: a workspace umbrella with no git root of its own
+# ---------------------------------------------------------------------------
+
+def _umbrella(tmp_path, name="umbrella"):
+    """A git-less directory that is provably outside every checkout.
+
+    The positive control is the point: a tmp dir that happened to sit under a
+    repository would make git resolve THAT root, and every umbrella arm would
+    then exercise the repo branch while reading as the umbrella one.
+    """
+    path = tmp_path / name
+    path.mkdir()
+    memory_api = backlog._memory_api()
+    assert memory_api.main_repo_root(str(path)) is None, (
+        f"the tmp dir resolves to a repository, so it cannot stand in for an "
+        f"umbrella: {path}"
+    )
+    return path
+
+
+def test_an_umbrella_with_no_git_root_can_hold_a_backlog(tmp_path, monkeypatch, capsys):
+    """A directory whose children are separate repos, itself under no `.git`,
+    must key a backlog on ITSELF: show, add and set all succeed, and the
+    stored project_path and roots both equal the resolved umbrella path.
+
+    Real git throughout: the git-unresolvable branch is the thing under test,
+    so stubbing the resolver would leave nothing being tested.
+
+    RED WHEN project_root() refuses every path git cannot resolve.
+    """
+    umbrella = _umbrella(tmp_path)
+    store = tmp_path / "store"
+    store.mkdir()
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(umbrella))
+    expected = str(umbrella.resolve())
+
+    assert backlog.main(["--backlog-dir", str(store), "show", "--no-reconcile"]) == 0
+    assert list(store.iterdir()) == [], "show wrote a file"
+
+    assert backlog.main(["--backlog-dir", str(store), "add", "An umbrella item"]) == 0
+    written = store / f"{umbrella.name}.json"
+    assert written.exists(), f"add wrote nothing; store holds {list(store.iterdir())}"
+    data = json.loads(written.read_text(encoding="utf-8"))
+    assert data["project"] == umbrella.name
+    assert data["project_path"] == expected
+    assert data["roots"] == [expected]
+    item_id = data["items"][0]["id"]
+
+    assert backlog.main(
+        ["--backlog-dir", str(store), "set", item_id, "--status", "active"]) == 0
+    data = json.loads(written.read_text(encoding="utf-8"))
+    assert data["items"][0]["status"] == "active"
+    assert data["project_path"] == expected
+    assert data["roots"] == [expected]
+
+
+def test_the_umbrella_fallback_never_fires_when_git_resolves(tmp_path, monkeypatch):
+    """The env path BELOW a repo root, and a linked worktree, both keep
+    normalising to the MAIN root. A fallback that fired here would store a
+    subdirectory or a worktree as project_path and fragment the project
+    across its own checkouts.
+
+    RED WHEN project_root() prefers the env path over git's answer.
+    """
+    main = _repo(tmp_path / "main")
+    sub = main / "pact-plugin" / "hooks"
+    sub.mkdir(parents=True)
+    linked = tmp_path / "wt"
+    subprocess.run(["git", "-C", str(main), "worktree", "add", "-q", str(linked), "-b", "wt"],
+                   check=True, capture_output=True)
+
+    for env_path in (main, sub, linked):
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(env_path))
+        assert backlog.project_root() == main.resolve(), (
+            f"CLAUDE_PROJECT_DIR={env_path} did not normalise to the main root"
+        )
+
+
+def test_an_unset_or_non_directory_project_dir_still_refuses(tmp_path, monkeypatch):
+    """The umbrella fallback needs an EXISTING DIRECTORY in CLAUDE_PROJECT_DIR.
+    With the variable unset, or naming a file, and git unable to resolve, the
+    write path refuses as before and writes nothing.
+
+    RED WHEN the fallback accepts an absent or non-directory env path.
+    """
+    store = tmp_path / "store"
+    store.mkdir()
+    real = backlog._memory_api()
+
+    class _NoGit:
+        PACTMemory = real.PACTMemory
+
+        @staticmethod
+        def main_repo_root(start=None):
+            return None
+
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.setattr(backlog, "_memory_api", lambda: _NoGit)
+    try:
+        backlog.project_root()
+    except backlog.BacklogWriteError as exc:
+        assert "CLAUDE_PROJECT_DIR" in str(exc), "the refusal names no remedy"
+    else:
+        raise AssertionError("an unset CLAUDE_PROJECT_DIR resolved a root")
+
+    # A file, with REAL git: `git -C <file>` cannot run there.
+    monkeypatch.setattr(backlog, "_memory_api", lambda: real)
+    not_a_dir = tmp_path / "file"
+    not_a_dir.write_text("x")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(not_a_dir))
+    try:
+        backlog.project_root()
+    except backlog.BacklogWriteError:
+        pass
+    else:
+        raise AssertionError("a non-directory CLAUDE_PROJECT_DIR resolved a root")
+    assert backlog.main(["--backlog-dir", str(store), "add", "x"]) == 2
+    assert list(store.iterdir()) == [], "a refused write left a file behind"
+
+
+def test_an_umbrella_backlog_is_found_again_by_the_read_path(tmp_path, monkeypatch):
+    """Round trip: a backlog written from an umbrella is the one the git-free
+    read path selects for that umbrella, and NOT for a sibling umbrella.
+
+    The control is load-bearing. The read path also admits a subdirectory of
+    a recorded checkout through its enclosing-checkout rung, so a match
+    alone could be that rung rather than exact membership; a sibling that
+    must NOT match pins the mechanism.
+
+    RED WHEN the writer stores a form of the path the reader does not
+    resolve to, or when the reader stops matching a git-less root.
+    """
+    umbrella = _umbrella(tmp_path)
+    sibling = _umbrella(tmp_path, "sibling")
+    store = tmp_path / "store"
+    store.mkdir()
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(umbrella))
+    assert backlog.main(["--backlog-dir", str(store), "add", "Round trip item"]) == 0
+    written = store / f"{umbrella.name}.json"
+
+    match, unreadable = backlog_store.find_for(str(umbrella), store)
+    assert unreadable == []
+    assert match == written, f"the read path selected {match}"
+    notice = backlog_store.session_block(str(umbrella), backlog_dir=store)
+    assert "Round trip item" in notice.context
+
+    miss, _ = backlog_store.find_for(str(sibling), store)
+    assert miss is None, f"a sibling umbrella claimed the backlog: {miss}"

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -4726,3 +4726,19 @@ def test_an_unresolvable_project_dir_falls_back_to_its_unresolved_path(tmp_path,
     data = json.loads(written[0].read_text(encoding="utf-8"))
     assert data["project_path"] == str(link)
     assert data["roots"] == [str(link)]
+
+
+def test_an_unset_project_dir_resolves_the_root_from_the_cwd_repository(tmp_path, monkeypatch):
+    """With CLAUDE_PROJECT_DIR unset, the writer resolves git from the process
+    cwd and returns the MAIN root, so a write run from inside a checkout with
+    no env anchor still keys on the repository rather than refusing.
+
+    RED WHEN rung 1 stops passing None through to git as "use the cwd".
+    """
+    main = _repo(tmp_path / "main")
+    sub = main / "pact-plugin" / "hooks"
+    sub.mkdir(parents=True)
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.chdir(sub)
+
+    assert backlog.project_root() == main.resolve()

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -904,10 +904,11 @@ def test_the_import_closure_probe_detects_a_forbidden_import(tmp_path):
 # --------------------------------------------------------------------------
 # validation: rejected, never truncated or silently dropped
 # --------------------------------------------------------------------------
-def test_an_over_long_note_is_rejected_and_nothing_is_written(tmp_path):
+def test_an_over_long_note_is_rejected_and_nothing_is_written(tmp_path, monkeypatch):
     """RED WHEN the writer truncates. Truncation would lose the intent the
     note exists to carry, so the file must stay absent rather than gain a
     shortened note."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))  # the writer keys on this, never the cwd
     path = tmp_path / "demo.json"
     data = _backlog(tmp_path, items=[_item(note="x" * 201)])
 
@@ -918,16 +919,18 @@ def test_an_over_long_note_is_rejected_and_nothing_is_written(tmp_path):
     assert not path.exists(), "a rejected backlog was written anyway"
 
 
-def test_a_note_at_the_limit_is_accepted(tmp_path):
+def test_a_note_at_the_limit_is_accepted(tmp_path, monkeypatch):
     """The boundary case. RED WHEN the comparison is off by one and rejects a
     note of exactly the permitted length."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))  # the writer keys on this, never the cwd
     path = tmp_path / "demo.json"
     assert backlog.save(_backlog(tmp_path, items=[_item(note="x" * 200)]), path) == []
     assert path.exists()
 
 
-def test_a_sixth_memory_id_is_rejected_rather_than_dropped(tmp_path):
+def test_a_sixth_memory_id_is_rejected_rather_than_dropped(tmp_path, monkeypatch):
     """RED WHEN the writer keeps five and discards the sixth silently."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))  # the writer keys on this, never the cwd
     path = tmp_path / "demo.json"
     ids = [f"{index:032x}" for index in range(6)]
 
@@ -937,9 +940,10 @@ def test_a_sixth_memory_id_is_rejected_rather_than_dropped(tmp_path):
     assert not path.exists()
 
 
-def test_an_absolute_plan_path_is_rejected_at_write_time(tmp_path):
+def test_an_absolute_plan_path_is_rejected_at_write_time(tmp_path, monkeypatch):
     """RED WHEN an absolute plan path is stored. An absolute path captured
     inside a worktree points into a directory `git worktree remove` deletes."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))  # the writer keys on this, never the cwd
     path = tmp_path / "demo.json"
     problems = backlog.save(
         _backlog(tmp_path, items=[_item(plan="/absolute/plan.md")]), path
@@ -1790,6 +1794,7 @@ def test_show_puts_the_item_id_in_reach_of_the_agent(tmp_path, monkeypatch, caps
 
     RED WHEN the id is dropped from the rendered line.
     """
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))  # the writer keys on this, never the cwd
     path = tmp_path / "b.json"
     backlog.save(_backlog(tmp_path, items=[_item(item_id="beef", title="FIND ME")]), path)
     monkeypatch.setattr(backlog, "store_path", lambda backlog_dir=None: path)
@@ -2477,7 +2482,7 @@ def test_repair_moves_every_corrupt_shape_including_non_utf8(tmp_path):
         assert aside.read_bytes() == raw, f"{label}: bytes changed in the move"
 
 
-def test_repair_refuses_what_it_cannot_read_and_leaves_it_in_place(tmp_path):
+def test_repair_refuses_what_it_cannot_read_and_leaves_it_in_place(tmp_path, monkeypatch):
     """Refusing is half; leaving the thing in place is the other half.
 
     A returncode-only assertion passes for a guard that refuses and moves the
@@ -2493,6 +2498,7 @@ def test_repair_refuses_what_it_cannot_read_and_leaves_it_in_place(tmp_path):
     would pass vacuously there. The directory also proves the distinction
     lives below the handler's existence check — it passes `exists()`.
     """
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))  # the writer keys on this, never the cwd
     readable = tmp_path / "readable.json"
     backlog.save(_backlog(tmp_path), readable)
     before = readable.read_bytes()
@@ -2515,13 +2521,14 @@ def test_repair_refuses_what_it_cannot_read_and_leaves_it_in_place(tmp_path):
     assert unreadable.is_dir(), "a refused repair moved the directory anyway"
 
 
-def test_force_overrides_every_refusal_branch(tmp_path):
+def test_force_overrides_every_refusal_branch(tmp_path, monkeypatch):
     """The capability the user deliberately kept, pinned as kept.
 
     All three branches: readable, unreadable, and corrupt. Message ORDER is
     asserted rather than wording — the unreadable-force text is being reworded
     and pinning it would redden on a copy edit.
     """
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))  # the writer keys on this, never the cwd
     readable = tmp_path / "readable.json"
     backlog.save(_backlog(tmp_path), readable)
     aside, message = backlog.repair(readable, force=True)
@@ -2542,7 +2549,7 @@ def test_force_overrides_every_refusal_branch(tmp_path):
     )
 
 
-def test_the_success_message_says_only_what_was_established(tmp_path):
+def test_the_success_message_says_only_what_was_established(tmp_path, monkeypatch):
     """The caveat appears on exactly one path, and no path calls the file corrupt.
 
     THE ABSENCES ARE THE LOAD-BEARING HALF. A caveat glued to every move would
@@ -2558,6 +2565,7 @@ def test_the_success_message_says_only_what_was_established(tmp_path):
     Each case asserts the message was PRODUCED before asserting what it lacks —
     an absence assertion passes when the code never ran.
     """
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))  # the writer keys on this, never the cwd
     def prose(name, force=False, raw=None, as_dir=False):
         path = tmp_path / name
         if as_dir:
@@ -2929,7 +2937,7 @@ def test_the_age_line_keys_on_the_trigger_and_not_on_the_anchor(monkeypatch, tmp
     )
 
 
-def test_a_refused_write_preserves_the_first_writers_data_and_stays_armed(tmp_path):
+def test_a_refused_write_preserves_the_first_writers_data_and_stays_armed(tmp_path, monkeypatch):
     """A guard that refuses AND loses the data passes a refusal-only assertion.
 
     THE TWO WRITERS MUST DIVERGE. Two byte-identical loads give the guard
@@ -2943,6 +2951,7 @@ def test_a_refused_write_preserves_the_first_writers_data_and_stays_armed(tmp_pa
     RED WHEN the CAS is removed, when the baseline is popped on the refusal
     path, or when the refusal writes anyway.
     """
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))  # the writer keys on this, never the cwd
     path = tmp_path / "demo.json"
     _write(tmp_path, "demo.json", _backlog(tmp_path, items=[_item(title="ORIGINAL")]))
 
@@ -3900,7 +3909,7 @@ def test_a_non_string_ref_is_reported_by_the_schema_check(tmp_path):
     )
 
 
-def test_a_bad_field_on_one_item_locks_writes_to_every_other_item(tmp_path):
+def test_a_bad_field_on_one_item_locks_writes_to_every_other_item(tmp_path, monkeypatch):
     """THE BYSTANDER LOCK, and both halves matter.
 
     A bad `ref` on item A refuses a write to item B — the file is validated as
@@ -3911,6 +3920,7 @@ def test_a_bad_field_on_one_item_locks_writes_to_every_other_item(tmp_path):
     RED WHEN the `ref` rule is removed (the write succeeds), and RED WHEN the
     message stops naming item A.
     """
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))  # the writer keys on this, never the cwd
     store, _ = _cli_store(tmp_path, [
         _item(item_id="aaaa", title="THE BROKEN ONE", ref=5),
         _item(item_id="bbbb", title="THE BYSTANDER"),

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -4661,3 +4661,25 @@ def test_a_git_less_subdirectory_of_an_umbrella_is_its_own_project(tmp_path, mon
     assert match == own
     match, _ = backlog_store.find_for(str(umbrella), store)
     assert match == umbrella_file
+
+
+def test_a_symlinked_umbrella_is_named_after_its_resolved_path(tmp_path, monkeypatch):
+    """The file NAME and the stored project_path come from ONE directory: a
+    session that opens an umbrella through a symlink writes the file the
+    resolved directory's sessions read, not a second file named after the
+    link.
+
+    RED WHEN the detector names the link while the writer stores the target.
+    """
+    umbrella = _umbrella(tmp_path)
+    link = tmp_path / "link"
+    link.symlink_to(umbrella)
+    store = tmp_path / "store"
+    store.mkdir()
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(link))
+
+    assert backlog.main(["--backlog-dir", str(store), "add", "Via the link"]) == 0
+    written = store / f"{umbrella.name}.json"
+    assert [p.name for p in store.iterdir()] == [written.name], list(store.iterdir())
+    data = json.loads(written.read_text(encoding="utf-8"))
+    assert data["project"] == Path(data["project_path"]).name

--- a/pact-plugin/tests/test_compact_summary_session_scope.py
+++ b/pact-plugin/tests/test_compact_summary_session_scope.py
@@ -224,6 +224,29 @@ class TestLegacyDrainTwoPass:
         assert len(archives) == 1
         assert archives[0].read_text(encoding="utf-8") == "LEGACY SENTINEL"
 
+    def test_symlinked_project_dir_drains_under_target_basename(
+        self, tmp_path, monkeypatch
+    ):
+        """The drain lands where the session's own writers land: under the
+        resolved project basename, never the symlink's name."""
+        from session_init import _archive_stale_compact_summary
+        from shared.constants import get_compact_summary_path
+
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "cfg"))
+        real = tmp_path / "real-project"
+        real.mkdir()
+        link = tmp_path / "link-name"
+        link.symlink_to(real, target_is_directory=True)
+        root = get_compact_summary_path()
+        root.parent.mkdir(parents=True, exist_ok=True)
+        root.write_text("LEGACY SENTINEL", encoding="utf-8")
+
+        _archive_stale_compact_summary(_SID_A, str(link))
+
+        dest_dir = tmp_path / "cfg" / "pact-sessions" / "real-project" / _SID_A
+        assert len(list(dest_dir.glob("compact-summary-*.txt"))) == 1
+        assert not (tmp_path / "cfg" / "pact-sessions" / "link-name").exists()
+
 
 class TestDegradationIsLossFree:
     """Degradation pin: an unidentified frame's bytes exist SOMEWHERE under

--- a/pact-plugin/tests/test_pact_context.py
+++ b/pact-plugin/tests/test_pact_context.py
@@ -116,7 +116,7 @@ init() ordering:
 
 Session-scoped path E2E:
 65. write_context → init → get_team_name full session-scoped cycle
-66. Session-scoped path uses Path(project_dir).name as slug
+66. Session-scoped path uses the resolved project dir's basename as slug
 
 pact_session.py path:
 67. _context_file_path returns session-scoped path when both args provided
@@ -397,6 +397,103 @@ class TestGetSessionDir:
         pact_context(session_id="", project_dir="")
 
         assert get_session_dir() == ""
+
+
+class TestProjectSlug:
+    """The session slug is the RESOLVED project directory's basename.
+
+    One helper, project_slug(), feeds every session-path derivation, so a
+    project launched through a symlinked directory names the same slug the
+    pact-memory project id and the backlog key already use: the target's
+    basename, never the link's.
+    """
+
+    @staticmethod
+    def _linked_project(tmp_path):
+        real = tmp_path / "real-project"
+        real.mkdir()
+        link = tmp_path / "link-name"
+        link.symlink_to(real, target_is_directory=True)
+        return real, link
+
+    def test_symlinked_dir_yields_target_basename(self, tmp_path):
+        from shared.pact_context import project_slug
+
+        _real, link = self._linked_project(tmp_path)
+        assert project_slug(str(link)) == "real-project"
+
+    def test_plain_dir_keeps_own_basename(self, tmp_path):
+        from shared.pact_context import project_slug
+
+        plain = tmp_path / "plain-project"
+        plain.mkdir()
+        assert project_slug(str(plain)) == "plain-project"
+
+    def test_empty_input_is_empty_not_cwd(self):
+        """Path('').resolve() is the CWD; the slug of nothing is nothing."""
+        from shared.pact_context import project_slug
+
+        assert project_slug("") == ""
+
+    def test_unresolvable_path_keeps_unresolved_basename(self, monkeypatch):
+        from shared.pact_context import project_slug
+
+        def _raise(self, *args, **kwargs):
+            raise OSError("resolve refused")
+
+        monkeypatch.setattr(Path, "resolve", _raise)
+        assert project_slug("/nowhere/link-name") == "link-name"
+
+    def test_get_session_dir_uses_target_basename(self, pact_context, tmp_path):
+        from shared.pact_context import get_session_dir
+
+        _real, link = self._linked_project(tmp_path)
+        pact_context(session_id="sid-1", project_dir=str(link))
+
+        result = get_session_dir()
+        assert result.endswith("pact-sessions/real-project/sid-1")
+        assert "/link-name/" not in result
+
+    def test_reconstruct_session_dir_uses_target_basename(self, tmp_path):
+        from shared.pact_context import reconstruct_session_dir
+
+        _real, link = self._linked_project(tmp_path)
+        result = reconstruct_session_dir(str(link), "sid-2")
+        assert result.endswith("pact-sessions/real-project/sid-2")
+        assert "/link-name/" not in result
+
+    def test_resolve_compact_summary_path_uses_target_basename(
+        self, tmp_path, monkeypatch
+    ):
+        from shared.pact_context import resolve_compact_summary_path
+
+        _real, link = self._linked_project(tmp_path)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(link))
+        result = str(resolve_compact_summary_path({"session_id": "sid-3"}))
+        assert "pact-sessions/real-project/sid-3/" in result
+        assert "/link-name/" not in result
+
+    def test_init_uses_target_basename(self, tmp_path, monkeypatch):
+        import shared.pact_context as ctx_module
+
+        _real, link = self._linked_project(tmp_path)
+        monkeypatch.setattr(ctx_module, "_context_path", None)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(link))
+        ctx_module.init({"session_id": "sid-4"})
+        result = str(ctx_module._context_path)
+        assert "pact-sessions/real-project/sid-4/" in result
+        assert "/link-name/" not in result
+
+    def test_build_context_cache_uses_target_basename(self, tmp_path, monkeypatch):
+        import shared.pact_context as ctx_module
+
+        _real, link = self._linked_project(tmp_path)
+        monkeypatch.setattr(ctx_module, "_context_path", None)
+        target, _context = ctx_module.build_context_cache(
+            "session-abcd1234", "sid-5", str(link)
+        )
+        assert "pact-sessions/real-project/sid-5/" in str(target)
+        assert "/link-name/" not in str(target)
 
 
 class TestInit:
@@ -1665,7 +1762,7 @@ class TestSessionScopedPathE2E:
         assert ctx_module.get_project_dir() == project_dir
 
     def test_session_scoped_path_uses_project_dir_name_as_slug(self, monkeypatch, tmp_path):
-        """Slug should be Path(project_dir).name, not the full path."""
+        """Slug should be the project dir's basename, not the full path."""
         import shared.pact_context as ctx_module
 
         monkeypatch.setattr(ctx_module, "_context_path", None)
@@ -1706,6 +1803,20 @@ class TestPactSessionPath:
             / "PACT-Plugin" / "abc-session-123" / "pact-session-context.json"
         )
         assert result == expected
+
+    def test_symlinked_project_dir_uses_target_basename(self, monkeypatch, tmp_path):
+        """The skill-script path agrees with the hook slug for a symlinked dir."""
+        from scripts.pact_session import _context_file_path
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        real = tmp_path / "real-project"
+        real.mkdir()
+        link = tmp_path / "link-name"
+        link.symlink_to(real, target_is_directory=True)
+
+        result = str(_context_file_path("sid-6", str(link)))
+        assert "pact-sessions/real-project/sid-6/" in result
+        assert "/link-name/" not in result
 
     def test_returns_none_when_args_missing(self, monkeypatch, tmp_path):
         """_context_file_path with missing args should return None."""

--- a/pact-plugin/tests/test_pact_context.py
+++ b/pact-plugin/tests/test_pact_context.py
@@ -1818,6 +1818,37 @@ class TestPactSessionPath:
         assert "pact-sessions/real-project/sid-6/" in result
         assert "/link-name/" not in result
 
+    def test_dotted_project_name_lands_on_the_writers_sanitised_dir(
+        self, monkeypatch, tmp_path
+    ):
+        """The reader must look where build_session_path put the file."""
+        from scripts.pact_session import _context_file_path
+        from shared.pact_context import _build_session_path, project_slug
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = _context_file_path("sid-7", "/somewhere/my.project")
+
+        assert "/my_project/sid-7/" in str(result)
+        assert result == (
+            _build_session_path(project_slug("/somewhere/my.project"), "sid-7")
+            / "pact-session-context.json"
+        )
+
+    def test_disk_discovery_globs_the_sanitised_session_id(self, monkeypatch, tmp_path):
+        """An env session id with an unsafe character matches the directory
+        the writer named, not a raw pattern that matches nothing."""
+        from scripts.pact_session import _resolve_context_on_disk
+
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "relocated"))
+        context_file = (
+            tmp_path / "relocated" / "pact-sessions" / "proj" / "sid_8"
+            / "pact-session-context.json"
+        )
+        context_file.parent.mkdir(parents=True)
+        context_file.write_text(json.dumps({"session_id": "sid 8"}), encoding="utf-8")
+
+        assert _resolve_context_on_disk("sid 8") == "sid 8"
+
     def test_returns_none_when_args_missing(self, monkeypatch, tmp_path):
         """_context_file_path with missing args should return None."""
         from scripts.pact_session import _context_file_path

--- a/pact-plugin/tests/test_project_id.py
+++ b/pact-plugin/tests/test_project_id.py
@@ -22,6 +22,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+# The real detector, for the arms that need a real filesystem: a symlink cannot
+# be expressed through the replica-plus-mock style below. conftest.py puts
+# skills/pact-memory on sys.path.
+from scripts.memory_api import PACTMemory
+
 
 @pytest.fixture
 def clean_env_no_claude_project_dir():
@@ -133,7 +138,13 @@ def _detect_project_id_under_test():
         # repo root. The rewrite fires when git resolves a main repo whose
         # root differs from the env path; only a repo-root env path or a
         # non-git path (where the main anchor equals, or cannot be resolved
-        # from, the env path) keeps the original basename.
+        # from, the env path) keeps the env basename — RESOLVED, so a
+        # symlinked project dir names its target. A path that will not
+        # resolve keeps its unresolved basename.
+        try:
+            env_root = Path(project_dir).resolve()
+        except (OSError, RuntimeError):
+            env_root = None
         try:
             result = subprocess.run(
                 ["git", "-C", project_dir, "rev-parse", "--git-common-dir"],
@@ -150,8 +161,9 @@ def _detect_project_id_under_test():
                 # not fire the rewrite for paths that differ only in case
                 # (a no-op on case-sensitive systems, where normcase is
                 # identity).
-                env_root = Path(project_dir).resolve()
-                if os.path.normcase(str(main_repo_root)) != os.path.normcase(str(env_root)):
+                if env_root is not None and os.path.normcase(
+                    str(main_repo_root)
+                ) != os.path.normcase(str(env_root)):
                     logger.debug(
                         "project_id detected from CLAUDE_PROJECT_DIR worktree main repo: %s",
                         main_repo_root.name,
@@ -159,8 +171,9 @@ def _detect_project_id_under_test():
                     return main_repo_root.name
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             pass
-        logger.debug("project_id detected from CLAUDE_PROJECT_DIR: %s", Path(project_dir).name)
-        return Path(project_dir).name
+        project_name = (env_root or Path(project_dir)).name
+        logger.debug("project_id detected from CLAUDE_PROJECT_DIR: %s", project_name)
+        return project_name
 
     # Strategy 2: Git repository root (worktree-safe)
     # Uses --git-common-dir instead of --show-toplevel because the latter
@@ -706,3 +719,41 @@ class TestCwdSubdirectoryDetection:
             result = _detect_project_id_under_test()
 
         assert result == "claude-dir-proj"
+
+
+class TestSymlinkedProjectDir:
+    """Strategy 1 names the directory CLAUDE_PROJECT_DIR RESOLVES TO, not the
+    link it was reached through.
+
+    The backlog writer stores the resolved path, so a link basename here and a
+    target path there split one project into two names. Real detector, real
+    filesystem, real git for the repo arm: the resolve is the thing under test.
+    """
+
+    def test_symlink_to_git_less_dir_names_the_target(self, tmp_path, monkeypatch):
+        """RED WHEN Strategy 1 returns the unresolved env basename on the
+        git-less branch."""
+        target = tmp_path / "plain-target"
+        target.mkdir()
+        link = tmp_path / "plain-link"
+        link.symlink_to(target)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(link))
+        assert PACTMemory._detect_project_id() == "plain-target"
+
+    def test_symlink_to_repo_root_names_the_target(self, tmp_path, monkeypatch):
+        """RED WHEN Strategy 1 returns the unresolved env basename on the
+        branch where git's main root equals the env path."""
+        target = tmp_path / "repo-target"
+        target.mkdir()
+        subprocess.run(["git", "init", "-q", str(target)], check=True, capture_output=True)
+        link = tmp_path / "repo-link"
+        link.symlink_to(target)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(link))
+        assert PACTMemory._detect_project_id() == "repo-target"
+
+    def test_plain_dir_keeps_its_own_basename(self, tmp_path, monkeypatch):
+        """Regression pin: resolving a path that is not a link changes nothing."""
+        plain = tmp_path / "plain-dir"
+        plain.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(plain))
+        assert PACTMemory._detect_project_id() == "plain-dir"

--- a/pact-plugin/tests/test_session_end.py
+++ b/pact-plugin/tests/test_session_end.py
@@ -1331,6 +1331,51 @@ class TestCleanupOldSessions:
         assert not (tmp_path / "link-name" / under_old).exists()
         assert not (tmp_path / "real-project" / under_new).exists()
 
+    def test_raw_slugs_are_sanitised_before_the_sweep(self, tmp_path, monkeypatch):
+        """Every writer stored the sanitised name, so raw names with a dot
+        or a space must reach the same directory, once."""
+        import session_end
+
+        current_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        old_id = "11111111-2222-3333-4444-555555555555"
+        self._create_session_dir(tmp_path / "my_project", old_id, age_days=10)
+        swept = []
+        real = session_end._reap_slug_dir
+        monkeypatch.setattr(
+            session_end, "_reap_slug_dir",
+            lambda slug_dir, *a: (swept.append(slug_dir), real(slug_dir, *a)),
+        )
+
+        session_end.cleanup_old_sessions(
+            project_slug="my.project",
+            current_session_id=current_id,
+            sessions_dir=str(tmp_path),
+            max_age_days=7,
+            old_slug="my project",
+        )
+
+        assert swept == [tmp_path / "my_project"]
+        assert not (tmp_path / "my_project" / old_id).exists()
+
+    def test_dotdot_slug_never_leaves_the_sessions_root(self, tmp_path, monkeypatch):
+        import session_end
+
+        swept = []
+        monkeypatch.setattr(
+            session_end, "_reap_slug_dir", lambda slug_dir, *a: swept.append(slug_dir)
+        )
+        session_end.cleanup_old_sessions(
+            project_slug="..",
+            current_session_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            sessions_dir=str(tmp_path),
+            max_age_days=7,
+            old_slug="..",
+        )
+
+        # The allowlist collapses the whole run to one underscore.
+        assert swept == [tmp_path / "_"]
+        assert swept[0].resolve().is_relative_to(tmp_path.resolve())
+
     def test_plain_project_dir_sweeps_one_slug_dir_once(self, tmp_path, monkeypatch):
         import session_end
 

--- a/pact-plugin/tests/test_session_end.py
+++ b/pact-plugin/tests/test_session_end.py
@@ -34,6 +34,18 @@ class TestGetProjectSlug:
         with patch("session_end.get_project_dir", return_value="/Users/example/Sites/my-project"):
             assert get_project_slug() == "my-project"
 
+    def test_symlinked_project_dir_names_the_target(self, tmp_path):
+        """The reaper scans the slug the session was written under: the
+        resolved basename, so a symlinked launch dir does not orphan it."""
+        from session_end import get_project_slug
+
+        real = tmp_path / "real-project"
+        real.mkdir()
+        link = tmp_path / "link-name"
+        link.symlink_to(real, target_is_directory=True)
+        with patch("session_end.get_project_dir", return_value=str(link)):
+            assert get_project_slug() == "real-project"
+
     def test_returns_empty_when_no_project_dir(self):
         from session_end import get_project_slug
 

--- a/pact-plugin/tests/test_session_end.py
+++ b/pact-plugin/tests/test_session_end.py
@@ -1309,6 +1309,45 @@ class TestCleanupOldSessions:
         assert (slug_dir / current_id).exists()
         assert not (slug_dir / old_id).exists()
 
+    def test_sweeps_the_old_slug_dir_beside_the_new_one(self, tmp_path):
+        """A project launched through a symlink has session dirs under both
+        the link's name and the target's name; both age out."""
+        from session_end import cleanup_old_sessions
+
+        current_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        under_old = "11111111-2222-3333-4444-555555555555"
+        under_new = "66666666-7777-8888-9999-000000000000"
+        self._create_session_dir(tmp_path / "link-name", under_old, age_days=10)
+        self._create_session_dir(tmp_path / "real-project", under_new, age_days=10)
+
+        cleanup_old_sessions(
+            project_slug="real-project",
+            current_session_id=current_id,
+            sessions_dir=str(tmp_path),
+            max_age_days=7,
+            old_slug="link-name",
+        )
+
+        assert not (tmp_path / "link-name" / under_old).exists()
+        assert not (tmp_path / "real-project" / under_new).exists()
+
+    def test_plain_project_dir_sweeps_one_slug_dir_once(self, tmp_path, monkeypatch):
+        import session_end
+
+        calls = []
+        monkeypatch.setattr(
+            session_end, "_reap_slug_dir", lambda slug_dir, *a: calls.append(slug_dir)
+        )
+        session_end.cleanup_old_sessions(
+            project_slug="my-project",
+            current_session_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            sessions_dir=str(tmp_path),
+            max_age_days=7,
+            old_slug="my-project",
+        )
+
+        assert calls == [tmp_path / "my-project"]
+
     def test_skips_current_session(self, tmp_path):
         from session_end import cleanup_old_sessions
 
@@ -2415,6 +2454,7 @@ class TestMainIntegrationCleanup:
         mock_cleanup.assert_called_once_with(
             project_slug="proj",
             current_session_id="test-session",
+            old_slug="proj",
         )
 
 

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -2341,6 +2341,26 @@ class TestExtractPrevSessionDirDualLocation:
 
         assert _extract_prev_session_dir("") is None
 
+    def test_absent_session_dir_line_falls_through_to_derived_path(
+        self, tmp_path, monkeypatch
+    ):
+        """A Session-dir line naming a directory that is no longer there
+        yields the path derived from the Resume line and the resolved slug."""
+        from session_init import _extract_prev_session_dir
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+        sid = "cccccccc-1111-2222-3333-444444444444"
+        sessions_root = (tmp_path / "home") / ".claude" / "pact-sessions"
+        absent = str(sessions_root / "old-name" / sid)
+        (tmp_path / "CLAUDE.md").write_text(
+            self._make_content(sid, absent), encoding="utf-8"
+        )
+
+        result = _extract_prev_session_dir(str(tmp_path))
+
+        assert result == str(sessions_root / tmp_path.name / sid)
+        assert result != absent
+
     def test_reads_dot_claude_when_only_dot_claude_exists(self, tmp_path, monkeypatch):
         """Reads .claude/CLAUDE.md when it is the only location present."""
         from session_init import _extract_prev_session_dir
@@ -2356,6 +2376,7 @@ class TestExtractPrevSessionDirDualLocation:
             (tmp_path / "home") / ".claude" / "pact-sessions"
             / "PACT-Plugin" / "aaaaaaaa-1111-2222-3333-444444444444"
         )
+        Path(expected).mkdir(parents=True)
         (dot_claude_dir / "CLAUDE.md").write_text(
             self._make_content("aaaaaaaa-1111-2222-3333-444444444444", expected),
             encoding="utf-8",
@@ -2377,6 +2398,7 @@ class TestExtractPrevSessionDirDualLocation:
             (tmp_path / "home") / ".claude" / "pact-sessions"
             / "PACT-Plugin" / "bbbbbbbb-1111-2222-3333-444444444444"
         )
+        Path(expected).mkdir(parents=True)
         (tmp_path / "CLAUDE.md").write_text(
             self._make_content("bbbbbbbb-1111-2222-3333-444444444444", expected),
             encoding="utf-8",
@@ -2403,6 +2425,8 @@ class TestExtractPrevSessionDirDualLocation:
         legacy = str(
             sessions_root / "PACT-Plugin" / "dddddddd-1111-2222-3333-444444444444"
         )
+        Path(preferred).mkdir(parents=True)
+        Path(legacy).mkdir(parents=True)
 
         (dot_claude_dir / "CLAUDE.md").write_text(
             self._make_content(
@@ -7069,15 +7093,39 @@ class TestAdoptOldSlugSessionDir:
         assert (old / "session-journal.jsonl").exists()
         assert not new.exists()
 
+    def test_symlink_at_old_slot_is_left_alone(self, tmp_path, monkeypatch):
+        from session_init import _adopt_old_slug_session_dir
+        import os
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _real, link = self._linked_project(tmp_path)
+        old, new = self._dirs(tmp_path)
+        target = tmp_path / "elsewhere"
+        target.mkdir()
+        (target / "session-journal.jsonl").write_text("ELSEWHERE\n")
+        old.parent.mkdir(parents=True)
+        old.symlink_to(target, target_is_directory=True)
+
+        assert _adopt_old_slug_session_dir(self._SID, str(link)) is False
+        assert old.is_symlink()
+        assert not os.path.lexists(new)
+
     def test_main_adopts_before_any_writer_creates_the_new_dir(self, tmp_path, monkeypatch):
-        """Through main() on resume: the journal is at the new slot afterwards
-        and the old slot is gone, so the adoption ran before the writers."""
+        """Through main() on resume with a ROOT compact summary present: the
+        archive block would create the new slot to drain it, so the journal
+        landing there and the root summary being drained together prove the
+        adoption ran first."""
         from session_init import main
+        from shared.constants import get_compact_summary_path
 
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         _real, link = self._linked_project(tmp_path)
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(link))
         old, new = self._seed_old(tmp_path)
+        root_summary = get_compact_summary_path()
+        root_summary.parent.mkdir(parents=True, exist_ok=True)
+        root_summary.write_text("STALE ROOT SUMMARY\n")
+        assert str(root_summary).startswith(str(tmp_path))
         stdin_data = _stdin_payload(source="resume", session_id=self._SID)
 
         with patch("session_init.setup_plugin_symlinks", return_value=None), \
@@ -7096,3 +7144,4 @@ class TestAdoptOldSlugSessionDir:
         journal = (new / "session-journal.jsonl").read_text()
         assert journal.startswith('{"type":"session_start"}\n')
         assert not old.exists()
+        assert not root_summary.exists()

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -6973,3 +6973,126 @@ class TestSymlinkRefreshRouting:
 
         assert "keeps the body it got at spawn" not in additional
         assert "keeps the body it got at spawn" not in system_msg
+
+
+class TestAdoptOldSlugSessionDir:
+    """A session launched through a symlink keeps its journal when the slug
+    becomes the resolved basename: session start moves the old-name folder
+    to the new-name slot, and only when the new slot is free."""
+
+    _SID = "aabb1122-0000-0000-0000-00000000ad0f"
+
+    @staticmethod
+    def _linked_project(tmp_path):
+        real = tmp_path / "real-project"
+        real.mkdir()
+        link = tmp_path / "link-name"
+        link.symlink_to(real, target_is_directory=True)
+        return real, link
+
+    def _dirs(self, tmp_path):
+        root = tmp_path / ".claude" / "pact-sessions"
+        return root / "link-name" / self._SID, root / "real-project" / self._SID
+
+    def _seed_old(self, tmp_path):
+        old, new = self._dirs(tmp_path)
+        old.mkdir(parents=True)
+        (old / "session-journal.jsonl").write_text('{"type":"session_start"}\n')
+        return old, new
+
+    def test_symlinked_project_adopts_old_dir(self, tmp_path, monkeypatch):
+        from session_init import _adopt_old_slug_session_dir
+        import os
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _real, link = self._linked_project(tmp_path)
+        old, new = self._seed_old(tmp_path)
+
+        assert _adopt_old_slug_session_dir(self._SID, str(link)) is True
+        assert (new / "session-journal.jsonl").read_text() == '{"type":"session_start"}\n'
+        assert not os.path.lexists(old)
+
+    def test_new_dir_with_content_is_never_clobbered(self, tmp_path, monkeypatch):
+        from session_init import _adopt_old_slug_session_dir
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _real, link = self._linked_project(tmp_path)
+        old, new = self._seed_old(tmp_path)
+        new.mkdir(parents=True)
+        (new / "session-journal.jsonl").write_text("NEW\n")
+
+        assert _adopt_old_slug_session_dir(self._SID, str(link)) is False
+        assert (new / "session-journal.jsonl").read_text() == "NEW\n"
+        assert (old / "session-journal.jsonl").read_text() == '{"type":"session_start"}\n'
+
+    def test_empty_new_dir_is_adopted(self, tmp_path, monkeypatch):
+        from session_init import _adopt_old_slug_session_dir
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _real, link = self._linked_project(tmp_path)
+        old, new = self._seed_old(tmp_path)
+        new.mkdir(parents=True)
+
+        assert _adopt_old_slug_session_dir(self._SID, str(link)) is True
+        assert (new / "session-journal.jsonl").read_text() == '{"type":"session_start"}\n'
+        assert not old.exists()
+
+    def test_plain_project_dir_never_renames(self, tmp_path, monkeypatch):
+        from session_init import _adopt_old_slug_session_dir
+        import os
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        plain = tmp_path / "real-project"
+        plain.mkdir()
+        session_dir = tmp_path / ".claude" / "pact-sessions" / "real-project" / self._SID
+        session_dir.mkdir(parents=True)
+        calls = []
+        monkeypatch.setattr(os, "rename", lambda *a: calls.append(a))
+
+        assert _adopt_old_slug_session_dir(self._SID, str(plain)) is False
+        assert calls == []
+        assert session_dir.is_dir()
+
+    def test_rename_failure_leaves_both_and_does_not_raise(self, tmp_path, monkeypatch):
+        from session_init import _adopt_old_slug_session_dir
+        import os
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _real, link = self._linked_project(tmp_path)
+        old, new = self._seed_old(tmp_path)
+
+        def _refuse(*_args):
+            raise OSError("rename refused")
+
+        monkeypatch.setattr(os, "rename", _refuse)
+        assert _adopt_old_slug_session_dir(self._SID, str(link)) is False
+        assert (old / "session-journal.jsonl").exists()
+        assert not new.exists()
+
+    def test_main_adopts_before_any_writer_creates_the_new_dir(self, tmp_path, monkeypatch):
+        """Through main() on resume: the journal is at the new slot afterwards
+        and the old slot is gone, so the adoption ran before the writers."""
+        from session_init import main
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _real, link = self._linked_project(tmp_path)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(link))
+        old, new = self._seed_old(tmp_path)
+        stdin_data = _stdin_payload(source="resume", session_id=self._SID)
+
+        with patch("session_init.setup_plugin_symlinks", return_value=None), \
+             patch("session_init.ensure_project_memory_md", return_value=None), \
+             patch("session_init.check_pinned_staleness", return_value=None), \
+             patch("session_init.update_session_info", return_value=None), \
+             patch("session_init.get_task_list", return_value=None), \
+             patch("session_init.restore_last_session", return_value=None), \
+             patch("session_init.check_resume_state", return_value=None), \
+             patch("sys.stdin", io.StringIO(stdin_data)), \
+             patch("sys.stdout", new_callable=io.StringIO):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+        journal = (new / "session-journal.jsonl").read_text()
+        assert journal.startswith('{"type":"session_start"}\n')
+        assert not old.exists()

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -2361,6 +2361,27 @@ class TestExtractPrevSessionDirDualLocation:
         assert result == str(sessions_root / tmp_path.name / sid)
         assert result != absent
 
+    def test_fallback_derives_the_sanitised_slug_dir(self, tmp_path, monkeypatch):
+        """A project whose name carries a dot lives under the sanitised slug
+        every writer uses; the fallback lands there, not on the raw name."""
+        from session_init import _extract_prev_session_dir
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+        project_dir = tmp_path / "my.project"
+        project_dir.mkdir()
+        sid = "eeeeeeee-1111-2222-3333-444444444444"
+        sessions_root = (tmp_path / "home") / ".claude" / "pact-sessions"
+        sanitised = sessions_root / "my_project" / sid
+        sanitised.mkdir(parents=True)
+        absent_raw = str(sessions_root / "my.project" / sid)
+        (project_dir / "CLAUDE.md").write_text(
+            self._make_content(sid, absent_raw), encoding="utf-8"
+        )
+
+        result = _extract_prev_session_dir(str(project_dir))
+
+        assert result == str(sanitised)
+
     def test_reads_dot_claude_when_only_dot_claude_exists(self, tmp_path, monkeypatch):
         """Reads .claude/CLAUDE.md when it is the only location present."""
         from session_init import _extract_prev_session_dir

--- a/pact-plugin/tests/test_session_journal.py
+++ b/pact-plugin/tests/test_session_journal.py
@@ -2697,6 +2697,9 @@ class TestExtractPrevSessionDir:
             "- Session dir: `~/.claude/pact-sessions/myproject/abc123`\n"
             "- Started: 2026-04-05\n"
         )
+        named = Path.home() / ".claude" / "pact-sessions" / "myproject" / "abc123"
+        assert str(named).startswith(str(tmp_path))
+        named.mkdir(parents=True)
 
         result = _extract_prev_session_dir(str(tmp_path))
         assert result is not None

--- a/pact-plugin/tests/test_session_resume.py
+++ b/pact-plugin/tests/test_session_resume.py
@@ -218,6 +218,7 @@ class TestUpdateSessionInfo:
         session_dir = str(
             Path.home() / ".claude" / "pact-sessions" / "myproject" / "abc-123"
         )
+        Path(session_dir).mkdir(parents=True)
         result = update_session_info("abc-123", "pact-abc123", session_dir)
         assert result is not None
 


### PR DESCRIPTION
## Summary

The backlog writer resolved `project_path` only through git's main repo root and refused (exit 2) when none resolved, so a multi-repo workspace directory with no `.git` of its own could never hold a backlog: `add`, `set` and `show`-with-create all failed before writing, and the session-start remedy ("`/PACT:next` writes, which records it") could not succeed there.

`project_root()` now resolves in this order:

1. git's main root when it resolves from `CLAUDE_PROJECT_DIR` (a repo root, a subdirectory below one, and a linked worktree all normalise to it — unchanged);
2. otherwise the resolved `CLAUDE_PROJECT_DIR` when it names an existing directory **and no `.git` sits at or above it** (the umbrella case);
3. otherwise a refusal that names which input it saw and echoes the rejected value.

The `.git`-above check is what keeps a git outage on a real repository subdirectory or worktree from writing a second backlog keyed on that subdirectory; a refusal writes nothing, so the stored name and the stored paths cannot disagree.

## Three names for one project now agree

PACT names a project three ways — the backlog file, the pact-memory project id, and the session-directory slug. Review found that a project launched through a symlinked directory got the link's name from two of them and the target's name from the third. All three now take the resolved directory's name:

- `_detect_project_id` (pact-memory) returns the resolved basename for a symlinked `CLAUDE_PROJECT_DIR`. **This re-keys the pact-memory store for projects launched through a symlink**: new records land under the target's name; older ones stay under the link's name.
- One `project_slug` helper replaces eleven inline derivations across `pact_context.py`, `session_init.py`, `session_end.py` and the pact-memory session script. The slug still keys on the launch directory (each worktree keeps its own session directory) and does not normalise to the git main root.
- **A session launched through a symlink and resumed across this upgrade** keeps its journal: session start moves the directory from the unresolved name to the resolved one before any writer touches it (only when the two differ, the old path is a real directory, and the new path is absent or empty; never clobbers, never raises), the previous-session-dir reader follows the moved path, and the session reaper sweeps the old-name directory beside the new one so earlier sessions under it age out.

All three derivations share the same fallback when resolving raises (the unresolved path), so they agree on the failure branch too.

## Tests

- Umbrella can hold a backlog; the fallback never fires when git resolves a root (repo root, subdirectory, linked worktree); unset/non-directory still refuses with nothing written; an umbrella backlog is found again by the read path and a sibling is not.
- A subdirectory or linked worktree under a stubbed git failure refuses with nothing written; a symlinked umbrella stores its resolved path and is named after it; a git-less subdirectory of an umbrella is its own project on both the name and path sides; an unresolvable directory falls back to its unresolved path with exit 0.
- Detector: symlink to a git-less dir and to a repo root each name the target; a plain directory keeps its name.
- Slug helper: four unit cases; a symlinked project directory at each session-path entry; the session-end slug; the compact-summary archive drains under the resolved name.
- Ten pre-existing backlog tests now pin `CLAUDE_PROJECT_DIR` instead of reading the cwd's repository, so the module passes outside a checkout; one test pins that an unset variable still resolves from the cwd's repository.
- Adoption: the move with a seeded journal; a non-empty destination is left alone; an empty one is adopted; a plain directory never renames; a symlink at the old slot is never moved; a failing rename raises nothing; the hook's own start path moves the directory before the compact-summary archive (seeded so the ordering is observable). The previous-session-dir reader falls through to the derived path when the copied one is gone. The reaper sweeps both names when they differ and one when they do not.

- Every reader and writer of a session path — including the resume-line fallback, the old-name reaper sweep, and the pact-memory session script — now composes it through the one sanitising helper, so a project name carrying a dot or a space, or a session id with an unsafe character, reads where it was written and cannot name a path outside the sessions root.

Full gate from `pact-plugin` at the final head: `15396 passed, 85 skipped`, 0 errors, 15481 collected.

## Version

PATCH bump to 4.7.6.

Addresses #1578.
