### PR TITLE
Amend orchestrator wait discipline and add wait_filler_gate PreToolUse hook (v4.7.12)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.7.11",
+      "version": "4.7.12",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.7.11/     # Plugin version
+│               └── 4.7.12/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.7.11",
+  "version": "4.7.12",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.7.11
+> **Version**: 4.7.12
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/agents/pact-orchestrator.md
+++ b/pact-plugin/agents/pact-orchestrator.md
@@ -140,6 +140,32 @@ When waiting for teammates to complete their tasks, **do not narrate waiting** �
 
 Idle notifications arrive as conversation turns. When a turn carries no actionable content — no blocker, no stage-ready, no question, no user input — emit no reply. Acknowledging every incoming turn is the reflex that produces narrate-the-wait noise. The next meaningful transition triggers the next meaningful reply. One protocol-defined exception: the single redundant confirm after a crossed wake (an idle notification postdating your directive send; one that predates it is a straggler — take no action) — see §12 Intentional Waiting.
 
+**The filler-call compulsion.** Waiting turns produce a reflex to close with *some* tool call — `Bash(true)`, `sleep`, a `TaskList` poll "just to check." This reflex IS the failure mode this section exists to prevent. Mechanics: every tool result generates a new turn, so a filler call manufactures the next turn that demands another — the loop runs until interrupted. **A tool call that produces no new information is a discipline violation, no matter how small.** Feeling the need to act ≠ a reason to act. Silence — no text, no calls — is a complete response, not an incomplete one.
+
+**The termination test.** Legitimate wait-time activity terminates on the awaited event: it fires once and ends when the event arrives (a watcher), or collapses the uncertainty in a single exchange (a probe). Activity that manufactures the next turn without terminating — narration, no-op calls, hand-polling — is the violation, however small each call.
+
+**Instrument the wait.** When you begin waiting on an asynchronous job you do not control — an external PR reviewer, a CI run, a test suite, any long-running background command — set up a watcher AT THAT MOMENT. Not when you next remember. Not when the user asks. The watcher polls until a terminating condition, then wakes you with the result; it carries a timeout so it fails loudly rather than hanging silently, and the timeout is not optional. Run it backgrounded so its exit re-invokes you. A watcher passes the termination test: one tool call, nothing until the event, then exactly the event. Narrating the wait and polling by hand each turn fail it.
+
+```bash
+SHA=<head>
+for i in $(seq 1 30); do
+  OUT=$(gh api repos/{owner}/{repo}/commits/$SHA/check-runs \
+        --jq '.check_runs[]|"\(.name): \(.status)/\(.conclusion // "-")"')
+  PENDING=$(printf '%s\n' "$OUT" | grep -c 'in_progress\|queued')
+  if [ "$PENDING" -eq 0 ]; then
+    echo "ALL CHECKS COMPLETE after $((i-1)) minutes"; printf '%s\n' "$OUT"
+    # ... report the findings surface too, not just completion
+    exit 0
+  fi
+  sleep 60
+done
+echo "TIMED OUT after 30 minutes — still pending:"; printf '%s\n' "$OUT"; exit 1
+```
+
+A watcher can die with its timeout — session end or platform task reaping kills the process and the timeout with it — so the timeout bound must live in your knowledge, not only in the watcher's process. Any turn arriving after the watcher's timeout window without a watcher result means the watcher is presumed dead: check the awaited event directly once, and re-arm if still pending. When you have reported the wait to the user, state the deadline in that report: "if I haven't brought you the result by ~T, the watcher died — prompt me."
+
+Report the findings surface, not only completion: for an external reviewer, read the inline threads — a completed check run says nothing about whether the reviewer found anything.
+
 ---
 
 ## 6. State Recovery (After Compaction or Session Resume)
@@ -575,7 +601,9 @@ committing. Teammates report an inbox drain in boundary messages
 
 Teammates signal protocol-defined waits via the `intentional_wait` task metadata (see `pact-agent-teams/SKILL.md::Intentional Waiting` for the teammate-side SET/CLEAR contract). The flag is audit metadata — it documents the wait for your inspection and session review. Your responsibilities:
 
-- **Don't interpret silence as stall.** Read the task metadata before dispatching `/PACT:imPACT`.
+- **Don't interpret silence as stall — or as progress.** Silence is uninformative in both directions: neither "stalled" nor "still working" is licensed by it. Read the task metadata before dispatching `/PACT:imPACT`.
+- **Fallback instruments when the task store is unavailable.** The store can drain; read the session journal, branch state, and filesystem mtimes instead — with the caveat that an mtime is a last-change time, not a liveness signal (never report a file's age as a run duration). `missed_wake_scan` is the existing fallback machinery, re-surfacing tasks idled on `awaiting_lead_completion` past the staleness threshold.
+- **Nudge first.** When silence leaves a teammate's state ambiguous, a `SendMessage` nudge is the first move: one message distinguishes still-running, finished-with-lost-notification, and died, at once. The probe-versus-noise boundary is §5's termination test — a nudge that asks a question whose answer changes your next action is a probe, terminating in a single exchange; one that reports your own state or repeats a standing directive is noise. This does not license accelerating nudges against the crossed-wake rule below: with a directive already in flight, the disk already shows the answer, so a further nudge is the capped redundant confirm, not a probe — never accelerate nudging in response to idle ticks.
 - **Crossed wake — one redundant confirm, then stop.** An idle notification that
   postdates your directive send is not a stall: durable-read the task; if the wait is
   unresolved, send exactly ONE redundant confirm naming the actionable state;

--- a/pact-plugin/hooks/hooks.json
+++ b/pact-plugin/hooks/hooks.json
@@ -92,6 +92,10 @@
           {
             "type": "command",
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/merge_guard_pre.py\""
+          },
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/wait_filler_gate.py\""
           }
         ]
       },

--- a/pact-plugin/hooks/wait_filler_gate.py
+++ b/pact-plugin/hooks/wait_filler_gate.py
@@ -14,11 +14,17 @@ no-op. Normalization, in order:
   2. Strip leading env assignments (`FOO=1 BAR=2 sleep 5` is still filler).
   3. Strip one optional `command `/`builtin ` prefix.
   4. Strip one optional trailing comment (` # ...`).
-Then deny on \\A(true|sleep ([0-9]+(\\.[0-9]+)?[smhd]?|infinity))\\Z —
+Then deny on \\A(true|sleep (([0-9]+(\\.[0-9]*)?|\\.[0-9]+)[smhd]?|infinity))\\Z —
 anchored \\A...\\Z, never $ (which matches before a single trailing
 newline and would re-make the newline forms order-dependent). Any shell
 metacharacter or composition fails the anchored pattern and is allowed:
 this is an honest-mistake guard, not an adversarial boundary.
+
+Under-block shapes consistent with the grammar, by design: a tab or
+multiple spaces between `sleep` and the duration (the pattern's separator
+is one literal space), and quoted env values containing spaces
+(`FOO="a b" sleep 5` mangles through the env-assignment strip). Both stay
+allowed — the persona layer is the standard; this hook is the floor.
 
 Fail direction: OPEN. Any internal error — malformed stdin, a matcher
 exception — allows the command (exit 0 + stderr note). A load/match
@@ -47,7 +53,7 @@ _DENY_REASON = (
 )
 
 _FILLER_PATTERN = re.compile(
-    r"\A(true|sleep ([0-9]+(\.[0-9]+)?[smhd]?|infinity))\Z"
+    r"\A(true|sleep (([0-9]+(\.[0-9]*)?|\.[0-9]+)[smhd]?|infinity))\Z"
 )
 _ENV_ASSIGNMENT = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*=\S*\s+")
 _WRAPPER_PREFIX = re.compile(r"\A(?:command|builtin)\s+")
@@ -79,7 +85,7 @@ def main() -> None:
     try:
         try:
             input_data = json.load(sys.stdin)
-        except (json.JSONDecodeError, ValueError) as error:
+        except ValueError as error:
             print(
                 f"wait_filler_gate: malformed stdin JSON — allowing "
                 f"(fail-open): {error}",

--- a/pact-plugin/hooks/wait_filler_gate.py
+++ b/pact-plugin/hooks/wait_filler_gate.py
@@ -14,17 +14,19 @@ no-op. Normalization, in order:
   2. Strip leading env assignments (`FOO=1 BAR=2 sleep 5` is still filler).
   3. Strip one optional `command `/`builtin ` prefix.
   4. Strip one optional trailing comment (` # ...`).
-Then deny on \\A(true|sleep (([0-9]+(\\.[0-9]*)?|\\.[0-9]+)[smhd]?|infinity))\\Z —
+Then deny on \\A(true|sleep[ \\t]+(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)[smhd]?|infinity))\\Z —
 anchored \\A...\\Z, never $ (which matches before a single trailing
-newline and would re-make the newline forms order-dependent). Any shell
-metacharacter or composition fails the anchored pattern and is allowed:
-this is an honest-mistake guard, not an adversarial boundary.
+newline and would re-make the newline forms order-dependent). The
+separator is `[ \t]+`: space and tab are the only bash word separators
+that can reach the matcher (an interior newline allows at step 1; other
+whitespace is not a bash word separator). Any shell metacharacter or
+composition fails the anchored pattern and is allowed: this is an
+honest-mistake guard, not an adversarial boundary.
 
-Under-block shapes consistent with the grammar, by design: a tab or
-multiple spaces between `sleep` and the duration (the pattern's separator
-is one literal space), and quoted env values containing spaces
-(`FOO="a b" sleep 5` mangles through the env-assignment strip). Both stay
-allowed — the persona layer is the standard; this hook is the floor.
+Under-block shape consistent with the grammar, by design: quoted env
+values containing spaces (`FOO="a b" sleep 5` mangles through the
+env-assignment strip). It stays allowed — the persona layer is the
+standard; this hook is the floor.
 
 Fail direction: OPEN. Any internal error — malformed stdin, a matcher
 exception — allows the command (exit 0 + stderr note). A load/match
@@ -53,7 +55,7 @@ _DENY_REASON = (
 )
 
 _FILLER_PATTERN = re.compile(
-    r"\A(true|sleep (([0-9]+(\.[0-9]*)?|\.[0-9]+)[smhd]?|infinity))\Z"
+    r"\A(true|sleep[ \t]+(([0-9]+(\.[0-9]*)?|\.[0-9]+)[smhd]?|infinity))\Z"
 )
 _ENV_ASSIGNMENT = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*=\S*\s+")
 _WRAPPER_PREFIX = re.compile(r"\A(?:command|builtin)\s+")

--- a/pact-plugin/hooks/wait_filler_gate.py
+++ b/pact-plugin/hooks/wait_filler_gate.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Location: pact-plugin/hooks/wait_filler_gate.py
+Summary: PreToolUse hook (matcher: Bash) that denies bare `true`/`sleep <N>`
+    filler commands — the turn-manufacturing no-ops a waiting agent emits
+    under the filler-call compulsion.
+Used by: pact-plugin/hooks/hooks.json PreToolUse "Bash" matcher entry.
+
+A command is denied iff, after normalization, it IS nothing but a filler
+no-op. Normalization, in order:
+  1. Strip leading AND trailing whitespace (including ALL trailing
+     newlines). A newline remaining after that strip is interior — the
+     command is composed — allow.
+  2. Strip leading env assignments (`FOO=1 BAR=2 sleep 5` is still filler).
+  3. Strip one optional `command `/`builtin ` prefix.
+  4. Strip one optional trailing comment (` # ...`).
+Then deny on \\A(true|sleep ([0-9]+(\\.[0-9]+)?[smhd]?|infinity))\\Z —
+anchored \\A...\\Z, never $ (which matches before a single trailing
+newline and would re-make the newline forms order-dependent). Any shell
+metacharacter or composition fails the anchored pattern and is allowed:
+this is an honest-mistake guard, not an adversarial boundary.
+
+Fail direction: OPEN. Any internal error — malformed stdin, a matcher
+exception — allows the command (exit 0 + stderr note). A load/match
+failure that denied on matcher=Bash would block every Bash call in every
+consumer session, and the gated commands are inert no-ops whose occasional
+escape costs nothing.
+
+Input: JSON on stdin, {"tool_name": "Bash", "tool_input": {"command": "<cmd>"}}
+Output: deny = {"hookSpecificOutput": {...}} + exit 2;
+        allow = {"suppressOutput": true} + exit 0. Errors to stderr.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+_ALLOW_OUTPUT = json.dumps({"suppressOutput": True})
+
+_DENY_REASON = (
+    "Passive waiting is the protocol — end the turn with no tool call; "
+    "teammate messages arrive as their own turns. A bare true/sleep filler "
+    "call manufactures the next turn without producing new information; "
+    "compose it with real work or end the turn."
+)
+
+_FILLER_PATTERN = re.compile(
+    r"\A(true|sleep ([0-9]+(\.[0-9]+)?[smhd]?|infinity))\Z"
+)
+_ENV_ASSIGNMENT = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*=\S*\s+")
+_WRAPPER_PREFIX = re.compile(r"\A(?:command|builtin)\s+")
+_TRAILING_COMMENT = re.compile(r"\s+#.*\Z")
+
+
+def _is_filler_command(command: str) -> bool:
+    """True iff the command is nothing but a bare `true`/`sleep <N>`.
+
+    Applies the module-docstring normalization chain in order. The chain
+    only ever strips benign decoration; anything it cannot reduce to the
+    anchored pattern (metacharacters, composition, quoting, wrappers like
+    `sudo`/`time`) is allowed.
+    """
+    normalized = command.strip()
+    if "\n" in normalized:
+        return False  # interior newline = composed command
+    while True:
+        stripped = _ENV_ASSIGNMENT.sub("", normalized, count=1)
+        if stripped == normalized:
+            break
+        normalized = stripped
+    normalized = _WRAPPER_PREFIX.sub("", normalized, count=1)
+    normalized = _TRAILING_COMMENT.sub("", normalized, count=1)
+    return _FILLER_PATTERN.match(normalized) is not None
+
+
+def main() -> None:
+    try:
+        try:
+            input_data = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError) as error:
+            print(
+                f"wait_filler_gate: malformed stdin JSON — allowing "
+                f"(fail-open): {error}",
+                file=sys.stderr,
+            )
+            sys.exit(0)
+
+        if not isinstance(input_data, dict) or input_data.get("tool_name") != "Bash":
+            print(_ALLOW_OUTPUT)
+            sys.exit(0)
+
+        tool_input = input_data.get("tool_input")
+        command = tool_input.get("command") if isinstance(tool_input, dict) else None
+        if not isinstance(command, str) or not _is_filler_command(command):
+            print(_ALLOW_OUTPUT)
+            sys.exit(0)
+
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": _DENY_REASON,
+            }
+        }))
+        sys.exit(2)
+
+    except Exception as error:  # noqa: BLE001 — fail-open catch-all
+        print(
+            f"wait_filler_gate: internal error — allowing (fail-open): {error}",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/pact-plugin/tests/test_hooks_json.py
+++ b/pact-plugin/tests/test_hooks_json.py
@@ -46,6 +46,7 @@ MUST_BE_SYNC = {
     "validate_handoff.py",  # Validates agent output
     "agent_handoff_emitter.py",  # Writes agent_handoff journal event on TaskCompleted
     "git_commit_check.py",  # Checks git commit conventions
+    "wait_filler_gate.py",  # Denies bare true/sleep filler commands
     "track_files.py",     # Tracks file edits (PostToolUse, non-async)
     "precompact_state_reminder.py",  # Emits state snapshot before compaction
     "postcompact_archive.py",  # Archives compact_summary to disk for session_init + secretary

--- a/pact-plugin/tests/test_wait_discipline_pins.py
+++ b/pact-plugin/tests/test_wait_discipline_pins.py
@@ -1,0 +1,194 @@
+"""
+Structural pin tests for the wait-discipline rules in the orchestrator
+persona (agents/pact-orchestrator.md §5 Wait in Silence, §12 Intentional
+Waiting).
+
+Pins the amendment surfaces:
+
+  §5 Wait in Silence:
+    - the filler-call compulsion block (names the reflex, states the
+      turn-manufacture mechanics, states the terminal action);
+    - the termination test — the discriminator stated ONCE at its §5 home:
+      legitimate wait-time activity terminates on the awaited event;
+    - the watcher rule (instrument at wait-START, timeout not optional,
+      backgrounded template loop, report-the-findings-surface) incl. the
+      watcher-liveness provision (a dead watcher is presumed on any
+      post-timeout turn without a result — check once and re-arm; a
+      user-reported wait carries a user-visible deadline).
+  §12 Intentional Waiting:
+    - the bidirectional silence rule (neither "stalled" nor "still working"
+      is licensed by silence);
+    - fallback instruments when the task store drains (session journal,
+      branch state, filesystem mtimes) incl. the mtime-is-not-liveness
+      caveat and the missed_wake_scan fallback machinery;
+    - the `SendMessage` nudge-first rule with the probe-versus-noise
+      boundary and the named crossed-wake-confirm boundary (nudge-first
+      does not license accelerating nudges).
+
+The discriminator single-home constraint is pinned STRUCTURALLY, not by
+count: the canonical phrase ("legitimate wait-time activity terminates on
+the awaited event") is pinned against the §5 section slice, and the
+reference language ("termination test") is pinned against the §12 slice
+and — in its watcher-rule form ("passes the termination test") — against
+the §5 slice. Stated once at the §5 home, referenced by the other two
+amendment sites: that is the structural test for "stated once, referenced
+by all three."
+
+PRESENCE pins, not counts (per the test_wake_ordering_pinned.py pattern —
+none of these phrases is intended to recur a fixed number of times).
+Matching is backtick-AND-whitespace-normalized on BOTH sides (see
+_phrase) so a re-wrap or an inline-code rendering inside a pinned span
+does not fail the pin while a re-WORD still does. Section slices are
+fence-aware: the §5 watcher template is a fenced bash block whose `#`
+comment lines must not terminate the §5 slice early.
+
+Counter-test-by-construction (measured at authoring time): this module was
+run against the PRE-AMENDMENT persona before the amendment text landed —
+all 21 cases RED (no pinned phrase pre-existed on its section slice), then
+21/21 GREEN after the amendment. The two heading pins guard the slice
+anchors so a heading rename fails with a clear message rather than 19
+empty-slice phrase failures.
+"""
+
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+
+ORCHESTRATOR = PLUGIN_ROOT / "agents" / "pact-orchestrator.md"
+
+WAIT_IN_SILENCE = "### Wait in Silence"
+INTENTIONAL_WAITING = "### Intentional Waiting (orchestrator responsibilities)"
+
+SECTION_HEADINGS = [WAIT_IN_SILENCE, INTENTIONAL_WAITING]
+
+
+def _raw(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _phrase(text: str) -> str:
+    """Phrase-matching normalization: strip backticks, then collapse any
+    whitespace run (including newlines from hard-wrapping) to a single
+    space. Applied to BOTH sides (section text and pinned phrase) so
+    phrases stored with or without backticks match consistently — tool
+    language inside a pinned span is inline-code formatted in the shipped
+    markdown."""
+    return " ".join(text.replace("`", "").split())
+
+
+def _section(path: Path, heading: str) -> str:
+    """Raw text of one section: from the exact heading line to the next
+    markdown heading or horizontal rule, whichever comes first. Fence-aware:
+    a `#`-leading line inside a fenced code block (the §5 watcher template
+    carries `#` comments) is example text, not a heading, and must not end
+    the slice early. Returns "" when the heading line is absent, so a
+    renamed heading fails every phrase pin on that slice (and the heading
+    pin below names the cause)."""
+    lines = _raw(path).splitlines()
+    try:
+        start = lines.index(heading)
+    except ValueError:
+        return ""
+    body = []
+    in_fence = False
+    for line in lines[start + 1:]:
+        stripped = line.strip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+        elif not in_fence and (stripped.startswith("#") or stripped == "---"):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+# ---------------------------------------------------------------------------
+# Heading pins — line-anchored exact match (slice anchors).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("heading", SECTION_HEADINGS, ids=lambda h: h.lstrip("# ")[:40])
+def test_section_heading_present(heading: str):
+    """The section heading must exist as an exact line — it is the slice
+    anchor for every phrase pin in this module, so a rename must fail here
+    with the cause named, not as 19 empty-slice phrase failures."""
+    assert heading in _raw(ORCHESTRATOR).splitlines(), (
+        f"pact-orchestrator.md: heading {heading!r} not found as an exact "
+        f"line. If the section was intentionally renamed, update this pin "
+        f"AND the slice anchor in this module in lockstep."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phrase pins — section-scoped, whitespace/backtick-normalized presence.
+# ---------------------------------------------------------------------------
+
+SECTION_PHRASE_PINS = [
+    # --- §5 Wait in Silence: the filler-call compulsion block ---
+    (WAIT_IN_SILENCE, "The filler-call compulsion"),
+    # The turn-manufacture mechanics sentence — the deviation-justifying
+    # fact that makes "end with NO tool call" non-negotiable.
+    (WAIT_IN_SILENCE, "every tool result generates a new turn, so a filler call manufactures the next turn"),
+    (WAIT_IN_SILENCE, "A tool call that produces no new information is a discipline violation"),
+    # --- §5: the termination test (discriminator canonical phrase, §5 home) ---
+    (WAIT_IN_SILENCE, "Legitimate wait-time activity terminates on the awaited event"),
+    # --- §5: the watcher rule ---
+    (WAIT_IN_SILENCE, "set up a watcher AT THAT MOMENT"),
+    (WAIT_IN_SILENCE, "the timeout is not optional"),
+    # The watcher rule's reference to the §5-home discriminator.
+    (WAIT_IN_SILENCE, "passes the termination test"),
+    # --- §5: the watcher-liveness provision ---
+    (WAIT_IN_SILENCE, "the watcher is presumed dead"),
+    (WAIT_IN_SILENCE, "re-arm if still pending"),
+    (WAIT_IN_SILENCE, "state the deadline in that report"),
+    # --- §5: report the findings surface ---
+    (WAIT_IN_SILENCE, "Report the findings surface, not only completion"),
+    # --- §12: bidirectional silence ---
+    (INTENTIONAL_WAITING, 'neither "stalled" nor "still working" is licensed'),
+    # --- §12: fallback instruments + mtime caveat + existing machinery ---
+    (INTENTIONAL_WAITING, "the session journal, branch state, and filesystem mtimes"),
+    (INTENTIONAL_WAITING, "a last-change time, not a liveness signal"),
+    (INTENTIONAL_WAITING, "missed_wake_scan is the existing fallback machinery"),
+    # --- §12: nudge-first + probe-versus-noise boundary ---
+    (INTENTIONAL_WAITING, "a SendMessage nudge is the first move"),
+    (INTENTIONAL_WAITING, "asks a question whose answer changes your next action is a probe"),
+    # §12's reference to the §5-home discriminator (the boundary the nudge
+    # rule is keyed to — the second reference site).
+    (INTENTIONAL_WAITING, "termination test"),
+    # The named crossed-wake-confirm boundary: nudge-first does not collide
+    # with the anti-acceleration rule.
+    (INTENTIONAL_WAITING, "never accelerate nudging in response to idle ticks"),
+]
+
+
+@pytest.mark.parametrize(
+    "heading, phrase",
+    SECTION_PHRASE_PINS,
+    ids=[f"{h.lstrip('# ')[:20]}::{p[:40]}" for h, p in SECTION_PHRASE_PINS],
+)
+def test_rule_phrase_present(heading: str, phrase: str):
+    """Each load-bearing wait-discipline phrase must be present on its own
+    section slice. Section-scoping is what makes the discriminator
+    single-home constraint structural: the canonical phrase is pinned
+    against the §5 slice and the reference language against the §12 slice,
+    so moving the statement out of its §5 home (or dropping a reference
+    site) flips exactly the pin for that site. If the wording was changed
+    intentionally, update the pin in lockstep."""
+    normalized_phrase = _phrase(phrase)
+    assert normalized_phrase in _phrase(_section(ORCHESTRATOR, heading)), (
+        f"pact-orchestrator.md {heading}: rule phrase {phrase!r} not found "
+        f"in the section (backtick-and-whitespace-normalized match). If the "
+        f"wording was changed intentionally, update this pin in lockstep; "
+        f"otherwise the wait-discipline rule this phrase carries is missing "
+        f"from a runtime-loaded surface."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Counter-test record (measured at authoring time): with the module run
+# against the pre-amendment persona, the 2 heading cases were GREEN (the
+# headings pre-existed — they are the slice anchors, not amendment text)
+# and all 19 phrase cases were RED (no pinned phrase pre-existed on its
+# slice). Post-amendment: 21/21 GREEN.
+# ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_wait_discipline_pins.py
+++ b/pact-plugin/tests/test_wait_discipline_pins.py
@@ -44,8 +44,10 @@ comment lines must not terminate the §5 slice early.
 
 Counter-test-by-construction (measured at authoring time): this module was
 run against the PRE-AMENDMENT persona before the amendment text landed —
-all 21 cases RED (no pinned phrase pre-existed on its section slice), then
-21/21 GREEN after the amendment. The two heading pins guard the slice
+19 of 21 cases RED (every phrase pin; no pinned phrase pre-existed on its
+section slice) and the 2 heading-anchor cases GREEN (the headings
+pre-existed — they are slice anchors, not amendment text), then 21/21
+GREEN after the amendment. The two heading pins guard the slice
 anchors so a heading rename fails with a clear message rather than 19
 empty-slice phrase failures.
 """

--- a/pact-plugin/tests/test_wait_discipline_pins.py
+++ b/pact-plugin/tests/test_wait_discipline_pins.py
@@ -46,10 +46,10 @@ Counter-test-by-construction (measured at authoring time): this module was
 run against the PRE-AMENDMENT persona before the amendment text landed —
 19 of 21 cases RED (every phrase pin; no pinned phrase pre-existed on its
 section slice) and the 2 heading-anchor cases GREEN (the headings
-pre-existed — they are slice anchors, not amendment text), then 21/21
-GREEN after the amendment. The two heading pins guard the slice
-anchors so a heading rename fails with a clear message rather than 19
-empty-slice phrase failures.
+pre-existed — they are slice anchors, not amendment text), then the full
+module GREEN after the amendment. The two heading pins guard the slice
+anchors so a heading rename fails with a clear message rather than an
+empty-slice failure per phrase pin.
 """
 
 from pathlib import Path
@@ -114,7 +114,7 @@ def _section(path: Path, heading: str) -> str:
 def test_section_heading_present(heading: str):
     """The section heading must exist as an exact line — it is the slice
     anchor for every phrase pin in this module, so a rename must fail here
-    with the cause named, not as 19 empty-slice phrase failures."""
+    with the cause named, not as an empty-slice failure per phrase pin."""
     assert heading in _raw(ORCHESTRATOR).splitlines(), (
         f"pact-orchestrator.md: heading {heading!r} not found as an exact "
         f"line. If the section was intentionally renamed, update this pin "
@@ -192,5 +192,5 @@ def test_rule_phrase_present(heading: str, phrase: str):
 # against the pre-amendment persona, the 2 heading cases were GREEN (the
 # headings pre-existed — they are the slice anchors, not amendment text)
 # and all 19 phrase cases were RED (no pinned phrase pre-existed on its
-# slice). Post-amendment: 21/21 GREEN.
+# slice). Post-amendment: the full module GREEN.
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_wait_filler_gate.py
+++ b/pact-plugin/tests/test_wait_filler_gate.py
@@ -7,7 +7,8 @@ consultation doc): every arm is an acceptance criterion.
 
 Deny arms D1-D15 (exit 2 + hookSpecificOutput deny envelope):
   bare builtin/sleep, leading/trailing whitespace incl. ALL trailing
-  newlines, duration suffixes (s/m/h/d), fractional N, `infinity`, env
+  newlines, space/tab separators between `sleep` and the duration,
+  duration suffixes (s/m/h/d), fractional N, `infinity`, env
   assignments, one `command `/`builtin ` prefix, one trailing comment, and
   the full normalization chain composed.
 
@@ -87,10 +88,10 @@ Counter-test record (measured at authoring time): this module was run
 against the repo BEFORE hooks/wait_filler_gate.py existed (TDD red-first):
 56 failed, 1 passed — every hook-dependent case red, the single green
 being the S4 seam-non-membership pin (it imports only the classifier, not
-the hook). Post-implementation: 57/57 green at authoring (alongside
-test_hooks_json.py, whose MUST_BE_SYNC sibling pin covers the async-flip
-shape); 58 at remediation cycle 1 (D6 twin); 59 with the trailing-dot
-admission arm added at the cycle-1 re-review.
+the hook). Post-implementation: the full module green at authoring
+(alongside test_hooks_json.py, whose MUST_BE_SYNC sibling pin covers the
+async-flip shape), again at remediation cycle 1 (D6 twin), and again
+with the trailing-dot admission arm added at the cycle-1 re-review.
 """
 
 import ast
@@ -150,6 +151,8 @@ def _bash_payload(command: str) -> str:
 DENY_ARMS = [
     ("D1", "true"),
     ("D2", "sleep 30"),
+    ("D2", "sleep  30"),
+    ("D2", "sleep\t30"),
     ("D3", "  true"),
     ("D4", "\tsleep 5"),
     ("D5", "true   "),

--- a/pact-plugin/tests/test_wait_filler_gate.py
+++ b/pact-plugin/tests/test_wait_filler_gate.py
@@ -48,16 +48,33 @@ Registration pins:
 S1 (script exists) is auto-covered by
 test_hooks_json.py::TestReferencedScriptsExist once registered.
 
-Mutation-ablation table (the TEST-phase verification spec — NOT executed
-at authoring time; each ablation predicts the flipped arms before running,
-and an ablation whose prediction agrees with the arm proves nothing):
-  drop `sleep` alternative from pattern      -> D2, D6-D8, D14 flip
-  drop whitespace strip                       -> D3-D5, D15 flip
-  drop env-assignment strip                   -> D9, D10, D14 flip
-  drop command/builtin prefix strip           -> D11, D12, D14 flip
-  drop comment strip                          -> D13, D14 flip
-  replace \\Z anchor with $                   -> D15 double-newline arm flips
-  invert fail-open to fail-closed             -> A26-A30 flip
+Mutation-ablation table (the TEST-phase verification spec; each ablation
+predicts the flipped arms before running, and an ablation whose prediction
+agrees with the arm proves nothing). AS-EXECUTED (TEST phase, isolated
+copy) — observed vs predicted, with the two corrections:
+  drop `sleep` alternative from pattern  -> observed 14 flips: every
+      sleep-based deny arm (D2, D4, D6, D7x4, D8, D9, D11, D13, D14,
+      D15x2); unique witnesses D2/D6/D7/D8. (Predicted row listed only the
+      unique-witness subset; 14 is the full flip set.)
+  drop whitespace strip                  -> observed 5: D3, D4, D5, D15x2
+      (unique witnesses D3/D5); as predicted.
+  drop env-assignment strip              -> observed 3: D9, D10, D14; as
+      predicted.
+  drop command/builtin prefix strip      -> observed 3: D11, D12, D14; as
+      predicted.
+  drop comment strip                     -> observed 2: D13, D14; as
+      predicted.
+  replace \\Z anchor with $               -> observed 0 — MASKED, not a
+      missing kill: the strip removes ALL trailing newlines and the
+      interior-newline check runs before the pattern, so no input reaches
+      the match with a trailing newline and $ == \\Z. The anchor is
+      zero-cost defense-in-depth documentation; the newline behavior is
+      certified by D15 flipping under the strip and sleep ablations. Do
+      not expect a test to couple to the anchor.
+  invert fail-open to fail-closed        -> observed 2: A26, A30. A27-A29
+      route through the validation-allow path, not the exception paths —
+      they are validation-allow cases, mislabeled above as fail-open arms;
+      fail-open is load-bearing where it exists (both exception paths).
 A total non-flip across arms is an instrument alarm, not a finding.
 
 Counter-test record (measured at authoring time): this module was run

--- a/pact-plugin/tests/test_wait_filler_gate.py
+++ b/pact-plugin/tests/test_wait_filler_gate.py
@@ -50,39 +50,47 @@ test_hooks_json.py::TestReferencedScriptsExist once registered.
 
 Mutation-ablation table (the TEST-phase verification spec; each ablation
 predicts the flipped arms before running, and an ablation whose prediction
-agrees with the arm proves nothing). AS-EXECUTED (TEST phase, isolated
-copy) — observed vs predicted, with the two corrections:
-  drop `sleep` alternative from pattern  -> observed 14 flips: every
-      sleep-based deny arm (D2, D4, D6, D7x4, D8, D9, D11, D13, D14,
-      D15x2); unique witnesses D2/D6/D7/D8. (Predicted row listed only the
-      unique-witness subset; 14 is the full flip set.)
+agrees with the arm proves nothing). AS-EXECUTED, RE-RUN at remediation
+cycle 1 against the post-widen grammar (isolated copy, 59 cases incl. the
+D6 `.5`/`5.` widened-grammar arms; the pre-widen cycle-0 run observed 14
+on the sleep row — the widen moved it by exactly the new arms):
+  drop `sleep` alternative from pattern  -> observed 16 flips: every
+      sleep-based deny arm (D2, D4, D6x3, D7x4, D8, D9, D11, D13, D14,
+      D15x2); unique witnesses D2/D6/D7/D8.
   drop whitespace strip                  -> observed 5: D3, D4, D5, D15x2
-      (unique witnesses D3/D5); as predicted.
-  drop env-assignment strip              -> observed 3: D9, D10, D14; as
-      predicted.
-  drop command/builtin prefix strip      -> observed 3: D11, D12, D14; as
-      predicted.
-  drop comment strip                     -> observed 2: D13, D14; as
-      predicted.
+      (unique witnesses D3/D5).
+  drop env-assignment strip              -> observed 3: D9, D10, D14.
+  drop command/builtin prefix strip      -> observed 3: D11, D12, D14.
+  drop comment strip                     -> observed 2: D13, D14.
   replace \\Z anchor with $               -> observed 0 — MASKED, not a
       missing kill: the strip removes ALL trailing newlines and the
       interior-newline check runs before the pattern, so no input reaches
       the match with a trailing newline and $ == \\Z. The anchor is
       zero-cost defense-in-depth documentation; the newline behavior is
       certified by D15 flipping under the strip and sleep ablations. Do
-      not expect a test to couple to the anchor.
+      not expect a test to couple to the anchor. (Confirmed structural at
+      cycle 1: a pyc same-second-mtime collision in the copy produced a
+      stale-bytecode restore false-red; the anchor re-run with __pycache__
+      cleared still observed 0.)
   invert fail-open to fail-closed        -> observed 2: A26, A30. A27-A29
       route through the validation-allow path, not the exception paths —
-      they are validation-allow cases, mislabeled above as fail-open arms;
-      fail-open is load-bearing where it exists (both exception paths).
+      they are validation-allow cases, not fail-open arms; fail-open is
+      load-bearing where it exists (both exception paths).
+  drop the leading-dot alternative       -> observed 1: the D6 'sleep .5'
+      twin (the widened grammar's new member is load-bearing).
+  narrow \\.[0-9]* back to \\.[0-9]+      -> observed 1: the D6 'sleep 5.'
+      arm (pins the trailing-dot admission — without the arm this
+      narrowing ships silently).
 A total non-flip across arms is an instrument alarm, not a finding.
 
 Counter-test record (measured at authoring time): this module was run
 against the repo BEFORE hooks/wait_filler_gate.py existed (TDD red-first):
 56 failed, 1 passed — every hook-dependent case red, the single green
 being the S4 seam-non-membership pin (it imports only the classifier, not
-the hook). Post-implementation: 57/57 green (alongside test_hooks_json.py,
-whose MUST_BE_SYNC sibling pin covers the async-flip shape).
+the hook). Post-implementation: 57/57 green at authoring (alongside
+test_hooks_json.py, whose MUST_BE_SYNC sibling pin covers the async-flip
+shape); 58 at remediation cycle 1 (D6 twin); 59 with the trailing-dot
+admission arm added at the cycle-1 re-review.
 """
 
 import ast
@@ -147,6 +155,7 @@ DENY_ARMS = [
     ("D5", "true   "),
     ("D6", "sleep 0.5"),
     ("D6", "sleep .5"),
+    ("D6", "sleep 5."),
     ("D7", "sleep 1m"),
     ("D7", "sleep 2h"),
     ("D7", "sleep 10s"),

--- a/pact-plugin/tests/test_wait_filler_gate.py
+++ b/pact-plugin/tests/test_wait_filler_gate.py
@@ -108,10 +108,13 @@ def _persona_watcher_template() -> str:
     """The watcher template fenced bash block from persona §5. A11 asserts
     the hook never gates the remedy the persona teaches (triad coherence),
     so the allow arm reads the template's exact loop shape from the persona
-    itself — a template edit and this arm cannot drift apart."""
+    itself — a template edit and this arm cannot drift apart. The anchor is
+    the watcher rule's own bold lead ('**Instrument the wait.**'), not the
+    §5 section heading: a future earlier bash fence in §5 would otherwise
+    re-point the extraction silently while the arm stayed green."""
     text = ORCHESTRATOR.read_text(encoding="utf-8")
-    section_start = text.index("### Wait in Silence")
-    fence_open = text.index("```bash\n", section_start) + len("```bash\n")
+    anchor = text.index("**Instrument the wait.**")
+    fence_open = text.index("```bash\n", anchor) + len("```bash\n")
     fence_close = text.index("```", fence_open)
     return text[fence_open:fence_close]
 
@@ -143,6 +146,7 @@ DENY_ARMS = [
     ("D4", "\tsleep 5"),
     ("D5", "true   "),
     ("D6", "sleep 0.5"),
+    ("D6", "sleep .5"),
     ("D7", "sleep 1m"),
     ("D7", "sleep 2h"),
     ("D7", "sleep 10s"),
@@ -346,7 +350,9 @@ def test_s3_stdlib_only_imports():
     """The hook imports stdlib only and never shared.* — one subprocess per
     Bash call in every consumer session keeps import cost minimal, and
     staying out of the shared closure keeps it out of every classifier
-    sweep."""
+    sweep. The membership check is an explicit allowlist rather than
+    sys.stdlib_module_names (3.10+): the CI matrix runs this suite on
+    Python 3.9, where that attribute does not exist."""
     tree = ast.parse(HOOK_PATH.read_text(encoding="utf-8"))
     imported = set()
     for node in ast.walk(tree):
@@ -355,8 +361,9 @@ def test_s3_stdlib_only_imports():
         elif isinstance(node, ast.ImportFrom) and node.module:
             imported.add(node.module.split(".")[0])
     assert "shared" not in imported, f"shared.* import found: {imported}"
-    assert imported <= set(sys.stdlib_module_names), (
-        f"non-stdlib imports: {sorted(imported - set(sys.stdlib_module_names))}"
+    assert imported <= {"__future__", "json", "re", "sys"}, (
+        f"imports outside the stdlib allowlist: "
+        f"{sorted(imported - {'__future__', 'json', 're', 'sys'})}"
     )
 
 

--- a/pact-plugin/tests/test_wait_filler_gate.py
+++ b/pact-plugin/tests/test_wait_filler_gate.py
@@ -57,7 +57,10 @@ D6 `.5`/`5.` widened-grammar arms; the pre-widen cycle-0 run observed 14
 on the sleep row — the widen moved it by exactly the new arms):
   drop `sleep` alternative from pattern  -> observed 16 flips: every
       sleep-based deny arm (D2, D4, D6x3, D7x4, D8, D9, D11, D13, D14,
-      D15x2); unique witnesses D2/D6/D7/D8.
+      D15x2); unique witnesses D2/D6/D7/D8. (Cycle-2 addendum: the
+      separator widen added two D2 separator arms, so a post-cycle-2
+      re-run observes 18 with D2x3 — the 16 and its enumeration are
+      as-executed at cycle 1.)
   drop whitespace strip                  -> observed 5: D3, D4, D5, D15x2
       (unique witnesses D3/D5).
   drop env-assignment strip              -> observed 3: D9, D10, D14.

--- a/pact-plugin/tests/test_wait_filler_gate.py
+++ b/pact-plugin/tests/test_wait_filler_gate.py
@@ -1,0 +1,353 @@
+"""
+Tests for wait_filler_gate.py — PreToolUse hook (matcher: Bash) that denies
+bare `true`/`sleep <N>` filler commands.
+
+The matrix below IS the executable acceptance spec (per the test
+consultation doc): every arm is an acceptance criterion.
+
+Deny arms D1-D15 (exit 2 + hookSpecificOutput deny envelope):
+  bare builtin/sleep, leading/trailing whitespace incl. ALL trailing
+  newlines, duration suffixes (s/m/h/d), fractional N, `infinity`, env
+  assignments, one `command `/`builtin ` prefix, one trailing comment, and
+  the full normalization chain composed.
+
+Allow arms A1-A25 (exit 0, no deny payload):
+  composed commands (&&, |, ;, ||), false-positive guards (substring,
+  prefix word, quoted substring, -ss flag), the persona §5 watcher template
+  verbatim (triad coherence — the hook must never gate the remedy the
+  persona teaches), retry loops, interior newline (composed), documented
+  under-block compositions (adversarial shapes asserted as ALLOW — they pin
+  the honest-mistake scope boundary), degenerate inputs (empty,
+  whitespace-only).
+
+Fail-open arms A26-A30 (exit 0):
+  invalid JSON on stdin, missing tool_input, null/non-string command,
+  wrong tool_name (belt-and-braces behind the hooks.json matcher), and a
+  forced internal exception in the matcher (no deny payload, warning to
+  stderr).
+
+Payload pins:
+  P1  deny exits 2 (asserted by every deny arm).
+  P2  deny stdout parses as JSON with the hookSpecificOutput envelope and a
+      stable role-neutral reason substring ("Passive waiting is the
+      protocol" — distinctive phrase, not full text, so wording edits
+      don't churn the pin).
+  P3  channel discipline: the deny payload carries ONLY the
+      hookSpecificOutput key (no systemMessage/suppressOutput siblings).
+
+Registration pins:
+  S2  registered under PreToolUse matcher "Bash" in hooks.json with no
+      async:true (the MUST_BE_SYNC entry in test_hooks_json.py is the
+      sibling pin — an async flip would otherwise pass silently).
+  S3  stdlib-only imports, no shared.* (AST scan — keeps per-Bash consumer
+      cost minimal and the hook out of every classifier closure).
+  S4  non-membership: "wait_filler_gate" not in SEAM_DEPENDENT_HOOKS
+      (decision pin for the seam classification — the hook reads only the
+      stdin input contract, no integration seam).
+
+S1 (script exists) is auto-covered by
+test_hooks_json.py::TestReferencedScriptsExist once registered.
+
+Mutation-ablation table (the TEST-phase verification spec — NOT executed
+at authoring time; each ablation predicts the flipped arms before running,
+and an ablation whose prediction agrees with the arm proves nothing):
+  drop `sleep` alternative from pattern      -> D2, D6-D8, D14 flip
+  drop whitespace strip                       -> D3-D5, D15 flip
+  drop env-assignment strip                   -> D9, D10, D14 flip
+  drop command/builtin prefix strip           -> D11, D12, D14 flip
+  drop comment strip                          -> D13, D14 flip
+  replace \\Z anchor with $                   -> D15 double-newline arm flips
+  invert fail-open to fail-closed             -> A26-A30 flip
+A total non-flip across arms is an instrument alarm, not a finding.
+
+Counter-test record (measured at authoring time): this module was run
+against the repo BEFORE hooks/wait_filler_gate.py existed (TDD red-first):
+56 failed, 1 passed — every hook-dependent case red, the single green
+being the S4 seam-non-membership pin (it imports only the classifier, not
+the hook). Post-implementation: 57/57 green (alongside test_hooks_json.py,
+whose MUST_BE_SYNC sibling pin covers the async-flip shape).
+"""
+
+import ast
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+HOOK_PATH = PLUGIN_ROOT / "hooks" / "wait_filler_gate.py"
+HOOKS_JSON = PLUGIN_ROOT / "hooks" / "hooks.json"
+ORCHESTRATOR = PLUGIN_ROOT / "agents" / "pact-orchestrator.md"
+
+sys.path.insert(0, str(PLUGIN_ROOT / "hooks"))
+
+DENY_REASON_ANCHOR = "Passive waiting is the protocol"
+
+
+def _persona_watcher_template() -> str:
+    """The watcher template fenced bash block from persona §5. A11 asserts
+    the hook never gates the remedy the persona teaches (triad coherence),
+    so the allow arm reads the template's exact loop shape from the persona
+    itself — a template edit and this arm cannot drift apart."""
+    text = ORCHESTRATOR.read_text(encoding="utf-8")
+    section_start = text.index("### Wait in Silence")
+    fence_open = text.index("```bash\n", section_start) + len("```bash\n")
+    fence_close = text.index("```", fence_open)
+    return text[fence_open:fence_close]
+
+
+def _invoke(stdin_text: str, capsys):
+    """Run main() against the given stdin text. Returns (exit_code,
+    parsed_stdout_json_or_None, stderr_text)."""
+    from wait_filler_gate import main
+    with patch("sys.stdin", io.StringIO(stdin_text)):
+        with pytest.raises(SystemExit) as exc:
+            main()
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out) if captured.out.strip() else None
+    return exc.value.code, payload, captured.err
+
+
+def _bash_payload(command: str) -> str:
+    return json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+
+
+# ---------------------------------------------------------------------------
+# Deny matrix — D1-D15. Each asserts P1 (exit 2) + the deny envelope.
+# ---------------------------------------------------------------------------
+
+DENY_ARMS = [
+    ("D1", "true"),
+    ("D2", "sleep 30"),
+    ("D3", "  true"),
+    ("D4", "\tsleep 5"),
+    ("D5", "true   "),
+    ("D6", "sleep 0.5"),
+    ("D7", "sleep 1m"),
+    ("D7", "sleep 2h"),
+    ("D7", "sleep 10s"),
+    ("D7", "sleep 3d"),
+    ("D8", "sleep infinity"),
+    ("D9", "FOO=1 sleep 5"),
+    ("D10", "A=1 B=2 true"),
+    ("D11", "command sleep 5"),
+    ("D12", "builtin true"),
+    ("D13", "sleep 5 # waiting"),
+    ("D14", "FOO=1 command sleep 5 # wait"),
+    ("D15", "sleep 30\n"),
+    ("D15", "sleep 30\n\n"),
+]
+
+
+@pytest.mark.parametrize(
+    "arm, command", DENY_ARMS, ids=[f"{a}:{c!r}" for a, c in DENY_ARMS]
+)
+def test_deny_bare_filler(arm, command, capsys):
+    """A command that normalizes to bare `true`/`sleep <N>` is denied:
+    exit 2 (P1) with the hookSpecificOutput deny envelope."""
+    code, payload, _ = _invoke(_bash_payload(command), capsys)
+    assert code == 2, f"{arm} {command!r}: expected deny (exit 2), got {code}"
+    envelope = payload["hookSpecificOutput"]
+    assert envelope["hookEventName"] == "PreToolUse"
+    assert envelope["permissionDecision"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# Allow matrix — A1-A25. Each asserts exit 0 and no deny payload.
+# ---------------------------------------------------------------------------
+
+ALLOW_ARMS = [
+    ("A1", "sleep 2 && git status"),
+    ("A2", "sleep 5 | tee log"),
+    ("A3", "true; git status"),
+    ("A4", "sleep 5 || echo done"),
+    ("A5", "echo true"),
+    ("A6", "ffmpeg -ss 30 -i in.mp4 out.mp4"),
+    ("A7", 'git commit -m "sleep 30 while waiting"'),
+    ("A8", "pytest -k test_true_marker"),
+    ("A9", "truecrypt mount volume"),
+    ("A10", "sleepy 5"),
+    ("A11", _persona_watcher_template()),
+    ("A12", "for i in 1 2 3; do curl -s api; sleep 60; done"),
+    ("A13", "echo x\nsleep 30"),
+    # A14-A23: documented under-block shapes — asserted as ALLOW to pin the
+    # honest-mistake scope boundary (deliberate evasion is out of scope).
+    ("A14", "true && true"),
+    ("A15", "(sleep 5)"),
+    ("A16", '"true"'),
+    ("A16", "'sleep' 5"),
+    ("A17", "sudo sleep 5"),
+    ("A18", "time sleep 5"),
+    ("A19", "\\sleep 5"),
+    ("A20", "sleep"),
+    ("A21", "sleep 5x"),
+    ("A22", "sleep -5"),
+    ("A23", "TRUE"),
+    ("A23", "Sleep 5"),
+    ("A24", ""),
+    ("A25", "   "),
+]
+
+
+@pytest.mark.parametrize(
+    "arm, command", ALLOW_ARMS, ids=[f"{a}:{c[:30]!r}" for a, c in ALLOW_ARMS]
+)
+def test_allow_non_filler(arm, command, capsys):
+    """Anything that is not a bare filler command passes: exit 0 and no
+    hookSpecificOutput deny payload."""
+    code, payload, _ = _invoke(_bash_payload(command), capsys)
+    assert code == 0, f"{arm} {command!r}: expected allow (exit 0), got {code}"
+    if payload is not None:
+        assert "hookSpecificOutput" not in payload, (
+            f"{arm} {command!r}: unexpected deny payload {payload!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fail-open arms — A26-A30.
+# ---------------------------------------------------------------------------
+
+
+def test_a26_invalid_json_fails_open(capsys):
+    code, payload, err = _invoke("this is not json{", capsys)
+    assert code == 0
+    assert payload is None or "hookSpecificOutput" not in payload
+    assert err.strip(), "fail-open arms emit a stderr note"
+
+
+def test_a27_missing_tool_input_fails_open(capsys):
+    code, payload, _ = _invoke(json.dumps({"tool_name": "Bash"}), capsys)
+    assert code == 0
+    if payload is not None:
+        assert "hookSpecificOutput" not in payload
+
+
+def test_a28_null_command_fails_open(capsys):
+    code, _, _ = _invoke(
+        json.dumps({"tool_name": "Bash", "tool_input": {"command": None}}), capsys
+    )
+    assert code == 0
+
+
+def test_a28_nonstring_command_fails_open(capsys):
+    code, _, _ = _invoke(
+        json.dumps({"tool_name": "Bash", "tool_input": {"command": 42}}), capsys
+    )
+    assert code == 0
+
+
+def test_a29_wrong_tool_name_allowed(capsys):
+    """The hooks.json matcher is the first filter; the hook-side tool_name
+    check is belt-and-braces — a deny-shaped command under another tool is
+    allowed."""
+    stdin_text = json.dumps(
+        {"tool_name": "Edit", "tool_input": {"command": "sleep 30"}}
+    )
+    code, payload, _ = _invoke(stdin_text, capsys)
+    assert code == 0
+    if payload is not None:
+        assert "hookSpecificOutput" not in payload
+
+
+def test_a30_internal_error_fails_open(monkeypatch, capsys):
+    """A forced exception inside the matcher fails OPEN: exit 0, no deny
+    payload, warning to stderr. A broken discipline gate must never block
+    real work on its own breakage."""
+    import wait_filler_gate
+
+    def _boom(_command):
+        raise RuntimeError("forced matcher failure")
+
+    monkeypatch.setattr(wait_filler_gate, "_is_filler_command", _boom)
+    code, payload, err = _invoke(_bash_payload("sleep 30"), capsys)
+    assert code == 0
+    assert payload is None or "hookSpecificOutput" not in payload
+    assert err.strip(), "fail-open on internal error must note it on stderr"
+
+
+# ---------------------------------------------------------------------------
+# Payload pins — P2 reason language, P3 channel discipline.
+# ---------------------------------------------------------------------------
+
+
+def test_p2_deny_reason_carries_stable_anchor(capsys):
+    """The deny reason carries the role-neutral mechanism language — a
+    distinctive substring, not the full text, so wording edits don't churn
+    the pin."""
+    _, payload, _ = _invoke(_bash_payload("true"), capsys)
+    reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
+    assert DENY_REASON_ANCHOR in reason
+    assert "(§5)" not in reason, (
+        "the hook fires for all agents; teammates do not load the "
+        "orchestrator persona, so a literal section pointer is a dead "
+        "reference on this surface"
+    )
+
+
+def test_p3_deny_payload_channel_discipline(capsys):
+    """The deny path emits the hookSpecificOutput envelope ONLY — no
+    systemMessage or suppressOutput siblings."""
+    _, payload, _ = _invoke(_bash_payload("true"), capsys)
+    assert set(payload.keys()) == {"hookSpecificOutput"}
+
+
+# ---------------------------------------------------------------------------
+# Registration pins — S2 hooks.json, S3 stdlib-only, S4 seam non-membership.
+# ---------------------------------------------------------------------------
+
+
+def test_s2_registered_under_pretooluse_bash_no_async():
+    """The hook is registered inside the existing PreToolUse matcher "Bash"
+    entry, and neither the entry nor the hook carries async:true (a deny
+    hook must be synchronous — test_hooks_json.py's MUST_BE_SYNC entry is
+    the sibling pin)."""
+    config = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
+    entries = [
+        e for e in config["hooks"]["PreToolUse"] if e.get("matcher") == "Bash"
+    ]
+    matching = [
+        h
+        for e in entries
+        for h in e.get("hooks", [])
+        if "wait_filler_gate.py" in h.get("command", "")
+    ]
+    assert matching, (
+        "wait_filler_gate.py not registered under a PreToolUse matcher "
+        '"Bash" entry in hooks.json'
+    )
+    for hook in matching:
+        assert hook.get("async") is not True, (
+            "wait_filler_gate.py must be synchronous (no async:true) — "
+            "it is a deny-capable hook"
+        )
+
+
+def test_s3_stdlib_only_imports():
+    """The hook imports stdlib only and never shared.* — one subprocess per
+    Bash call in every consumer session keeps import cost minimal, and
+    staying out of the shared closure keeps it out of every classifier
+    sweep."""
+    tree = ast.parse(HOOK_PATH.read_text(encoding="utf-8"))
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+    assert "shared" not in imported, f"shared.* import found: {imported}"
+    assert imported <= set(sys.stdlib_module_names), (
+        f"non-stdlib imports: {sorted(imported - set(sys.stdlib_module_names))}"
+    )
+
+
+def test_s4_not_seam_dependent():
+    """The hook reads only the PreToolUse stdin input contract — no
+    task-dir, team-config, journal, or inbox seam — so it must NOT enter
+    SEAM_DEPENDENT_HOOKS (decision pin; the L2 integration-test requirement
+    does not apply to a stdin-contract hook)."""
+    from shared.hook_infra_classifier import SEAM_DEPENDENT_HOOKS
+
+    assert "wait_filler_gate" not in SEAM_DEPENDENT_HOOKS


### PR DESCRIPTION
## Summary

One coherent change resolving the wait-discipline triad (#1211, #1609, #1610), planned as a single unit in `docs/plans/wait-discipline-rules-plan.md` (untracked working doc).

- **Persona §5 (Wait in Silence)**: names the filler-call compulsion and forbids it; states the unifying discriminator once — legitimate wait-time activity terminates on the awaited event; adds the instrument-the-wait watcher rule (backgrounded watcher with a non-optional timeout at the START of any external async wait) with the R7 liveness provision (presumed-dead watcher → check once and re-arm; user-visible deadline in any reported wait).
- **Persona §12 (Intentional Waiting)**: silence rule made bidirectional (silence licenses neither "stalled" nor "still working"); fallback instruments for task-store drain (session journal, branch state, filesystem mtimes — with the mtime-is-not-liveness caveat); `SendMessage` nudge as the first move, bounded by the §5 termination test and the crossed-wake confirm boundary.
- **New hook `wait_filler_gate.py`**: narrow, fail-open, stdlib-only PreToolUse Bash gate that mechanically denies bare `true` / `sleep <N>` filler calls after a normalization chain (whitespace incl. all trailing newlines → env assignments → one `command `/`builtin ` prefix → one trailing comment). Any shell metacharacter allows. Registered inside the existing PreToolUse `Bash` matcher block; added to `MUST_BE_SYNC`.
- **Tests**: 61-case deny/allow matrix (57 at authoring + 4 remediation arms) (`test_wait_filler_gate.py`) with a mutation-ablation pass whose observed cardinalities are recorded in the module docstring; 21 persona-text presence pins (`test_wait_discipline_pins.py`) including the discriminator single-home structural pin and the R7 phrases. Full-suite gate: **15658 passed, 0 failed, 0 errors** (final collect 15,743 = 15,659 baseline + 78 new + 2 sibling + 4 remediation, fully attributed).
- **Version**: 4.7.11 → 4.7.12 PATCH (4 files).

Closes #1211. Closes #1609. Closes #1610.

## Hook-infra classification

WAIVER — hook-infra SECONDARY requirement. PR: wait-discipline triad (#1211/#1609/#1610). Changed hooks-tree paths: pact-plugin/hooks/wait_filler_gate.py (new), pact-plugin/hooks/hooks.json (registration). classify_diff MEASURED on the PR path set: primary=True, secondary=False, seam_hooks=∅ → waiver_required=True. Basis: the hook reads ONLY the PreToolUse stdin input contract; no task-dir resolution, team config, journal/inbox, env-keyed path, or shared resolver — no integration seam exists whose silent breakage could ship it inert. Closest precedent: git_commit_check (PreToolUse Bash, stdin-driven, not in the seam set). Non-membership pinned by test_wait_filler_gate.py::test_s4_not_seam_dependent; consumer cost pinned by test_s3_stdlib_only_imports. Residual: platform delivery of PreToolUse + deny honoring is platform-runtime-only — manual smoke-note, this PR.

## Manual smoke-note (post-merge verification)

MANUAL SMOKE-NOTE — wait_filler_gate platform-delivery residual. What pytest cannot certify: that the platform fires PreToolUse for a Bash call, delivers the stdin contract, and honors permissionDecision:deny. Probe (one minute, consumer session with this build installed via the marketplace installer; uninstall→install to switch builds): (1) Bash `sleep 30` → PASS = blocked, reason begins "Passive waiting is the protocol". (2) Bash `sleep 2 && git status` → PASS = executes normally. (3) Bash `true` → PASS = blocked as (1). If (1)/(3) do not block: registration/install defect — verify the install carries the registration before debugging the hook (cache-miss failure mode). If (2) blocks: matcher regression — route back RED. Record one line in the PR: probe date, build SHA, per-step pass/fail.

## Review notes

- Known prose nit, not blocking: commit ad39b4f1's message says "s/m/h suffixes" but the shipped pattern is `[smhd]` — the `d` suffix IS denied (D7 `sleep 3d` arm green). Commit-message-only; the code matches the architect contract.
- Documented under-block boundary (adversarial-only, by design per the honest-mistake-guard philosophy): quoted command names, `sudo`/`time` wrappers, subshells, escape evasion, and reversed decorator order (`command FOO=1 sleep 5`) all allow; each is pinned as ALLOW in the matrix (A14–A23 + the coder-flagged addition).
