### PR TITLE
Set CLAUDE_PROJECT_DIR once at session start (root fix for the mis-scope family)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.7.12",
+      "version": "4.7.13",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.7.12/     # Plugin version
+│               └── 4.7.13/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.7.12",
+  "version": "4.7.13",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.7.12
+> **Version**: 4.7.13
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -38,6 +38,7 @@ import json
 import os
 import re
 import secrets
+import shlex
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1124,6 +1125,44 @@ def check_settings_well_formed() -> Optional[str]:
         return None
 
 
+def _persist_project_dir_env(project_dir: str) -> None:
+    """Append `export CLAUDE_PROJECT_DIR=<value>` to the platform's CLAUDE_ENV_FILE.
+
+    CLAUDE_ENV_FILE is the platform's sanctioned SessionStart channel for
+    persisting env vars into subsequent Bash-tool environments; the plugin has
+    no other route to make CLAUDE_PROJECT_DIR ambient for skill-spawned CLIs
+    (the platform delivers it to hook processes only). Called from main() only
+    when BOTH $CLAUDE_ENV_FILE and $CLAUDE_PROJECT_DIR are present — the
+    both-present condition is the structural guard that keeps an env-absent
+    frame's cwd-fallback value out of the export. The checks below are the
+    defensive layer so the helper stays total when called directly in tests.
+
+    Producer-side shlex.quote: the env file is sourced by a shell, so a path
+    containing spaces or `$` must arrive quoted. Dedupe on the identical
+    export line keeps resume/compact/clear re-fires idempotent.
+
+    Never raises: SessionStart hot path (same total contract as the outer
+    safety net). A failed append fails open to the pre-fix status quo.
+    """
+    env_file = os.environ.get("CLAUDE_ENV_FILE")
+    if not env_file or not os.environ.get("CLAUDE_PROJECT_DIR"):
+        return
+    if not os.path.isabs(project_dir):
+        return
+    line = f"export CLAUDE_PROJECT_DIR={shlex.quote(project_dir)}"
+    try:
+        try:
+            existing = Path(env_file).read_text(encoding="utf-8")
+        except FileNotFoundError:
+            existing = ""
+        if line in existing.splitlines():
+            return
+        with open(env_file, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    except OSError:
+        pass
+
+
 def main():
     """
     Main entry point for the SessionStart hook.
@@ -1179,7 +1218,20 @@ def main():
             input_data = {}
             stdin_json_error = str(exc)
 
-        project_dir = os.environ.get("CLAUDE_PROJECT_DIR", ".")
+        # Resolve-once: the env value verbatim when the platform delivers it,
+        # else the absolute cwd (os.getcwd() is always absolute and physical —
+        # matching the platform's own resolved CLAUDE_PROJECT_DIR). This single
+        # value feeds BOTH the session-context record and the env-file export,
+        # so the exported == recorded invariant holds by construction. The
+        # former "." default is gone: env-absent frames now record the absolute
+        # cwd.
+        project_dir = os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+        # Env-file export gate: only frames where the platform delivered BOTH
+        # the env-file channel and the project dir append — an env-absent
+        # frame never reaches the append, so the cwd fallback is never
+        # exported (the structural guard).
+        if os.environ.get("CLAUDE_ENV_FILE") and os.environ.get("CLAUDE_PROJECT_DIR"):
+            _persist_project_dir_env(project_dir)
         context_parts = []
         system_messages = []
 

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -1138,11 +1138,17 @@ def _persist_project_dir_env(project_dir: str) -> None:
     defensive layer so the helper stays total when called directly in tests.
 
     Producer-side shlex.quote: the env file is sourced by a shell, so a path
-    containing spaces or `$` must arrive quoted. Dedupe on the identical
-    export line keeps resume/compact/clear re-fires idempotent.
+    containing spaces or `$` must arrive quoted. Dedupe matches the TERMINATED
+    full logical line against the raw file text (not splitlines() membership):
+    a quoted value can itself contain a newline, and only the raw-text match
+    self-matches on re-fire. An unterminated foreign last line gets its
+    newline written first, so the export starts on its own line instead of
+    gluing onto it.
 
     Never raises: SessionStart hot path (same total contract as the outer
-    safety net). A failed append fails open to the pre-fix status quo.
+    safety net). A failed append fails open to the pre-fix status quo —
+    OSError AND UnicodeError (a non-UTF-8 env file) both fail open locally
+    rather than escaping into main()'s outer net and degrading the frame.
     """
     env_file = os.environ.get("CLAUDE_ENV_FILE")
     if not env_file or not os.environ.get("CLAUDE_PROJECT_DIR"):
@@ -1155,11 +1161,14 @@ def _persist_project_dir_env(project_dir: str) -> None:
             existing = Path(env_file).read_text(encoding="utf-8")
         except FileNotFoundError:
             existing = ""
-        if line in existing.splitlines():
+        if f"{line}\n" in existing:
             return
+        payload = line + "\n"
+        if existing and not existing.endswith("\n"):
+            payload = "\n" + payload
         with open(env_file, "a", encoding="utf-8") as fh:
-            fh.write(line + "\n")
-    except OSError:
+            fh.write(payload)
+    except (OSError, UnicodeError):
         pass
 
 

--- a/pact-plugin/hooks/shared/backlog.py
+++ b/pact-plugin/hooks/shared/backlog.py
@@ -207,9 +207,34 @@ def project_root() -> Path:
     resolved directory, so the stored name and the stored paths agree; the
     inputs on which the two would diverge are the ones this function refuses,
     and a refusal writes nothing.
+
+    TWO SESSION-RECORD RULES SIT AROUND THAT ANCHOR, both reached through the
+    existing `_memory_api()` channel (no new import direction):
+
+    - DISAGREEMENT REFUSES. When CLAUDE_PROJECT_DIR and the session record are
+      both present and name different directories, the write fails closed,
+      naming both values and the remedy. Reads stay liberal (env wins); a
+      write under a disagreed scope is the silent mis-scope this family of
+      issues pays for.
+    - ABSENCE ANCHORS ON THE RECORD. When CLAUDE_PROJECT_DIR is unset, the
+      recorded project_dir stands in for it below, so an umbrella session
+      whose env var never arrived still resolves the session's own scope
+      instead of refusing. The refusal itself is unchanged — it stays the
+      guard for shells with no session behind them (cron, manual CLI).
     """
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
-    root = _memory_api().main_repo_root(project_dir)
+    memory_api = _memory_api()
+    disagreement = memory_api.env_record_project_dir_disagreement()
+    if disagreement is not None:
+        raise BacklogWriteError(
+            memory_api.format_project_dir_disagreement(*disagreement)
+        )
+    env_dir = os.environ.get("CLAUDE_PROJECT_DIR")
+    record_dir = "" if env_dir else memory_api.get_project_dir_from_session_record()
+    # `source` names where the anchor came from so the refusal below never
+    # attributes a recorded value to the (unset) variable, or vice versa.
+    project_dir = env_dir or record_dir or None
+    source = "CLAUDE_PROJECT_DIR" if env_dir else "the session record's project_dir"
+    root = memory_api.main_repo_root(project_dir)
     if root is not None:
         return root
     if project_dir and Path(project_dir).is_dir():
@@ -219,11 +244,11 @@ def project_root() -> Path:
         if _enclosing_checkout(resolved) is None:
             return resolved
         why = (
-            f"CLAUDE_PROJECT_DIR={project_dir!r} sits inside a repository git "
+            f"{source}={project_dir!r} sits inside a repository git "
             f"could not read"
         )
     elif project_dir:
-        why = f"CLAUDE_PROJECT_DIR={project_dir!r} does not name an existing directory"
+        why = f"{source}={project_dir!r} does not name an existing directory"
     else:
         why = "CLAUDE_PROJECT_DIR is unset"
     raise BacklogWriteError(

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -691,6 +691,9 @@ def cmd_update(args, db_path=None):
     memory = PACTMemory(db_path=db_path)
     try:
         resolved_id = memory.update(args.memory_id, updates, replace=args.replace)
+    except ProjectScopeDisagreementError as exc:
+        # Same deliberate refusal shape as cmd_save: both values + remedy.
+        _error("SCOPE_DISAGREEMENT", _scrub(str(exc)))
     except PrefixTooShortError as exc:
         # Order: PrefixTooShortError IS a ValueError; catch it before the
         # field-validation ValueError handler below.
@@ -776,6 +779,9 @@ def cmd_delete(args, db_path=None):
     memory = PACTMemory(db_path=db_path)
     try:
         resolved_id = memory.delete(args.memory_id)
+    except ProjectScopeDisagreementError as exc:
+        # Same deliberate refusal shape as cmd_save: both values + remedy.
+        _error("SCOPE_DISAGREEMENT", _scrub(str(exc)))
     except PrefixTooShortError as exc:
         _error("PREFIX_TOO_SHORT", str(exc), minimum=exc.minimum)
     except AmbiguousPrefixError as exc:

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -52,7 +52,7 @@ from scripts.database import (
     AmbiguousPrefixError,
     PrefixTooShortError,
 )
-from scripts.memory_api import PACTMemory
+from scripts.memory_api import PACTMemory, ProjectScopeDisagreementError
 from scripts.setup_memory import ensure_initialized, get_setup_status
 
 
@@ -530,6 +530,10 @@ def cmd_save(args, db_path=None):
         if claude_md_root:
             save_kwargs["claude_md_root"] = Path(claude_md_root)
         memory_id = memory.save(memory_dict, **save_kwargs)
+    except ProjectScopeDisagreementError as exc:
+        # A deliberate fail-closed refusal (env vs session record), not bad
+        # input: the message already names both values and the remedy.
+        _error("SCOPE_DISAGREEMENT", _scrub(str(exc)))
     except ValueError as exc:
         _error(
             "ValueError",
@@ -750,7 +754,11 @@ def cmd_sync(args, db_path=None):
     claude_md_root = getattr(args, "claude_md_root", None)
     if claude_md_root:
         sync_kwargs["claude_md_root"] = Path(claude_md_root)
-    memory_ids = memory.sync(**sync_kwargs)
+    try:
+        memory_ids = memory.sync(**sync_kwargs)
+    except ProjectScopeDisagreementError as exc:
+        # Same deliberate refusal shape as cmd_save: both values + remedy.
+        _error("SCOPE_DISAGREEMENT", _scrub(str(exc)))
     _success({
         "sync_status": memory.last_sync_status,
         "projected": len(memory_ids),

--- a/pact-plugin/skills/pact-memory/scripts/memory_api.py
+++ b/pact-plugin/skills/pact-memory/scripts/memory_api.py
@@ -73,9 +73,21 @@ from .working_memory import (
 from .memory_init import ensure_memory_ready, get_embedding_catchup_status
 # Dual import: relative (when loaded as package) vs absolute (when tests add scripts/ to sys.path)
 try:
-    from .pact_session import get_session_id_from_context_file
+    from .pact_session import (
+        ProjectScopeDisagreementError,
+        env_record_project_dir_disagreement,
+        format_project_dir_disagreement,
+        get_project_dir_from_session_record,
+        get_session_id_from_context_file,
+    )
 except ImportError:
-    from pact_session import get_session_id_from_context_file
+    from pact_session import (
+        ProjectScopeDisagreementError,
+        env_record_project_dir_disagreement,
+        format_project_dir_disagreement,
+        get_project_dir_from_session_record,
+        get_session_id_from_context_file,
+    )
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -244,8 +256,9 @@ class PACTMemory:
 
         Args:
             project_id: Project identifier. If not provided, auto-detected using
-                        (in order): CLAUDE_PROJECT_DIR env var, git repo root,
-                        or current working directory basename.
+                        (in order): CLAUDE_PROJECT_DIR env var, the session
+                        record's project_dir, git repo root, or current working
+                        directory basename (home scope warns).
             session_id: Session identifier. Auto-detected from context file if not provided.
             db_path: Custom database path. Uses default if not provided.
         """
@@ -309,16 +322,76 @@ class PACTMemory:
         return start  # fallback: use original
 
     @staticmethod
+    def _project_name_for_declared_dir(declared_dir: str, source: str) -> str:
+        """Name the project a DECLARED directory belongs to.
+
+        Shared by Strategy 1 (CLAUDE_PROJECT_DIR) and Strategy 1.5 (the
+        session record): both carry one directory naming the session's scope,
+        and both must derive the project name from it identically.
+
+        When the directory points below a repo's root (a worktree OR an
+        in-repo subdirectory), its basename is not the project name and would
+        fragment the project_id across sessions. Prefer the MAIN repo's
+        basename so every session of a project shares one key, aligning these
+        branches with the git-root and cwd-marker branches (Strategies 2/3),
+        which already resolve to the repo root. The rewrite fires when git
+        resolves a main repo whose root differs from the declared path; only
+        a repo-root declared path or a non-git path (where the main anchor
+        equals, or cannot be resolved from, the declared path) keeps the
+        declared basename — RESOLVED, so a symlinked project dir names its
+        target, which is the path the git branch above and the backlog writer
+        already record. A path that will not resolve keeps its unresolved
+        basename.
+
+        Args:
+            declared_dir: The directory value (env var or session record).
+            source: Label for the debug log naming where the value came from.
+        """
+        try:
+            declared_root = Path(declared_dir).resolve()
+        except (OSError, RuntimeError):
+            declared_root = None
+        # The local name is declared_main_root, NOT main_repo_root: rebinding
+        # the module-level helper's own name would make it local for the whole
+        # method and raise UnboundLocalError on the call itself.
+        declared_main_root = main_repo_root(declared_dir)
+        # Compare via normcase so a case-insensitive filesystem does not
+        # fire the rewrite for paths that differ only in case (a no-op on
+        # case-sensitive systems, where normcase is identity).
+        if (
+            declared_main_root is not None
+            and declared_root is not None
+            and os.path.normcase(str(declared_main_root)) != os.path.normcase(str(declared_root))
+        ):
+            logger.debug(
+                "project_id detected from %s worktree main repo: %s",
+                source,
+                declared_main_root.name,
+            )
+            return declared_main_root.name
+        project_name = (declared_root or Path(declared_dir)).name
+        logger.debug("project_id detected from %s: %s", source, project_name)
+        return project_name
+
+    @staticmethod
     def _detect_project_id() -> Optional[str]:
         """
-        Detect project ID from environment with multiple fallback strategies.
+        Detect project ID with multiple fallback strategies.
 
         Detection order:
         1. CLAUDE_PROJECT_DIR environment variable (original behavior)
+        1.5. Session record — the project_dir session_init persisted at
+           SessionStart, discovered via the CLAUDE_CODE_SESSION_ID glob in
+           pact_session. BELOW env (a present declaration wins) and ABOVE git:
+           in a multi-repo workspace the cwd's git root can be the WRONG
+           scope, so the session's own recorded identity outranks it.
         2. Git repository root via 'git rev-parse --git-common-dir' (worktree-safe)
         3. Current working directory — walked UP to the nearest project marker
            (.git, .claude/, or CLAUDE.md at either location). This handles the
-           case where the user runs the CLI from a subdirectory.
+           case where the user runs the CLI from a subdirectory. A walk that
+           lands on the HOME directory WARNS: home scope means every project
+           shares one memory space, and silent home scope is a mis-scope
+           vector.
 
         Returns:
             Project ID string (directory basename), or None if all methods fail.
@@ -326,44 +399,14 @@ class PACTMemory:
         # Strategy 1: Environment variable (original behavior)
         project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
         if project_dir:
-            # When CLAUDE_PROJECT_DIR points below a repo's root (a worktree OR
-            # an in-repo subdirectory), its basename is not the project name and
-            # would fragment the project_id across sessions. Prefer the MAIN
-            # repo's basename so every session of a project shares one key,
-            # aligning this env branch (Strategy 1) with the git-root and
-            # cwd-marker branches (Strategies 2/3), which already resolve to the
-            # repo root. The rewrite fires when git resolves a main repo whose
-            # root differs from the env path; only a repo-root env path or a
-            # non-git path (where the main anchor equals, or cannot be resolved
-            # from, the env path) keeps the env basename — RESOLVED, so a
-            # symlinked project dir names its target, which is the path the
-            # git branch above and the backlog writer already record. A path
-            # that will not resolve keeps its unresolved basename.
-            # The local name is env_main_root, NOT main_repo_root: rebinding
-            # the module-level helper's own name inside this method would make
-            # it local for the whole method and raise UnboundLocalError on the
-            # call itself.
-            try:
-                env_root = Path(project_dir).resolve()
-            except (OSError, RuntimeError):
-                env_root = None
-            env_main_root = main_repo_root(project_dir)
-            # Compare via normcase so a case-insensitive filesystem does not
-            # fire the rewrite for paths that differ only in case (a no-op on
-            # case-sensitive systems, where normcase is identity).
-            if (
-                env_main_root is not None
-                and env_root is not None
-                and os.path.normcase(str(env_main_root)) != os.path.normcase(str(env_root))
-            ):
-                logger.debug(
-                    "project_id detected from CLAUDE_PROJECT_DIR worktree main repo: %s",
-                    env_main_root.name,
-                )
-                return env_main_root.name
-            project_name = (env_root or Path(project_dir)).name
-            logger.debug("project_id detected from CLAUDE_PROJECT_DIR: %s", project_name)
-            return project_name
+            return PACTMemory._project_name_for_declared_dir(project_dir, "CLAUDE_PROJECT_DIR")
+
+        # Strategy 1.5: session record (inert under pytest — the discovery
+        # refuses test processes — so the replica in test_project_id.py needs
+        # no record leg to stay equivalent here).
+        record_dir = get_project_dir_from_session_record()
+        if record_dir:
+            return PACTMemory._project_name_for_declared_dir(record_dir, "session record")
 
         # Strategy 2: Git repository root (worktree-safe)
         # main_repo_root() carries the --git-common-dir resolution and the
@@ -392,6 +435,23 @@ class PACTMemory:
             cwd_root = PACTMemory._find_project_root(Path.cwd())
             cwd_name = cwd_root.name
             if cwd_name:
+                # Home scope is the last resort, and it must not be silent: a
+                # walk that lands on the home directory (typically via the
+                # .claude marker there) scopes every save to the USER, and
+                # searches under a project then silently miss. Warn so the
+                # mis-scope is visible.
+                try:
+                    home = Path.home().resolve()
+                except (OSError, RuntimeError):
+                    home = None
+                if home is not None and os.path.normcase(str(cwd_root)) == os.path.normcase(str(home)):
+                    logger.warning(
+                        "project_id resolved to the HOME directory (%s); memories "
+                        "will be scoped to user scope %r, not a project. Run from "
+                        "the project directory or set CLAUDE_PROJECT_DIR.",
+                        cwd_root,
+                        cwd_name,
+                    )
                 logger.debug("project_id detected from cwd: %s", cwd_name)
                 return cwd_name
         except OSError:
@@ -514,6 +574,16 @@ class PACTMemory:
         # save; a stale value would make that promise false in exactly the
         # silent way this channel exists to remove.
         self._last_sync_status = None
+
+        # FAIL CLOSED on an env/record disagreement, BEFORE any store work: the
+        # row would land under the env-derived project while the session's other
+        # readers follow the record — the silent mis-scope this refusal exists
+        # to make visible. Reads are unaffected; only writes refuse.
+        disagreement = env_record_project_dir_disagreement()
+        if disagreement is not None:
+            raise ProjectScopeDisagreementError(
+                format_project_dir_disagreement(*disagreement)
+            )
 
         # Ensure memory system is ready (lazy initialization)
         _ensure_ready()
@@ -1113,6 +1183,16 @@ class PACTMemory:
             # reports the None beside it, which is what makes it diagnosable.
             self._last_sync_status = SyncResult.EMPTY
             return []
+        # Same fail-closed rule as save(): on an env/record disagreement the
+        # rebuild would project the env-derived project's records over the
+        # record-scoped file. Refuse BEFORE the query, and raise so the CLI
+        # can envelope the refusal on stderr rather than report a falsy
+        # outcome with the reason invisible.
+        disagreement = env_record_project_dir_disagreement()
+        if disagreement is not None:
+            raise ProjectScopeDisagreementError(
+                format_project_dir_disagreement(*disagreement)
+            )
         records = self.list(limit=MAX_WORKING_MEMORIES)
         payload = [r.to_dict() for r in records]
         try:

--- a/pact-plugin/skills/pact-memory/scripts/memory_api.py
+++ b/pact-plugin/skills/pact-memory/scripts/memory_api.py
@@ -1036,7 +1036,20 @@ class PACTMemory:
                 dict-list item contains unknown sub-object keys.
             PrefixTooShortError: prefix is shorter than the minimum.
             AmbiguousPrefixError: prefix matches more than one memory.
+            ProjectScopeDisagreementError: CLAUDE_PROJECT_DIR and the session
+                record name different project directories (fail-closed write
+                refusal; reads follow env).
         """
+        # Same fail-closed rule as save()/sync(), evaluated at CALL time — the
+        # constructor-bound project_id may predate a mid-process disagreement.
+        # update() has no sync-status channel, so there is no REFUSED line to
+        # set here; the typed exception is the refusal's whole surface.
+        disagreement = env_record_project_dir_disagreement()
+        if disagreement is not None:
+            raise ProjectScopeDisagreementError(
+                format_project_dir_disagreement(*disagreement)
+            )
+
         # Ensure memory system is ready (lazy initialization)
         _ensure_ready()
 
@@ -1096,7 +1109,18 @@ class PACTMemory:
         Raises:
             PrefixTooShortError: prefix is shorter than the minimum.
             AmbiguousPrefixError: prefix matches more than one memory.
+            ProjectScopeDisagreementError: CLAUDE_PROJECT_DIR and the session
+                record name different project directories (fail-closed write
+                refusal; reads follow env).
         """
+        # Same fail-closed rule as save()/sync(), evaluated at CALL time.
+        # delete() has no status channel; the typed exception is the surface.
+        disagreement = env_record_project_dir_disagreement()
+        if disagreement is not None:
+            raise ProjectScopeDisagreementError(
+                format_project_dir_disagreement(*disagreement)
+            )
+
         # Ensure memory system is ready (lazy initialization)
         _ensure_ready()
 
@@ -1175,6 +1199,12 @@ class PACTMemory:
         carries the outcome as for save(); `empty` means nothing was
         projected -- no project id resolved, or the project has no records --
         and the file was not touched.
+
+        Refuses (raises ProjectScopeDisagreementError, status `refused`) when
+        CLAUDE_PROJECT_DIR and the session record disagree — UNLESS the caller
+        declares `claude_md_root`: an explicit destination warrant is
+        containment-checked downstream, so the ambient disagreement is moot
+        and the warranted call proceeds.
         """
         self._last_sync_status = None
         if self._project_id is None:
@@ -1193,12 +1223,21 @@ class PACTMemory:
         # can envelope the refusal on stderr rather than report a falsy
         # outcome with the reason invisible. The status channel reports the
         # refusal FIRST, matching save() and the ambient-guard refusal class.
-        disagreement = env_record_project_dir_disagreement()
-        if disagreement is not None:
-            self._last_sync_status = SyncResult.REFUSED
-            raise ProjectScopeDisagreementError(
-                format_project_dir_disagreement(*disagreement)
-            )
+        #
+        # THE WARRANT EXCEPTION: a caller that declares `claude_md_root` has
+        # named and containment-checked the destination, so the ambient
+        # disagreement is moot — the module-layer guard in working_memory
+        # already exempts a declared anchor, and the public API honors the
+        # same warrant rather than refusing a warranted call. save() keeps
+        # the unconditional refusal: its mis-scope vector is the DB ROW,
+        # which no CLAUDE.md destination warrant covers.
+        if claude_md_root is None:
+            disagreement = env_record_project_dir_disagreement()
+            if disagreement is not None:
+                self._last_sync_status = SyncResult.REFUSED
+                raise ProjectScopeDisagreementError(
+                    format_project_dir_disagreement(*disagreement)
+                )
         records = self.list(limit=MAX_WORKING_MEMORIES)
         payload = [r.to_dict() for r in records]
         try:

--- a/pact-plugin/skills/pact-memory/scripts/memory_api.py
+++ b/pact-plugin/skills/pact-memory/scripts/memory_api.py
@@ -578,9 +578,13 @@ class PACTMemory:
         # FAIL CLOSED on an env/record disagreement, BEFORE any store work: the
         # row would land under the env-derived project while the session's other
         # readers follow the record — the silent mis-scope this refusal exists
-        # to make visible. Reads are unaffected; only writes refuse.
+        # to make visible. Reads are unaffected; only writes refuse. The status
+        # channel reports the refusal FIRST, matching the ambient-guard refusal
+        # class — a caller that only reads `last_sync_status` sees a deliberate
+        # refusal, not an absent status.
         disagreement = env_record_project_dir_disagreement()
         if disagreement is not None:
+            self._last_sync_status = SyncResult.REFUSED
             raise ProjectScopeDisagreementError(
                 format_project_dir_disagreement(*disagreement)
             )
@@ -1187,9 +1191,11 @@ class PACTMemory:
         # rebuild would project the env-derived project's records over the
         # record-scoped file. Refuse BEFORE the query, and raise so the CLI
         # can envelope the refusal on stderr rather than report a falsy
-        # outcome with the reason invisible.
+        # outcome with the reason invisible. The status channel reports the
+        # refusal FIRST, matching save() and the ambient-guard refusal class.
         disagreement = env_record_project_dir_disagreement()
         if disagreement is not None:
+            self._last_sync_status = SyncResult.REFUSED
             raise ProjectScopeDisagreementError(
                 format_project_dir_disagreement(*disagreement)
             )

--- a/pact-plugin/skills/pact-memory/scripts/pact_session.py
+++ b/pact-plugin/skills/pact-memory/scripts/pact_session.py
@@ -207,11 +207,25 @@ def get_project_dir_from_session_record() -> str:
     rung to the reader's cwd ABOVE the git rung, inverting the precedence the
     rung exists to establish.
 
+    The record's session_id field is cross-checked against the env id that
+    LOCATED the file: a MISMATCH means the globbed record is not this
+    session's own (a misfiled or planted record), so it reads as no record.
+    An ABSENT field is accepted — legacy records predate the always-written
+    field, and the locating glob already matched the env id's directory.
+
     Returns "" on every failure: no env id, no unique context file, corrupt
-    JSON, non-mapping payload, non-string/non-absolute field. Never raises.
+    JSON, non-mapping payload, non-string/non-absolute field, session_id
+    mismatch. Never raises.
     """
-    found = _discover_context_record().get("project_dir", "")
+    record = _discover_context_record()
+    found = record.get("project_dir", "")
     if not isinstance(found, str) or not os.path.isabs(found):
+        return ""
+    record_session = record.get("session_id")
+    if record_session is not None and (
+        not isinstance(record_session, str)
+        or record_session != os.environ.get("CLAUDE_CODE_SESSION_ID", "")
+    ):
         return ""
     return found
 
@@ -260,7 +274,11 @@ def format_project_dir_disagreement(env_value: str, record_value: str) -> str:
         f"CLAUDE_PROJECT_DIR ({env_value}) disagrees with this session's "
         f"recorded project directory ({record_value}); the write was refused "
         f"rather than scoped silently. Nothing was written. Run without the "
-        f"override, or re-export CLAUDE_PROJECT_DIR to the recorded value."
+        f"override, or re-export CLAUDE_PROJECT_DIR to the recorded value. "
+        f"The comparison is textual (normcase/normpath, not resolved): a "
+        f"symlinked or case-differing spelling of the same directory refuses "
+        f"although identical, and re-exporting the recorded value is the "
+        f"remedy for that spelling."
     )
 
 

--- a/pact-plugin/skills/pact-memory/scripts/pact_session.py
+++ b/pact-plugin/skills/pact-memory/scripts/pact_session.py
@@ -82,11 +82,18 @@ _discovered_session_id = _DISCOVERY_UNSET
 _discovered_for_env = None
 
 
-def _resolve_context_on_disk(env_session: str) -> str:
-    """Find the one context file naming this session id, and read the id back.
+def _context_record_on_disk(env_session: str) -> dict:
+    """Find the one context file naming this session id, and parse it.
 
-    The expensive half of discovery, split out so it can be cached without the
-    guards being cached with it.
+    The shared glob+parse half of discovery, split out so the session-id
+    reader and the project_dir reader share one derivation (and one set of
+    failure modes) instead of drifting into two.
+
+    Returns the parsed mapping, or {} on any failure: the glob raised, the
+    match count was not exactly one (uniqueness was measured on one machine,
+    not guaranteed, so picking the first would be a coin toss over which
+    project's session this is), the file did not parse, or the payload was
+    not a mapping. Fail-open by posture: callers land on their own fallback.
     """
     try:
         sessions_root = get_claude_config_dir() / "pact-sessions"
@@ -94,22 +101,26 @@ def _resolve_context_on_disk(env_session: str) -> str:
         safe_session = _UNSAFE_SLUG_CHARS_RE.sub("_", env_session)
         matches = list(sessions_root.glob(f"*/{safe_session}/pact-session-context.json"))
     except OSError:
-        return ""
+        return {}
 
-    # Fail closed on anything but a single match. Uniqueness was measured on one
-    # machine, not guaranteed, so picking the first would be a coin toss over
-    # which project's session this is.
     if len(matches) != 1:
-        return ""
+        return {}
 
     try:
         data = json.loads(matches[0].read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError, ValueError):
-        return ""
+        return {}
 
-    if not isinstance(data, dict):
-        return ""
-    found = data.get("session_id", "")
+    return data if isinstance(data, dict) else {}
+
+
+def _resolve_context_on_disk(env_session: str) -> str:
+    """Find the one context file naming this session id, and read the id back.
+
+    The expensive half of session-id discovery, split out so it can be cached
+    without the guards being cached with it.
+    """
+    found = _context_record_on_disk(env_session).get("session_id", "")
     return found if isinstance(found, str) else ""
 
 
@@ -144,6 +155,113 @@ def _discover_session_id() -> str:
         _discovered_session_id = _resolve_context_on_disk(env_session)
         _discovered_for_env = env_session
     return _discovered_session_id
+
+
+_discovered_record = _DISCOVERY_UNSET
+_discovered_record_for_env = None
+
+
+def _discover_context_record() -> dict:
+    """Return this session's parsed context record, discovered from the env id.
+
+    The record route of the same discovery `_discover_session_id` performs,
+    with the SAME two guards (a test process is refused before any read; no
+    env id means no answer) and the same cache discipline: the filesystem
+    lookup is cached, the guards are re-run on every call. The guards are
+    duplicated here rather than shared through `_discover_session_id` because
+    that function's cache is pinned by tests that count its calls to
+    `_resolve_context_on_disk` — routing id discovery through this record
+    cache would let a warm record cache starve that call count.
+
+    Returns {} whenever the answer is not unambiguous.
+    """
+    # Twin guard pair of _discover_session_id's — keep in sync.
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return {}
+    env_session = os.environ.get("CLAUDE_CODE_SESSION_ID", "")
+    if not env_session:
+        return {}
+
+    global _discovered_record, _discovered_record_for_env
+    if _discovered_record is _DISCOVERY_UNSET or _discovered_record_for_env != env_session:
+        _discovered_record = _context_record_on_disk(env_session)
+        _discovered_record_for_env = env_session
+    return _discovered_record
+
+
+def get_project_dir_from_session_record() -> str:
+    """Return this session's recorded project_dir, or "" when unavailable.
+
+    The session-record rung of the project-scope read contract: below
+    CLAUDE_PROJECT_DIR (a present declaration wins), ABOVE any git/cwd
+    derivation (in a multi-repo workspace the cwd's git root can be the WRONG
+    scope; the record is the session's own resolved identity, written by
+    session_init at SessionStart).
+
+    Existence is deliberately NOT checked: the value is a scope ANCHOR, and a
+    recorded directory deleted between sessions is the caller-resolver's
+    fall-through case, not a discovery failure.
+
+    A NON-ABSOLUTE recorded value is rejected. Records written before the
+    resolve-once fix could hold "." — resolving that HERE would alias this
+    rung to the reader's cwd ABOVE the git rung, inverting the precedence the
+    rung exists to establish.
+
+    Returns "" on every failure: no env id, no unique context file, corrupt
+    JSON, non-mapping payload, non-string/non-absolute field. Never raises.
+    """
+    found = _discover_context_record().get("project_dir", "")
+    if not isinstance(found, str) or not os.path.isabs(found):
+        return ""
+    return found
+
+
+class ProjectScopeDisagreementError(RuntimeError):
+    """A WRITE was refused because CLAUDE_PROJECT_DIR and the session record
+    name different project directories.
+
+    Raised on write paths only (backlog set, memory save, working-memory
+    sync). READS follow the env value: deliberate per-command cross-scope
+    inspection is legitimate, but a write under a disagreed scope is the
+    silent mis-scope this family of issues pays for. The message carries BOTH
+    values and the remedy.
+    """
+
+
+def env_record_project_dir_disagreement() -> tuple[str, str] | None:
+    """Return (env_value, record_value) when both are present AND disagree.
+
+    None when either side is absent (nothing to disagree with) or the two
+    match. Comparison is normcase(normpath(...)) string equality, NOT
+    resolved-path equality: the record holds the platform's value verbatim so
+    textual equality is the invariant by construction, while normpath
+    collapses a trailing slash or '.' segments. Resolving would DERIVE (a
+    symlinked alias would pass), and derivation is what the verbatim rule
+    exists to avoid — a disagreeing write must refuse, not be reconciled.
+    """
+    env_value = os.environ.get("CLAUDE_PROJECT_DIR", "")
+    if not env_value:
+        return None
+    record_value = get_project_dir_from_session_record()
+    if not record_value:
+        return None
+    env_norm = os.path.normcase(os.path.normpath(env_value))
+    record_norm = os.path.normcase(os.path.normpath(record_value))
+    if env_norm == record_norm:
+        return None
+    return env_value, record_value
+
+
+def format_project_dir_disagreement(env_value: str, record_value: str) -> str:
+    """The ONE refusal text every write path raises on an env/record
+    disagreement — both values and the remedy, so the refusal is a visible
+    decision instead of a silent winner."""
+    return (
+        f"CLAUDE_PROJECT_DIR ({env_value}) disagrees with this session's "
+        f"recorded project directory ({record_value}); the write was refused "
+        f"rather than scoped silently. Nothing was written. Run without the "
+        f"override, or re-export CLAUDE_PROJECT_DIR to the recorded value."
+    )
 
 
 def get_session_id_from_context_file(

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -2917,6 +2917,14 @@ def sync_retrieved_to_claude_md(
     # process can legitimately drive it.
     _refuse_ambient_target_under_pytest(None, claude_md_root)
 
+    # The disagreement guard joins it: this function is the FOURTH write path,
+    # and its raise lands in the `except Exception` swallow at the tail, whose
+    # warning interpolates the refusal text — so the diagnostic names both
+    # values and the remedy even though the reason channel reads FAILED (the
+    # one production caller passes sync_to_claude=False, so the guard is inert
+    # in production today; it protects the path's future re-enablement).
+    _refuse_ambient_sync_on_project_dir_disagreement(None, claude_md_root)
+
     claude_md_path, resolved_root = _resolve_display_claude_md_with_base()
 
     # Declared anchor replaces the containment base; it does not steer

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -44,6 +44,26 @@ try:
 except ImportError:
     from config import STORE_ORIGIN_HOME, store_path_origin
 
+# Same dual-import idiom as the config import above. pact_session carries the
+# sys.path bootstrap that makes hooks/shared importable from this package (the
+# precedent the amended twin comments below now cite), and holds the
+# session-record project_dir rung plus the env/record disagreement refusal
+# this module's resolvers and sync guard consume.
+try:
+    from .pact_session import (
+        ProjectScopeDisagreementError,
+        env_record_project_dir_disagreement,
+        format_project_dir_disagreement,
+        get_project_dir_from_session_record,
+    )
+except ImportError:
+    from pact_session import (
+        ProjectScopeDisagreementError,
+        env_record_project_dir_disagreement,
+        format_project_dir_disagreement,
+        get_project_dir_from_session_record,
+    )
+
 # Configure logging
 logger = logging.getLogger(__name__)
 
@@ -162,8 +182,10 @@ COMPRESSED_ENTRY_TOKEN_CEILING = 128
 # writers append `: ` and the value.
 _MEMORY_ID_LABEL = "**Memory ID**"
 
-# Pin caps constants (twin copy of hooks/pin_caps.py — cannot import across
-# the skills-to-hooks package boundary). Drift-detection test in
+# Pin caps constants (twin copy of hooks/pin_caps.py — the import IS possible
+# but requires the sys.path bootstrap pact_session.py in this directory
+# carries; the drift-gated twin remains the chosen mechanism here).
+# Drift-detection test in
 # tests/test_staleness.py guards against divergence; if you change these,
 # update hooks/pin_caps.py in the SAME commit.
 #
@@ -181,9 +203,10 @@ OVERRIDE_RATIONALE_MAX = 120
 # PACT-managed boundary marker prefixes. Used by _find_terminator_offset to
 # terminate section scans on any PACT boundary marker. The canonical
 # definition lives in hooks/shared/claude_md_manager.py as
-# PACT_BOUNDARY_PREFIXES — this module cannot import from hooks/shared/
-# (separate package boundary), so the alternation is inlined here. The
-# three prefixes rarely change; if a 4th is added, update this string.
+# PACT_BOUNDARY_PREFIXES — importing it would require the sys.path bootstrap
+# pact_session.py in this directory carries, so the alternation is inlined
+# here instead. The three prefixes rarely change; if a 4th is added, update
+# this string.
 _PACT_BOUNDARY_ALT = "PACT_MEMORY_|PACT_MANAGED_|PACT_ROUTING_"
 
 # Session-block boundary marker prefix, and it is deliberately NOT a member of
@@ -210,7 +233,9 @@ _SESSION_BOUNDARY_ALT = "SESSION_"
 _SESSION_END_MARKER = f"<!-- {_SESSION_BOUNDARY_ALT}END -->"
 
 # Managed-region boundary markers. Twin copies of the canonical definitions
-# in hooks/shared/claude_md_manager.py (cannot import — separate package).
+# in hooks/shared/claude_md_manager.py (the import would require the sys.path
+# bootstrap pact_session.py in this directory carries; the drift-gated twin
+# remains the chosen mechanism here).
 _MANAGED_START_MARKER = "<!-- PACT_MANAGED_START: Managed by pact-plugin - do not edit this block -->"
 _MANAGED_END_MARKER = "<!-- PACT_MANAGED_END -->"
 
@@ -232,8 +257,9 @@ MEMORY_START_MARKER = "<!-- PACT_MEMORY_START -->"
 MEMORY_END_MARKER = "<!-- PACT_MEMORY_END -->"
 
 # file_lock: vendored twin of hooks/shared/claude_md_manager.file_lock —
-# skills/pact-memory/scripts/ cannot import from hooks/shared/ (separate
-# package boundary). Cross-process correctness is preserved because
+# the import IS possible via the sys.path bootstrap pact_session.py in this
+# directory carries; the drift-gated twin remains the chosen mechanism here.
+# Cross-process correctness is preserved because
 # fcntl.flock serializes on the sidecar inode, not the Python object: a hook
 # process and this skill process locking the SAME .{name}.lock sidecar
 # contend on the same kernel lock. The drift-detection test
@@ -245,8 +271,9 @@ _LOCK_TIMEOUT_SECONDS = 5.0
 _LOCK_POLL_INTERVAL = 0.1
 
 # _sanitize_prompt_field: vendored twin of
-# hooks/shared/session_resume._sanitize_prompt_field — skills/pact-memory/
-# scripts/ cannot import from hooks/shared/ (separate package boundary).
+# hooks/shared/session_resume._sanitize_prompt_field — the import IS possible
+# via the sys.path bootstrap pact_session.py in this directory carries; the
+# drift-gated twin remains the chosen mechanism here.
 # The drift-detection test (TestSanitizePromptFieldTwinCopyDrift in
 # tests/test_staleness.py) guards byte-alignment of the function body with
 # the canonical copy; if you change either, update both in the SAME commit.
@@ -297,8 +324,9 @@ _PROMPT_CONTROL_CHARS_RE = re.compile("[\\x00-\\x1f\\x7f-\\x9f\\u2028\\u2029]+")
 def file_lock(target_file: Path):
     """Acquire an exclusive sidecar file lock for a target CLAUDE.md path.
 
-    Twin of hooks/shared/claude_md_manager.file_lock — kept local because
-    skills/pact-memory/scripts/ cannot import from hooks/shared/. Body MUST
+    Twin of hooks/shared/claude_md_manager.file_lock — kept local as a
+    drift-gated twin; importing the canonical would require the sys.path
+    bootstrap pact_session.py in this directory carries. Body MUST
     stay byte-identical to the canonical copy (drift test enforces this).
 
     NOT RE-ENTRANT: fcntl.flock is non-re-entrant at the OS level. Nesting one
@@ -395,8 +423,10 @@ class ContainmentError(OSError):
     catches it via `except OSError`. Callers convert it to an OPAQUE skip
     message that does not leak the resolved victim path.
 
-    Twin of ContainmentError in `hooks/shared/claude_md_manager.py` (this module
-    cannot import from hooks/shared). The two class defs are trivial markers;
+    Twin of ContainmentError in `hooks/shared/claude_md_manager.py` (importing
+    it would require the sys.path bootstrap pact_session.py in this directory
+    carries; the twin remains the chosen mechanism). The two class defs are
+    trivial markers;
     the load-bearing logic is the containment CHECK inside `_atomic_write_text`,
     drift-gated by TestAtomicWriteTwinCopyDrift.
     """
@@ -428,10 +458,10 @@ def _detect_line_ending(name: str, parent_fd: int) -> str:
     writes its LF template to a name that is not there, so nothing converts.
     A read failure reports LF for the same reason.
 
-    Twin copy: the canonical definition is in `hooks/shared/claude_md_manager.py`
-    and this module cannot import from `hooks/shared/` (separate package), the
-    same constraint that produced the `file_lock` and `_atomic_write_text`
-    twins. The two bodies are gated identical by
+    Twin copy: the canonical definition is in `hooks/shared/claude_md_manager.py`;
+    importing it would require the sys.path bootstrap pact_session.py in this
+    directory carries, the same consideration that keeps the `file_lock` and
+    `_atomic_write_text` twins. The two bodies are gated identical by
     TestLineEndingHelperTwinCopyDrift.
 
     Args:
@@ -480,8 +510,9 @@ def _restore_line_ending(content: str, line_ending: str) -> str:
     keeps its early return, so an LF file is byte-identical to what this wrote
     before.
 
-    Twin copy: the canonical definition is in `hooks/shared/claude_md_manager.py`
-    and this module cannot import from `hooks/shared/` (separate package). The
+    Twin copy: the canonical definition is in `hooks/shared/claude_md_manager.py`;
+    importing it would require the sys.path bootstrap pact_session.py in this
+    directory carries. The
     two bodies are gated identical by TestLineEndingHelperTwinCopyDrift.
 
     Args:
@@ -596,9 +627,10 @@ def _atomic_write_text(target: Path, content: str, project_root: Path) -> None:
     version-invariant end-to-end, and a symlink loop still raises upstream.
 
     NOTE: a deliberate duplicate of `_atomic_write_text` in
-    `hooks/shared/claude_md_manager.py`. This module cannot import from
-    `hooks/shared/` (separate package), the same constraint that produced the
-    `file_lock` twin above. This twin IS drift-gated by
+    `hooks/shared/claude_md_manager.py`. Importing it would require the
+    sys.path bootstrap pact_session.py in this directory carries, the same
+    consideration that keeps the `file_lock` twin above. This twin IS
+    drift-gated by
     TestAtomicWriteTwinCopyDrift: the
     containment CHECK is a security invariant that must not silently diverge
     between the hook and skill copies (#1118-class hazard). That gate compares
@@ -854,7 +886,8 @@ def extract_managed_region(content: str) -> Optional[Tuple[str, int]]:
     is deliberately deferred rather than invented here.
 
     Twin of hooks/shared/claude_md_manager.extract_managed_region — kept
-    local because skills/pact-memory/scripts/ cannot import from hooks/shared/.
+    local as a drift-gated twin; importing the canonical would require the
+    sys.path bootstrap pact_session.py in this directory carries.
 
     Returns (region_text, start_offset) where start_offset is the absolute
     position of the first character after MANAGED_START_MARKER. Returns None
@@ -1035,14 +1068,15 @@ def _get_claude_md_path() -> Optional[Path]:
     """
     Get the path to CLAUDE.md in the project root.
 
-    Uses CLAUDE_PROJECT_DIR environment variable if set, then falls back
-    to git worktree/repo root detection, then to current working directory.
-    At each level, checks both `.claude/CLAUDE.md` (new default) and
-    `./CLAUDE.md` (legacy) in priority order.
+    Uses CLAUDE_PROJECT_DIR environment variable if set, then the session
+    record's project_dir, then git worktree/repo root detection, then the
+    current working directory. At each level, checks both `.claude/CLAUDE.md`
+    (new default) and `./CLAUDE.md` (legacy) in priority order.
 
     Note: This mirrors the resolution strategy in hooks/staleness.py
-    (get_project_claude_md_path). Kept as a local copy because this
-    module lives in skills/ and cannot import from hooks/.
+    (get_project_claude_md_path). Kept as a local copy: importing staleness
+    would require the sys.path bootstrap pact_session.py in this directory
+    carries, and the drift-noted twin remains the chosen mechanism here.
 
     Returns:
         Path to CLAUDE.md if it exists, None otherwise.
@@ -1050,6 +1084,19 @@ def _get_claude_md_path() -> Optional[Path]:
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
     if project_dir:
         found = _find_existing_claude_md(Path(project_dir))
+        if found is not None:
+            return found
+
+    # Session-record rung: the directory session_init recorded at SessionStart,
+    # discovered via the CLAUDE_CODE_SESSION_ID glob in pact_session. Below env
+    # (a present declaration wins), ABOVE the git/cwd derivations — in a
+    # multi-repo workspace the cwd's git root can be the WRONG scope. The
+    # existence coupling is preserved: the record supplies the base to PROBE,
+    # and a miss falls through exactly like an env miss (this resolver never
+    # creates CLAUDE.md).
+    record_dir = get_project_dir_from_session_record()
+    if record_dir:
+        found = _find_existing_claude_md(Path(record_dir))
         if found is not None:
             return found
 
@@ -1095,6 +1142,15 @@ def _resolve_display_claude_md_with_base() -> Tuple[Optional[Path], Optional[Pat
     thin wrapper returning `[0]`):
       1. CLAUDE_PROJECT_DIR env var, if set -> that dir's .claude/CLAUDE.md
          (preferred) or ./CLAUDE.md (legacy).
+      1.5. Session record — the project_dir session_init recorded at
+         SessionStart -> the same probe under the recorded dir. Below env
+         (a present declaration wins), above the git derivations: in a
+         multi-repo workspace the cwd's git root can be the WRONG scope. The
+         existence coupling is preserved — the record supplies the base to
+         PROBE and a miss falls through; this resolver never creates
+         CLAUDE.md. (Numbered 1.5, matching memory_api's Strategy 1.5, so the
+         long-standing branch-2/branch-3 references to the git anchors below
+         keep their meaning.)
       2. Git worktree root via `git rev-parse --show-toplevel` -> the same
          .claude/-then-legacy probe under the worktree root.
       3. Main repo root via `git rev-parse --git-common-dir`.parent -> the
@@ -1134,6 +1190,15 @@ def _resolve_display_claude_md_with_base() -> Tuple[Optional[Path], Optional[Pat
         project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
         if project_dir:
             base = Path(project_dir)
+            found = _find_existing_claude_md(base)
+            if found is not None:
+                return found, base
+
+        # Branch 1.5: session record (see the docstring's ordering). Same probe
+        # shape as the env branch; a miss falls through to the git anchors.
+        record_dir = get_project_dir_from_session_record()
+        if record_dir:
+            base = Path(record_dir)
             found = _find_existing_claude_md(base)
             if found is not None:
                 return found, base
@@ -1556,7 +1621,8 @@ def _sanitize_prompt_field(
     """Sanitize a record field value for interpolation into CLAUDE.md.
 
     Twin of hooks/shared/session_resume._sanitize_prompt_field — kept local
-    because skills/pact-memory/scripts/ cannot import from hooks/shared/.
+    as a drift-gated twin; importing the canonical would require the sys.path
+    bootstrap pact_session.py in this directory carries.
     Body MUST stay byte-identical to the canonical copy (drift test enforces
     this); this docstring is allowed to differ. Change either copy and you
     change both in the SAME commit.
@@ -1965,8 +2031,9 @@ def _project_root_of(claude_md_path: Path) -> Path:
     re-derivation from the leaf.
 
     The two-layout knowledge is owned by `hooks/shared/claude_md_manager.py`
-    (`_DOT_CLAUDE_RELATIVE` / `_LEGACY_RELATIVE`); this module cannot import
-    from that package and vendors twins throughout, so this mirrors it. If a
+    (`_DOT_CLAUDE_RELATIVE` / `_LEGACY_RELATIVE`); importing it would require
+    the sys.path bootstrap pact_session.py in this directory carries, and
+    this module vendors twins throughout, so this mirrors it. If a
     THIRD location is ever supported, this must be swept with the others.
     """
     parent = claude_md_path.parent
@@ -2059,6 +2126,41 @@ class SyncResult:
 
 class AmbientSyncRefused(RuntimeError):
     """Raised when a test process would sync to an ambiently-resolved CLAUDE.md."""
+
+
+def _refuse_ambient_sync_on_project_dir_disagreement(
+    target: Optional[Path],
+    claude_md_root: Optional[Path] = None,
+) -> None:
+    """Refuse an AMBIENT working-memory sync when CLAUDE_PROJECT_DIR and the
+    session record name different project directories.
+
+    The write-path half of the read contract's disagreement policy. READS
+    follow the env value (deliberate per-command cross-scope inspection is
+    legitimate); WRITES fail closed, because a sync under a disagreed scope
+    projects one scope's records over another scope's file — the silent
+    mis-scope this family of issues pays for. The refusal text (both values +
+    remedy) comes from pact_session's ONE formatter, shared with the backlog
+    and memory-save refusals so all three paths say the same words.
+
+    SCOPE mirrors the sibling ambient guards deliberately: an explicit
+    `target` or a declared `claude_md_root` is a warrant that names the
+    destination, making the ambient disagreement moot.
+
+    Raises ProjectScopeDisagreementError rather than returning a falsy
+    SyncResult, matching the sibling guard's rationale: a quiet falsy would
+    leave a deliberate refusal indistinguishable from a broken one.
+    """
+    if target is not None:
+        return
+    if claude_md_root is not None:
+        return
+    disagreement = env_record_project_dir_disagreement()
+    if disagreement is None:
+        return
+    raise ProjectScopeDisagreementError(
+        format_project_dir_disagreement(*disagreement)
+    )
 
 
 def _refuse_ambient_target_under_pytest(
@@ -2264,7 +2366,7 @@ def sync_to_claude_md(
     it is the whole section: the pre-formatted entries, newest first, are
     written in place of whatever the section holds, and the file's existing
     entries are not consulted. `memory`, `files` and `memory_id` are ignored
-    on that arm. Everything else -- resolution, both ambient guards, the
+    on that arm. Everything else -- resolution, the ambient guards, the
     lock, the splice window, the budget, containment and the `SyncResult` --
     is the same code on both arms, which is why the replace is a keyword here
     and not a second writer.
@@ -2367,9 +2469,12 @@ def sync_to_claude_md(
         A REFUSAL DOES NOT COME BACK THIS WAY. The ambient-target guard RAISES
         `AmbientSyncRefused` before any of these returns, so `SyncResult.REFUSED`
         is produced by whoever catches it, not here. See the guard's own
-        docstring for why it raises rather than returns.
+        docstring for why it raises rather than returns. The disagreement guard
+        beside it raises `ProjectScopeDisagreementError` the same way, and for
+        the same reason.
     """
     _refuse_ambient_target_under_pytest(target, claude_md_root)
+    _refuse_ambient_sync_on_project_dir_disagreement(target, claude_md_root)
 
     if target is not None:
         claude_md_path = Path(target)

--- a/pact-plugin/tests/conftest.py
+++ b/pact-plugin/tests/conftest.py
@@ -336,6 +336,32 @@ def _scrub_claude_plugin_root_env():
 
 
 @pytest.fixture(autouse=True)
+def _scrub_claude_env_file_env():
+    """Pop + restore ``os.environ['CLAUDE_ENV_FILE']`` around every test.
+    Runs for EVERY test (autouse).
+
+    session_init.main() reads ``CLAUDE_ENV_FILE`` and APPENDS an
+    ``export CLAUDE_PROJECT_DIR=...`` line to it whenever the variable and
+    ``CLAUDE_PROJECT_DIR`` are both present. A suite running inside a real
+    hook process (or a developer shell that sourced one) carries a LIVE
+    session env file in the environment, and every main()-driving test that
+    sets ``CLAUDE_PROJECT_DIR`` would append a bogus export line to that live
+    file — the same ambient-env hazard class ``_scrub_claude_plugin_root_env``
+    closes. Same posture: POP at setup so every test starts from a
+    guaranteed-unset baseline, restore the original at teardown. Tests that
+    exercise the env-file channel set the variable explicitly via
+    ``monkeypatch.setenv`` (which overrides the scrub for that test).
+    """
+    _UNSET = object()
+    original = os.environ.pop("CLAUDE_ENV_FILE", _UNSET)
+    yield
+    if original is _UNSET:
+        os.environ.pop("CLAUDE_ENV_FILE", None)
+    else:
+        os.environ["CLAUDE_ENV_FILE"] = original
+
+
+@pytest.fixture(autouse=True)
 def _isolate_config_root_to_tmp(tmp_path, monkeypatch):
     """Redirect the Claude Code config/state root to a per-test tmp tree for
     EVERY test (autouse, opt-OUT), via TWO mechanisms: scrub any inherited

--- a/pact-plugin/tests/fixtures/project_dir.py
+++ b/pact-plugin/tests/fixtures/project_dir.py
@@ -12,6 +12,7 @@ fixtures; nothing here is injected.
 
 import json
 import os
+import shlex
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -194,8 +195,6 @@ def source_export_line(env_file: Path, name: str) -> Optional[str]:
     row asserts the value a spawned Bash WOULD see. shlex.split is the honest
     inverse of the producer's shlex.quote.
     """
-    import shlex
-
     if not env_file.exists():
         return None
     prefix = f"export {name}="

--- a/pact-plugin/tests/fixtures/project_dir.py
+++ b/pact-plugin/tests/fixtures/project_dir.py
@@ -1,0 +1,168 @@
+"""
+Project-dir read-contract test helpers: umbrella tree factory, session-context
+writer, discovery enabler, and subprocess env builder.
+
+Consumed by: tests/test_project_dir_resolution.py (Phase B of
+claude-project-dir-once — the session-record rung and the fail-closed
+env/record write refusal).
+
+Per the thin-conftest rule these are direct-import helpers, not pytest
+fixtures; nothing here is injected.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional
+
+from shared.pact_context import project_slug
+
+# Sentinel for child_env's project_dir argument: leave the variable ABSENT in
+# the child (distinct from setting it to "").
+DELETE = object()
+
+
+def make_umbrella(tmp_path: Path) -> SimpleNamespace:
+    """Fabricate the umbrella workspace the read contract exists for.
+
+    Layout under ``tmp_path``:
+      - ``.claude/`` — the config root children resolve (CLAUDE_CONFIG_DIR).
+      - ``umbrella/`` — the project workspace: NO ``.git`` of its own, a
+        CLAUDE.md carrying the managed markers, and ``subrepo/`` with its own
+        ``git init`` and NO CLAUDE.md.
+
+    PRECONDITION GUARD (not optional): ``git -C <umbrella> rev-parse`` MUST
+    FAIL at setup. A contributor whose TMPDIR sits under a repository would
+    otherwise watch the marker walk / git rung resolve their TMPDIR's root,
+    and every umbrella arm would measure that foreign repo while reading as
+    the umbrella one.
+    """
+    config_root = tmp_path / ".claude"
+    config_root.mkdir()
+    umbrella = tmp_path / "umbrella"
+    umbrella.mkdir()
+    (umbrella / "CLAUDE.md").write_text(
+        "# umbrella\n\n<!-- PACT_MANAGED_START: Managed by pact-plugin - do not edit this block -->\n"
+        "<!-- PACT_MANAGED_END -->\n",
+        encoding="utf-8",
+    )
+    subrepo = umbrella / "subrepo"
+    subrepo.mkdir()
+    subprocess.run(
+        ["git", "init", "-q", str(subrepo)],
+        check=True,
+        capture_output=True,
+        env={**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull},
+    )
+
+    probe = subprocess.run(
+        ["git", "-C", str(umbrella), "rev-parse"],
+        capture_output=True,
+        env={**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull},
+    )
+    assert probe.returncode != 0, (
+        f"git resolves a repository at/above {umbrella} — the umbrella is not "
+        f"git-less (TMPDIR under a repo?), so every arm built on it would "
+        f"measure the wrong scope"
+    )
+    return SimpleNamespace(config_root=config_root, project=umbrella, subrepo=subrepo)
+
+
+def write_session_context(
+    config_root: Path,
+    session_id: str,
+    project_dir: Path,
+    *,
+    slug: Optional[str] = None,
+    body: Optional[str] = None,
+) -> Path:
+    """Write a pact-session-context.json where the discovery glob looks:
+    ``<config_root>/pact-sessions/<slug>/<session_id>/pact-session-context.json``.
+
+    The glob wildcard matches ANY slug directory, so the slug only needs to be
+    present; it defaults to the writer's own derivation (project_slug of the
+    recorded dir) so the fixture stays faithful to production. ``body``
+    overrides the whole payload for the corrupt/shape arms.
+    """
+    slug = slug if slug is not None else project_slug(str(project_dir))
+    target_dir = config_root / "pact-sessions" / slug / session_id
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / "pact-session-context.json"
+    if body is None:
+        body = json.dumps({
+            "team_name": "session-test",
+            "session_id": session_id,
+            "project_dir": str(project_dir),
+            "plugin_root": "",
+            "started_at": "2026-01-01T00:00:00Z",
+        })
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+def enable_record_discovery(monkeypatch, pact_session_module) -> None:
+    """Turn the shipped PYTEST_CURRENT_TEST refusal off for the test body.
+
+    Same pattern as test_session_discovery_route.enable_discovery: the refusal
+    reads os.environ, so deleting the variable supplies the REAL predicate a
+    different input — no stub, no seam. MUST be called from the test body
+    (pytest re-sets the variable between phases), and ONLY after the sandbox
+    assertion: with the refusal off, the discovery glob must be rooted under
+    the per-test tmp home, never the operator's real one.
+    """
+    real_home = Path(os.path.expanduser("~")).resolve()
+    assert Path.home().resolve() != real_home, (
+        "REFUSING to enable discovery: Path.home() is the real home, so the "
+        "autouse redirect is not in effect and the glob would search the "
+        "operator's live session directory"
+    )
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(
+        pact_session_module, "_discovered_record", pact_session_module._DISCOVERY_UNSET
+    )
+    assert not os.environ.get("PYTEST_CURRENT_TEST"), (
+        "the pytest marker is still set — the refusal will fire and every "
+        "assertion below would pass without exercising the record route"
+    )
+
+
+def child_env(
+    config_root: Path,
+    *,
+    home: Path,
+    session_id: Optional[str] = None,
+    project_dir=DELETE,
+    memory_dir: Optional[Path] = None,
+) -> dict:
+    """A CONSTRUCTED env for a subprocess row — never an os.environ copy.
+
+    An inherited env leaks the operator's session (CLAUDE_CODE_SESSION_ID),
+    the suite's pytest marker (PYTEST_CURRENT_TEST, which would trip the
+    record discovery's refusal in the child), and the real config root into
+    the child, and the row would pass against live session state. Only what a
+    row names crosses the boundary:
+
+    - PATH (the child must find git/python)
+    - HOME=home — Path.home monkeypatching does NOT cross the process
+      boundary, so the child's home fallback must come from the real variable
+    - CLAUDE_CONFIG_DIR=config_root (the fixture's tmp config root)
+    - CLAUDE_CODE_SESSION_ID=session_id when given (the discovery glob key)
+    - CLAUDE_PROJECT_DIR=project_dir when given; ABSENT when DELETE (the
+      default), which is the point of most rows
+    - PACT_TEST_MEMORY_DIR=memory_dir when given (the store redirect; the
+      child must not open the operator's real memory store)
+    """
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": str(home),
+        "CLAUDE_CONFIG_DIR": str(config_root),
+    }
+    if session_id is not None:
+        env["CLAUDE_CODE_SESSION_ID"] = session_id
+    if project_dir is not DELETE:
+        env["CLAUDE_PROJECT_DIR"] = str(project_dir)
+    if memory_dir is not None:
+        env["PACT_TEST_MEMORY_DIR"] = str(memory_dir)
+    return env

--- a/pact-plugin/tests/fixtures/project_dir.py
+++ b/pact-plugin/tests/fixtures/project_dir.py
@@ -166,3 +166,41 @@ def child_env(
     if memory_dir is not None:
         env["PACT_TEST_MEMORY_DIR"] = str(memory_dir)
     return env
+
+
+def git_flake_shim(tmp_path: Path) -> Path:
+    """A PATH shim dir whose `git` ALWAYS fails — the #1600 induced-flakiness
+    experiment as a permanent fixture.
+
+    Prepended to PATH it makes every git subprocess exit 1, so a resolution
+    arm can prove its answer cannot have come from git. Pair every shimmed arm
+    with a shim-LIVE control (an arm where git's death changes the answer) —
+    without it, a shim that never took effect reads identically to the
+    invariant it exists to prove.
+    """
+    shim_dir = tmp_path / "git-shim"
+    shim_dir.mkdir(exist_ok=True)
+    shim = shim_dir / "git"
+    shim.write_text("#!/bin/sh\necho 'git: disabled by test shim' >&2\nexit 1\n")
+    shim.chmod(0o755)
+    return shim_dir
+
+
+def source_export_line(env_file: Path, name: str) -> Optional[str]:
+    """Parse `export NAME=<shlex-quoted value>` back out of an env file.
+
+    pytest standing in for the platform's source step: the platform reads
+    CLAUDE_ENV_FILE and exports the lines into the next Bash tool env; the
+    row asserts the value a spawned Bash WOULD see. shlex.split is the honest
+    inverse of the producer's shlex.quote.
+    """
+    import shlex
+
+    if not env_file.exists():
+        return None
+    prefix = f"export {name}="
+    for line in env_file.read_text(encoding="utf-8").splitlines():
+        if line.startswith(prefix):
+            parts = shlex.split(line[len(prefix):])
+            return parts[0] if parts else ""
+    return None

--- a/pact-plugin/tests/runbooks/claude-env-file-probe.md
+++ b/pact-plugin/tests/runbooks/claude-env-file-probe.md
@@ -1,0 +1,67 @@
+# Runbook: CLAUDE_ENV_FILE dogfood live-probe (Phase A gate, claude-project-dir-once)
+
+**Purpose:** the ONE documented live-probe smoke note for the
+`CLAUDE_ENV_FILE` distribution channel that `hooks/session_init.py` Phase A
+relies on. The unit/integration layers ship in the PR
+(`tests/test_session_init_env_file.py`); what they cannot prove is the
+platform half of the contract — that a SessionStart hook's appended
+`export VAR=value` line actually lands in a subsequent Bash-tool environment.
+This runbook is that measurement, plus the two premises the design keys on
+(hook cwd, version floor).
+
+**Status: RUN 2026-09-09, Claude Code 2.1.266, macOS (Darwin).** Results in §3.
+
+## §1 — Method (throwaway; never the shipped hooks.json)
+
+Scratch config only — the probe registers a one-line SessionStart hook in a
+disposable `CLAUDE_CONFIG_DIR`, never in any real config:
+
+1. `mkdir -p /tmp/pact-env-file-probe/{config,project}`; scratch
+   `config/settings.json` registers a matcher-less SessionStart hook running
+   `/tmp/pact-env-file-probe/hook.sh`.
+2. `hook.sh` logs `pwd`, `$CLAUDE_PROJECT_DIR`, `$CLAUDE_ENV_FILE` to a probe
+   log, then appends `export PACT_PROBE_VAR=probe-ok` to `"$CLAUDE_ENV_FILE"`
+   (guarded on non-empty, per the hooks doc's own example shape).
+3. Headless leg: from the probe project dir,
+   `CLAUDE_CONFIG_DIR=/tmp/pact-env-file-probe/config claude -p --dangerously-skip-permissions "<prompt that runs exactly: echo PROBE_VALUE=${PACT_PROBE_VAR:-UNSET}>"`.
+4. Control leg: same prompt against a hook-less scratch config — must print
+   `PROBE_VALUE=UNSET`, separating the env-file channel from ambient shell
+   inheritance.
+
+## §2 — Acceptance criteria
+
+1. **Channel works:** headless spawned-Bash prints `PROBE_VALUE=probe-ok`;
+   control prints `PROBE_VALUE=UNSET`.
+2. **Hook-cwd premise:** `os.getcwd()` semantics inside a SessionStart hook
+   match the platform's `CLAUDE_PROJECT_DIR` (soundness of the record-side
+   cwd-fallback leg).
+3. **Version floor:** changelog evidence for when `CLAUDE_ENV_FILE` became
+   reliable; the shipped hook must no-op cleanly when the var is unset.
+
+## §3 — Results (2026-09-09, v2.1.266)
+
+1. **PASS.** Headless leg printed `PROBE_VALUE=probe-ok`; hook-less control
+   printed `PROBE_VALUE=UNSET`. The env-file append reaches the spawned
+   Bash-tool environment. `$CLAUDE_ENV_FILE` pointed at
+   `<config>/session-env/<session-uuid>/sessionstart-hook-0.sh`.
+2. **PASS, with a macOS nuance.** Hook process received
+   `CLAUDE_PROJECT_DIR=/private/tmp/pact-env-file-probe/project`; the shell's
+   logical `pwd` printed `/tmp/...` (macOS `/tmp` symlink), but Python's
+   `os.getcwd()` returns the PHYSICAL path (`/private/tmp/...`) — matching the
+   platform value. The premise holds for the Python implementation; a
+   shell-level string comparison would false-negative through symlinked roots.
+3. **Floor: introduction not changelogged.** Earliest `CLAUDE_ENV_FILE`
+   changelog entries are fixes (2.1.108, 2.1.111, 2.1.136 — the last covers
+   staleness after `/resume` or `/clear`). Installed 2.1.266 postdates all of
+   them. The implementation's unset-var no-op covers older versions by
+   failing open.
+
+**Unverified modes (explicitly not claimed):** in-process teammate Bash and
+tmux teammate Bash propagation were not launchable from the teammate session
+that ran this probe. The measured leg is the headless spawned-Bash path; the
+interactive spawned-Bash path shares the Bash tool's env construction but was
+not separately driven. The session-record rung (Phase B) covers sessions
+where the channel is absent.
+
+**Cleanup:** `/tmp/pact-env-file-probe/` is throwaway; no shipped file
+references it. Re-run by repeating §1 on any newer platform version.

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -4662,6 +4662,17 @@ def test_an_unset_or_non_directory_project_dir_still_refuses(tmp_path, monkeypat
         def main_repo_root(start=None):
             return None
 
+        # The session-record channel, inert: under pytest the real discovery
+        # refuses, and these arms pin the no-record behaviour, so the double
+        # answers "no record" / "no disagreement" explicitly.
+        @staticmethod
+        def get_project_dir_from_session_record():
+            return ""
+
+        @staticmethod
+        def env_record_project_dir_disagreement():
+            return None
+
     monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
     monkeypatch.setattr(backlog, "_memory_api", lambda: _NoGit)
     try:
@@ -4739,6 +4750,17 @@ def test_a_directory_inside_a_repository_git_cannot_read_still_refuses(tmp_path,
 
         @staticmethod
         def main_repo_root(start=None):
+            return None
+
+        # The session-record channel, inert: under pytest the real discovery
+        # refuses, and these arms pin the no-record behaviour, so the double
+        # answers "no record" / "no disagreement" explicitly.
+        @staticmethod
+        def get_project_dir_from_session_record():
+            return ""
+
+        @staticmethod
+        def env_record_project_dir_disagreement():
             return None
 
     monkeypatch.setattr(backlog, "_memory_api", lambda: _NoGit)

--- a/pact-plugin/tests/test_config_injection_both_modes.py
+++ b/pact-plugin/tests/test_config_injection_both_modes.py
@@ -65,6 +65,9 @@ def _emit(frame, monkeypatch, tmp_path):
     injection test uses, so the REAL classify_session_role -> gate ->
     format_pact_runtime_config path executes."""
     monkeypatch.setenv("CLAUDE_PROJECT_DIR", _PROJECT_DIR)
+    # session_init.main() now appends to $CLAUDE_ENV_FILE when both vars are
+    # present — keep these drives hermetic against an ambient env file.
+    monkeypatch.delenv("CLAUDE_ENV_FILE", raising=False)
     # PACT_PR_GREEDY_FIX on so a PRESENT block is unambiguous (ON text); the gate
     # decision under test is presence/absence, independent of the value.
     monkeypatch.setenv("PACT_PR_GREEDY_FIX", "1")

--- a/pact-plugin/tests/test_project_dir_resolution.py
+++ b/pact-plugin/tests/test_project_dir_resolution.py
@@ -39,6 +39,7 @@ import sqlite3
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -1159,3 +1160,153 @@ class TestLiberalReadsUnderDisagreement:
         assert got.returncode == 0, f"get refused a read: {got.stderr[:400]!r}"
         assert "SCOPE_DISAGREEMENT" not in got.stderr
         assert "LIBERAL-READ-SEED" in got.stdout
+
+
+# ---------------------------------------------------------------------------
+# Cycle-2: the refusal surface extends to update()/delete() and the
+# retrieved-sync projection warns through its swallow
+# ---------------------------------------------------------------------------
+
+def _store_row_context(store: Path, memory_id: str) -> str:
+    with sqlite3.connect(str(store)) as conn:
+        return conn.execute(
+            "SELECT context FROM memories WHERE id = ?", (memory_id,)
+        ).fetchone()[0]
+
+
+class TestUpdateDeleteRefusalOnDisagreement:
+    """update()/delete() are writes: under an env/record disagreement they
+    refuse with both values + remedy BEFORE any store mutation; under
+    agreement they proceed (the guard must not over-fire)."""
+
+    def _seed_and_arm(self, tmp_path, monkeypatch):
+        """A committed row scoped to the env project (written with NO session
+        behind it), then the disagreement armed on top of it."""
+        umbrella = make_umbrella(tmp_path)
+        other = tmp_path / "other"
+        other.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(other))
+        memory = PACTMemory()  # constructed AFTER the env manipulation
+        seed_id = memory.save({"context": "CYCLE2-SEED", "goal": "g"})
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        return umbrella, other, memory, seed_id
+
+    def test_update_refuses_naming_both_values_before_any_mutation(
+        self, tmp_path, monkeypatch
+    ):
+        umbrella, other, memory, seed_id = self._seed_and_arm(tmp_path, monkeypatch)
+        store = tmp_path / ".claude" / "pact-memory" / "memory.db"
+        before = _store_row_context(store, seed_id)
+
+        with pytest.raises(ProjectScopeDisagreementError) as excinfo:
+            memory.update(seed_id, {"context": "CYCLE2-MUTATED"})
+        text = str(excinfo.value)
+        assert str(other) in text, "the refusal does not name the env value"
+        assert str(umbrella.project) in text, "the refusal does not name the record"
+        assert "re-export CLAUDE_PROJECT_DIR" in text, "the refusal names no remedy"
+        assert _store_row_context(store, seed_id) == before, (
+            "a refused update still mutated the row"
+        )
+
+    def test_delete_refuses_naming_both_values_before_any_mutation(
+        self, tmp_path, monkeypatch
+    ):
+        umbrella, other, memory, seed_id = self._seed_and_arm(tmp_path, monkeypatch)
+        store = tmp_path / ".claude" / "pact-memory" / "memory.db"
+
+        with pytest.raises(ProjectScopeDisagreementError) as excinfo:
+            memory.delete(seed_id)
+        text = str(excinfo.value)
+        assert str(other) in text and str(umbrella.project) in text
+        assert "re-export CLAUDE_PROJECT_DIR" in text
+        assert _store_row_context(store, seed_id) == "CYCLE2-SEED", (
+            "a refused delete still removed the row"
+        )
+
+    def test_agreement_update_and_delete_proceed(self, tmp_path, monkeypatch):
+        """The guard must not over-fire: with env == record, update and delete
+        behave exactly as before."""
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(umbrella.project))
+        memory = PACTMemory()
+        seed_id = memory.save({"context": "CYCLE2-AGREE", "goal": "g"})
+
+        assert memory.update(seed_id, {"context": "CYCLE2-UPDATED"}) == seed_id
+        store = tmp_path / ".claude" / "pact-memory" / "memory.db"
+        assert "CYCLE2-UPDATED" in _store_row_context(store, seed_id)
+        assert memory.delete(seed_id) == seed_id
+
+
+class TestRetrievedSyncWarnsUnderDisagreement:
+    def test_search_swallow_warns_with_the_disagreement_and_does_not_raise(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """The retrieved-context projection is a read side-effect: under a
+        disagreement the projection's guard raises, search()'s swallow turns
+        it into a WARNING that names the disagreement, and no exception
+        escapes to the caller."""
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        other = tmp_path / "other"
+        other.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(other))
+
+        fake_result = SimpleNamespace(
+            id="fake-memory-id",
+            to_dict=lambda: {"context": "CYCLE2-RETRIEVED", "goal": "g"},
+        )
+        monkeypatch.setattr(
+            "scripts.memory_api.graph_enhanced_search",
+            lambda *a, **kw: [fake_result],
+        )
+        memory = PACTMemory(project_id="proj")
+        with caplog.at_level(logging.WARNING):
+            results = memory.search("anything", sync_to_claude=True)
+        assert results == [fake_result], "the read itself must not refuse"
+        warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any(
+            "disagrees" in w and str(other) in w and str(umbrella.project) in w
+            for w in warnings
+        ), (
+            f"the swallow's warning does not name the disagreement: {warnings}"
+        )
+
+
+class TestWarrantedSyncProceedsUnderDisagreement:
+    """The claude_md_root warrant on the public sync path: a caller that
+    DECLARES the containment anchor has named its destination, so the ambient
+    disagreement is moot — the write proceeds to the named root, NOT the
+    record scope. The no-warrant path still refuses (TestWriteRefusalOn-
+    Disagreement and the TestSyncCliEnvelope row are the counter arms)."""
+
+    def test_sync_with_declared_root_proceeds_to_the_named_destination(
+        self, tmp_path, monkeypatch
+    ):
+        """The declared root is a CONTAINMENT warrant, not a steering knob:
+        the display resolver still resolves env-first (branch 1), so the
+        honest shape is env == the named destination's root, with the warrant
+        making the ambient disagreement (record names the umbrella) moot."""
+        umbrella = make_umbrella(tmp_path)
+        umbrella_md = _seed_claude_md(umbrella.project)
+        other = tmp_path / "other"
+        other_md = _seed_claude_md(other)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(other))
+        # A record committed under the env scope with NO session behind it.
+        memory = PACTMemory()
+        memory.save({"context": "WARRANT-TOKEN", "goal": "g"})
+        # NOW the disagreement is armed (record=umbrella, env=other).
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+
+        written_ids = memory.sync(claude_md_root=other)
+        assert memory.last_sync_status == wm.SyncResult.WROTE, (
+            f"a warranted sync under disagreement must proceed; got "
+            f"{memory.last_sync_status}"
+        )
+        assert written_ids, "the warranted sync projected no records"
+        assert "WARRANT-TOKEN" in other_md.read_text(encoding="utf-8"), (
+            "the projection did not land under the NAMED root"
+        )
+        assert "WARRANT-TOKEN" not in umbrella_md.read_text(encoding="utf-8"), (
+            "the projection reached the record-scoped file despite the warrant"
+        )

--- a/pact-plugin/tests/test_project_dir_resolution.py
+++ b/pact-plugin/tests/test_project_dir_resolution.py
@@ -1101,6 +1101,55 @@ class TestSyncCliEnvelope:
             f"the refusal must name both values; stderr: {proc.stderr!r}"
         )
 
+    def test_sync_cli_with_declared_root_proceeds_under_disagreement(self, tmp_path):
+        """The warrant at the CLI layer: `sync --claude-md-root <env-scoped
+        root>` under an env/record disagreement exits 0 and projects under the
+        NAMED root (containment warrant, not steering — resolution is
+        env-first and unchanged). The refusal row above is the counter arm."""
+        umbrella = make_umbrella(tmp_path)
+        umbrella_md = _seed_claude_md(umbrella.project)
+        other = tmp_path / "other"
+        other_md = _seed_claude_md(other)
+        store = tmp_path / "memory.db"
+        env = child_env(
+            umbrella.config_root, home=tmp_path, session_id=SID,
+            project_dir=other, memory_dir=tmp_path / "memdir",
+        )
+        # Seed under the env scope with NO record yet on disk (no disagreement
+        # until the context file exists — write it after the seed).
+        seed_env = dict(env)
+        del seed_env["CLAUDE_CODE_SESSION_ID"]
+        setup = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "setup", "--db-path", str(store)],
+            capture_output=True, text=True, env=seed_env, cwd=str(other), timeout=120,
+        )
+        assert setup.returncode == 0, f"store setup failed: {setup.stderr[:400]!r}"
+        save = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "save", "--db-path", str(store),
+             json.dumps({"context": "WARRANT-CLI-TOKEN", "goal": "g"})],
+            capture_output=True, text=True, env=seed_env, cwd=str(other), timeout=120,
+        )
+        assert save.returncode == 0, f"seed save failed: {save.stderr[:400]!r}"
+        write_session_context(umbrella.config_root, SID, umbrella.project)
+
+        proc = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "sync", "--db-path", str(store),
+             "--claude-md-root", str(other)],
+            capture_output=True, text=True, env=env, cwd=str(other), timeout=120,
+        )
+        assert proc.returncode == 0, (
+            f"a warranted sync refused at the CLI layer: {proc.stderr[:400]!r}"
+        )
+        assert "SCOPE_DISAGREEMENT" not in proc.stderr
+        envelope = json.loads(proc.stdout)
+        assert envelope["ok"] is True and envelope["result"]["sync_status"] == "wrote"
+        assert "WARRANT-CLI-TOKEN" in other_md.read_text(encoding="utf-8"), (
+            "the projection did not land under the named root"
+        )
+        assert "WARRANT-CLI-TOKEN" not in umbrella_md.read_text(encoding="utf-8"), (
+            "the projection reached the record-scoped file despite the warrant"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Edge: READS proceed under an env/record disagreement (the liberal half)

--- a/pact-plugin/tests/test_project_dir_resolution.py
+++ b/pact-plugin/tests/test_project_dir_resolution.py
@@ -189,6 +189,38 @@ class TestSessionRecordReader:
         monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
         assert pact_session.get_project_dir_from_session_record() == ""
 
+    def test_mismatched_session_id_in_the_record_is_rejected(self, tmp_path, monkeypatch):
+        """The payload's session_id must equal the env id that LOCATED the
+        file: a mismatch means the globbed record is not this session's own
+        (misfiled or planted), so it reads as no record and resolution falls
+        through to the git rung."""
+        umbrella = make_umbrella(tmp_path)
+        enable_record_discovery(monkeypatch, pact_session)
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", SID)
+        write_session_context(
+            Path.home() / ".claude", SID, umbrella.project,
+            body=json.dumps({"session_id": "some-other-session", "project_dir": str(umbrella.project)}),
+        )
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        assert pact_session.get_project_dir_from_session_record() == ""
+        repo = _git_repo(tmp_path / "fallthrough-repo")
+        monkeypatch.chdir(repo)
+        assert PACTMemory._detect_project_id() == "fallthrough-repo", (
+            "a rejected record must fall through to the git rung, not answer"
+        )
+
+    def test_absent_session_id_field_is_accepted(self, tmp_path, monkeypatch):
+        """Legacy records predate the always-written field; the locating glob
+        already matched the env id's directory, so an ABSENT field serves."""
+        umbrella = make_umbrella(tmp_path)
+        enable_record_discovery(monkeypatch, pact_session)
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", SID)
+        write_session_context(
+            Path.home() / ".claude", SID, umbrella.project,
+            body=json.dumps({"project_dir": str(umbrella.project)}),
+        )
+        assert pact_session.get_project_dir_from_session_record() == str(umbrella.project)
+
 
 # ---------------------------------------------------------------------------
 # Precedence: _detect_project_id's Strategy 1.5 (record below env, above git)
@@ -321,6 +353,33 @@ class TestWriteRefusalOnDisagreement:
             memory.sync()
         assert str(other) in str(excinfo.value)
         assert str(umbrella.project) in str(excinfo.value)
+
+    def test_save_refusal_reports_refused_on_the_status_channel(self, tmp_path, monkeypatch):
+        """Channel parity: a caller that only reads last_sync_status after the
+        typed exception must see a deliberate REFUSAL, not an absent status —
+        matching the ambient-guard refusal class."""
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        other = tmp_path / "other"
+        other.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(other))
+
+        memory = PACTMemory()
+        with pytest.raises(ProjectScopeDisagreementError):
+            memory.save({"context": "c", "goal": "g"})
+        assert memory.last_sync_status == wm.SyncResult.REFUSED
+
+    def test_sync_refusal_reports_refused_on_the_status_channel(self, tmp_path, monkeypatch):
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        other = tmp_path / "other"
+        other.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(other))
+
+        memory = PACTMemory(project_id="proj")
+        with pytest.raises(ProjectScopeDisagreementError):
+            memory.sync()
+        assert memory.last_sync_status == wm.SyncResult.REFUSED
 
     def test_agreement_with_a_trailing_slash_does_not_refuse(self, tmp_path, monkeypatch):
         """normpath collapses the spelling difference; the predicate — not a
@@ -1024,3 +1083,63 @@ class TestSyncCliEnvelope:
         assert other.name in proc.stderr and umbrella.project.name in proc.stderr, (
             f"the refusal must name both values; stderr: {proc.stderr!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Edge: READS proceed under an env/record disagreement (the liberal half)
+# ---------------------------------------------------------------------------
+
+class TestLiberalReadsUnderDisagreement:
+    def test_cli_reads_proceed_and_follow_the_env_scope(self, tmp_path):
+        """Reads never refuse: a disagreeing env prefix is a deliberate
+        per-command cross-scope inspection. The child lists and gets the
+        ENV-scoped record while the record names a different project — exit 0,
+        env-scoped answer, no refusal on stderr."""
+        umbrella = make_umbrella(tmp_path)
+        other = tmp_path / "other"
+        other.mkdir()
+        store = tmp_path / "memory.db"
+        # Seed a record under the ENV scope with NO session behind it (no
+        # record, no disagreement — the write proceeds).
+        seed_env = child_env(
+            umbrella.config_root, home=tmp_path, project_dir=other,
+            memory_dir=tmp_path / "memdir",
+        )
+        setup = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "setup", "--db-path", str(store)],
+            capture_output=True, text=True, env=seed_env, cwd=str(other), timeout=120,
+        )
+        assert setup.returncode == 0, f"store setup failed: {setup.stderr[:400]!r}"
+        save = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "save", "--db-path", str(store),
+             json.dumps({"context": "LIBERAL-READ-SEED", "goal": "g"})],
+            capture_output=True, text=True, env=seed_env, cwd=str(other), timeout=120,
+        )
+        assert save.returncode == 0, f"seed save failed: {save.stderr[:400]!r}"
+        seed_id = json.loads(save.stdout)["result"]["memory_id"]
+        assert _memory_store_scopes(store) == ["other"]
+
+        # Now read with a DISAGREEING session record armed (record=umbrella,
+        # env=other): both read verbs must proceed and follow the env scope.
+        write_session_context(umbrella.config_root, SID, umbrella.project)
+        read_env = child_env(
+            umbrella.config_root, home=tmp_path, session_id=SID,
+            project_dir=other, memory_dir=tmp_path / "memdir",
+        )
+        listed = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "list", "--db-path", str(store)],
+            capture_output=True, text=True, env=read_env, cwd=str(other), timeout=120,
+        )
+        assert listed.returncode == 0, f"list refused a read: {listed.stderr[:400]!r}"
+        assert "SCOPE_DISAGREEMENT" not in listed.stderr
+        assert "LIBERAL-READ-SEED" in listed.stdout, (
+            f"list under a disagreeing env did not follow the env scope: "
+            f"{listed.stdout[:400]!r}"
+        )
+        got = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "get", "--db-path", str(store), seed_id],
+            capture_output=True, text=True, env=read_env, cwd=str(other), timeout=120,
+        )
+        assert got.returncode == 0, f"get refused a read: {got.stderr[:400]!r}"
+        assert "SCOPE_DISAGREEMENT" not in got.stderr
+        assert "LIBERAL-READ-SEED" in got.stdout

--- a/pact-plugin/tests/test_project_dir_resolution.py
+++ b/pact-plugin/tests/test_project_dir_resolution.py
@@ -25,9 +25,9 @@ enable_record_discovery (the test_session_discovery_route pattern — the
 refusal reads os.environ, so deleting PYTEST_CURRENT_TEST supplies the REAL
 predicate a different input) plus a real context file written into the
 redirected tmp config root. No getter is monkeypatched: every row exercises
-the shipped discovery chain. The one subprocess row crosses the real process
-boundary with a constructed env (child_env), because Path.home patching does
-not cross it.
+the shipped discovery chain. The subprocess rows (R1/R2/R4/R5 + the CLI
+envelope rows) cross the real process boundary with a constructed env
+(child_env), because Path.home patching does not cross it.
 """
 
 from __future__ import annotations
@@ -35,6 +35,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sqlite3
 import subprocess
 import sys
 from pathlib import Path
@@ -44,7 +45,9 @@ import pytest
 from fixtures.project_dir import (
     child_env,
     enable_record_discovery,
+    git_flake_shim,
     make_umbrella,
+    source_export_line,
     write_session_context,
 )
 # EVERY import here goes through the `scripts.` package route, deliberately.
@@ -64,6 +67,9 @@ from shared import backlog
 _MEMORY_CLI = (
     Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts" / "cli.py"
 )
+_BACKLOG_CLI = Path(__file__).parent.parent / "hooks" / "shared" / "backlog.py"
+_SESSION_INIT = Path(__file__).parent.parent / "hooks" / "session_init.py"
+_PACT_MEMORY_ROOT = Path(__file__).parent.parent / "skills" / "pact-memory"
 SID = "record-rung-session-0001"
 
 
@@ -549,3 +555,472 @@ class TestCliRefusalEnvelope:
         assert "PYTEST_CURRENT_TEST" not in env
         assert "CLAUDE_CODE_SESSION_ID" not in env
         assert env["HOME"] == str(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# R1 — #1613 acceptance: an umbrella session writes unprefixed (subprocess)
+# ---------------------------------------------------------------------------
+
+def _memory_store_scopes(store: Path) -> list:
+    """The project_id of every row in the store — the scope the writer USED,
+    read from the DB rather than inferred from an exit code."""
+    with sqlite3.connect(str(store)) as conn:
+        return [row[0] for row in conn.execute("SELECT project_id FROM memories")]
+
+
+class TestR1UmbrellaAcceptance:
+    """The #1613 acceptance shape end-to-end: env var ABSENT, session record
+    armed, cwd = the umbrella. backlog set, memory save, and WM sync all run
+    unprefixed and land under the recorded scope. Every leg is a real
+    subprocess with a constructed env — the boundary the issue measured."""
+
+    def _env(self, umbrella, tmp_path, memory_dir):
+        return child_env(
+            umbrella.config_root,
+            home=tmp_path,
+            session_id=SID,
+            memory_dir=memory_dir,
+        )
+
+    def test_r1_backlog_add_and_set_unprefixed_key_on_the_record(self, tmp_path):
+        umbrella = make_umbrella(tmp_path)
+        write_session_context(umbrella.config_root, SID, umbrella.project)
+        store = tmp_path / "store"
+        store.mkdir()
+        env = self._env(umbrella, tmp_path, None)
+
+        add = subprocess.run(
+            [sys.executable, str(_BACKLOG_CLI), "--backlog-dir", str(store),
+             "add", "umbrella item"],
+            capture_output=True, text=True, env=env, cwd=str(umbrella.project),
+        )
+        assert add.returncode == 0, f"unprefixed add refused: {add.stderr!r}"
+        written = store / "umbrella.json"
+        assert written.exists(), (
+            f"add did not key on the record basename; store holds "
+            f"{sorted(p.name for p in store.iterdir())}"
+        )
+        item_id = json.loads(written.read_text(encoding="utf-8"))["items"][0]["id"]
+        set_ = subprocess.run(
+            [sys.executable, str(_BACKLOG_CLI), "--backlog-dir", str(store),
+             "set", item_id, "--status", "active"],
+            capture_output=True, text=True, env=env, cwd=str(umbrella.project),
+        )
+        assert set_.returncode == 0, f"unprefixed set refused: {set_.stderr!r}"
+
+    def test_r1_memory_save_and_sync_unprefixed_scope_the_record(self, tmp_path):
+        """The acceptance shape faithfully: the DEFAULT store (a real session
+        passes no --db-path), so the store lands under the child's tmp HOME
+        with origin 'home' — and the ambient-sync guard's redirected-store
+        refusal does not fire. (That guard is the incident class of the
+        scratch-store incident, not a defect in this fix.)"""
+        umbrella = make_umbrella(tmp_path)
+        claude_md = _seed_claude_md(umbrella.project)
+        write_session_context(umbrella.config_root, SID, umbrella.project)
+        env = self._env(umbrella, tmp_path, None)
+        default_store = tmp_path / ".claude" / "pact-memory" / "memory.db"
+
+        save = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "save",
+             json.dumps({"context": "R1-UMBRELLA-SAVE", "goal": "g"})],
+            capture_output=True, text=True, env=env, cwd=str(umbrella.project),
+            timeout=120,
+        )
+        assert save.returncode == 0, f"unprefixed save failed: {save.stderr[:400]!r}"
+        save_envelope = json.loads(save.stdout)
+        assert save_envelope["ok"] is True
+        assert save_envelope["result"]["sync_status"] == "wrote", (
+            f"save's WM sync leg did not write: {save_envelope}"
+        )
+        assert default_store.exists(), "save did not create the default store"
+        assert _memory_store_scopes(default_store) == ["umbrella"], (
+            f"the save did not scope to the recorded project: "
+            f"{_memory_store_scopes(default_store)}"
+        )
+        assert "R1-UMBRELLA-SAVE" in claude_md.read_text(encoding="utf-8"), (
+            "save's sync leg did not land in the umbrella CLAUDE.md"
+        )
+
+        # The standalone sync surface, unprefixed (a rebuild over the same
+        # record keeps the section intact).
+        sync = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "sync"],
+            capture_output=True, text=True, env=env, cwd=str(umbrella.project),
+            timeout=120,
+        )
+        assert sync.returncode == 0, f"unprefixed sync failed: {sync.stderr[:400]!r}"
+        sync_envelope = json.loads(sync.stdout)
+        assert sync_envelope["ok"] is True, f"sync envelope: {sync_envelope}"
+        assert sync_envelope["result"]["project_id"] == "umbrella"
+        assert "R1-UMBRELLA-SAVE" in claude_md.read_text(encoding="utf-8"), (
+            "the standalone sync did not project the umbrella scope's record"
+        )
+
+    def test_r1_resolution_probe_equals_the_recorded_value(self, tmp_path):
+        """The acceptance probe in pytest form: a hook-side reader inside the
+        session resolves the SAME value the session record carries."""
+        umbrella = make_umbrella(tmp_path)
+        write_session_context(umbrella.config_root, SID, umbrella.project)
+        env = self._env(umbrella, tmp_path, None)
+        probe = subprocess.run(
+            [sys.executable, "-c",
+             "import sys; sys.path.insert(0, sys.argv[1]); "
+             "from scripts.pact_session import get_project_dir_from_session_record as g; "
+             "print(g())",
+             str(_PACT_MEMORY_ROOT)],
+            capture_output=True, text=True, env=env, cwd=str(umbrella.project),
+        )
+        assert probe.returncode == 0, f"probe failed: {probe.stderr[:400]!r}"
+        assert probe.stdout.strip() == str(umbrella.project)
+
+
+# ---------------------------------------------------------------------------
+# R2 — #1485: cwd in a git sub-repo of the umbrella
+# ---------------------------------------------------------------------------
+
+class TestR2SubRepoCwd:
+    """The exact #1485 frame: cwd inside the umbrella's git sub-repo (no
+    CLAUDE.md of its own), env absent, record naming the umbrella. Without the
+    record rung the git strategy answers the SUB-repo's basename."""
+
+    def test_r2_record_outranks_the_subrepo_git_root(self, tmp_path, monkeypatch):
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.chdir(umbrella.subrepo)
+        assert PACTMemory._detect_project_id() == "umbrella"
+
+    def test_r2_record_outranks_the_marker_walk_when_the_subrepo_has_its_own_claude_md(
+        self, tmp_path, monkeypatch
+    ):
+        """Anti-correlated arm: the sub-repo carrying its OWN CLAUDE.md means
+        the marker walk would resolve the sub-repo — the fixture's natural
+        ordering AGREES with the wrong answer, so a full-tie fixture would
+        mask a precedence mutation. The record must still win."""
+        umbrella = make_umbrella(tmp_path)
+        umbrella_md = _seed_claude_md(umbrella.project)
+        _seed_claude_md(umbrella.subrepo)  # the marker walk's answer, if reached
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.chdir(umbrella.subrepo)
+        assert wm._get_claude_md_path() == umbrella_md
+
+    def test_r2_subprocess_save_from_the_subrepo_scopes_the_umbrella(self, tmp_path):
+        umbrella = make_umbrella(tmp_path)
+        write_session_context(umbrella.config_root, SID, umbrella.project)
+        store = tmp_path / "memory.db"
+        env = child_env(
+            umbrella.config_root, home=tmp_path, session_id=SID,
+            memory_dir=tmp_path / "memdir",
+        )
+        setup = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "setup", "--db-path", str(store)],
+            capture_output=True, text=True, env=env, cwd=str(umbrella.subrepo),
+            timeout=120,
+        )
+        assert setup.returncode == 0, f"store setup failed: {setup.stderr[:400]!r}"
+        save = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "save", "--db-path", str(store),
+             json.dumps({"context": "R2-SUBREPO-SAVE", "goal": "g"})],
+            capture_output=True, text=True, env=env, cwd=str(umbrella.subrepo),
+            timeout=120,
+        )
+        assert save.returncode == 0, f"save from the sub-repo failed: {save.stderr[:400]!r}"
+        assert _memory_store_scopes(store) == ["umbrella"], (
+            f"cwd in the sub-repo mis-scoped the save: {_memory_store_scopes(store)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# R3 — #1005: ambiguous cwd; the record outranks the home/user fallback
+# ---------------------------------------------------------------------------
+
+class TestR3AmbiguousCwd:
+    def test_r3_record_outranks_an_ambiguous_cwd(self, tmp_path, monkeypatch):
+        """cwd in a bare directory whose marker walk would land on the tmp HOME
+        config dir (answering the tmp basename): without the record rung the
+        answer is the walk's; with it, the record's. The no-record/no-env
+        negative half is pinned by TestHomeScopeWarning (the last resort warns
+        rather than silently scoping home)."""
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        bare = tmp_path / "bare"
+        bare.mkdir()
+        monkeypatch.chdir(bare)
+        assert PACTMemory._detect_project_id() == "umbrella"
+
+
+# ---------------------------------------------------------------------------
+# R4 — #1600: bimodal git cannot split parent and child
+# ---------------------------------------------------------------------------
+
+class TestR4BimodalGit:
+    """The git-flake shim makes every git subprocess fail. The CONTROL arm
+    proves the shim is live (git's death changes the worktree answer); the
+    INVARIANT arms prove the record rung's answer does not depend on git at
+    all, in-process or across the process boundary."""
+
+    def _worktree_pair(self, tmp_path):
+        main = _git_repo(tmp_path / "main-proj")
+        linked = tmp_path / "wt"
+        subprocess.run(
+            ["git", "-C", str(main), "worktree", "add", "-q", str(linked), "-b", "wt"],
+            check=True, capture_output=True,
+            env={**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull},
+        )
+        return main, linked
+
+    def test_r4_control_git_death_changes_the_worktree_answer(self, tmp_path, monkeypatch):
+        """CONTROL, not a result row: cwd in a linked worktree, NO record. Git
+        alive answers the MAIN repo (Strategy 2); git dead falls to the marker
+        walk, which names the WORKTREE. The two answers differing is the proof
+        the shim took effect — and the bimodal shape #1600 recorded."""
+        main, linked = self._worktree_pair(tmp_path)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.chdir(linked)
+        assert PACTMemory._detect_project_id() == "main-proj"  # git alive
+
+        shim = git_flake_shim(tmp_path)
+        monkeypatch.setenv("PATH", f"{shim}{os.pathsep}{os.environ.get('PATH', '')}")
+        assert PACTMemory._detect_project_id() == "wt", (
+            "git's death did NOT change the answer — the shim is not live and "
+            "the invariant arms below prove nothing"
+        )
+
+    def test_r4_record_answer_is_git_independent(self, tmp_path, monkeypatch):
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.chdir(umbrella.subrepo)
+        shim = git_flake_shim(tmp_path)
+        monkeypatch.setenv("PATH", f"{shim}{os.pathsep}{os.environ.get('PATH', '')}")
+        assert PACTMemory._detect_project_id() == "umbrella"
+
+    def test_r4_parent_and_child_agree_with_git_broken(self, tmp_path, monkeypatch):
+        """The one-value invariant across the boundary: the parent's in-process
+        resolution and the child CLI's scope are ONE value under broken git —
+        the parent/subprocess disagreement #1600 measured cannot recur."""
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        shim = git_flake_shim(tmp_path)
+        monkeypatch.setenv("PATH", f"{shim}{os.pathsep}{os.environ.get('PATH', '')}")
+        monkeypatch.chdir(umbrella.subrepo)
+        parent_answer = PACTMemory._detect_project_id()
+
+        store = tmp_path / "memory.db"
+        env = child_env(
+            umbrella.config_root, home=tmp_path, session_id=SID,
+            memory_dir=tmp_path / "memdir",
+        )
+        env["PATH"] = f"{shim}{os.pathsep}{env['PATH']}"
+        setup = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "setup", "--db-path", str(store)],
+            capture_output=True, text=True, env=env, cwd=str(umbrella.subrepo),
+            timeout=120,
+        )
+        assert setup.returncode == 0, f"store setup failed: {setup.stderr[:400]!r}"
+        save = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "save", "--db-path", str(store),
+             json.dumps({"context": "R4-BROKEN-GIT", "goal": "g"})],
+            capture_output=True, text=True, env=env, cwd=str(umbrella.subrepo),
+            timeout=120,
+        )
+        assert save.returncode == 0, f"child save failed: {save.stderr[:400]!r}"
+        assert _memory_store_scopes(store) == [parent_answer] == ["umbrella"]
+
+    def test_r4_backlog_set_with_record_and_broken_git(self, tmp_path):
+        """backlog's writer runs git twice (main-root + worktree list); with
+        git dead and the env absent, the record anchor plus the stat-based
+        enclosing-checkout walk still resolve the umbrella — no refusal."""
+        umbrella = make_umbrella(tmp_path)
+        write_session_context(umbrella.config_root, SID, umbrella.project)
+        store = tmp_path / "store"
+        store.mkdir()
+        shim = git_flake_shim(tmp_path)
+        env = child_env(umbrella.config_root, home=tmp_path, session_id=SID)
+        env["PATH"] = f"{shim}{os.pathsep}{env['PATH']}"
+        add = subprocess.run(
+            [sys.executable, str(_BACKLOG_CLI), "--backlog-dir", str(store),
+             "add", "broken-git item"],
+            capture_output=True, text=True, env=env, cwd=str(umbrella.project),
+        )
+        assert add.returncode == 0, (
+            f"backlog add refused under broken git despite the record: {add.stderr!r}"
+        )
+        assert (store / "umbrella.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# R5 — the env-file channel: real session_init writes BOTH halves over the
+# real process boundary, and a spawned-Bash child inherits the recorded value
+# ---------------------------------------------------------------------------
+
+class TestR5EnvFileSeam:
+    """R5's two forms, per the probe outcome: the LITERAL os.environ leg is
+    claimed for the standard spawned-Bash path only (the dogfood probe passed
+    there with control-leg causation — tests/runbooks/claude-env-file-probe.md);
+    this row drives the real writer and the platform's source step is played
+    by source_export_line. Teammate-mode (in-process/tmux) propagation is
+    UNVERIFIED at the platform layer and NOT claimed here — those sessions are
+    covered by the rung-2 resolution-equality rows (R1/R2), and the
+    distinction is recorded, not erased."""
+
+    def test_r5_session_init_writes_record_and_export_and_a_bash_child_inherits(
+        self, tmp_path
+    ):
+        umbrella = make_umbrella(tmp_path)
+        env_file = tmp_path / "session-env.sh"
+        sid5 = "r5-env-file-session-0001"
+        env = child_env(
+            umbrella.config_root, home=tmp_path, session_id=sid5,
+            project_dir=umbrella.project, memory_dir=tmp_path / "memdir",
+        )
+        env["CLAUDE_ENV_FILE"] = str(env_file)
+        frame = {
+            "source": "startup",
+            "session_id": sid5,
+            "agent_type": "pact-orchestrator",  # lead frame: persist is lead-gated
+        }
+        proc = subprocess.run(
+            [sys.executable, str(_SESSION_INIT)],
+            input=json.dumps(frame),
+            capture_output=True, text=True, env=env, cwd=str(umbrella.project),
+            timeout=180,
+        )
+        assert proc.returncode == 0, (
+            f"session_init failed in the stripped frame: {proc.stderr[:600]!r}"
+        )
+
+        # The RECORD half, written by the real writer (Tier 2 — no stubbed
+        # persist_context).
+        ctx_path = (
+            umbrella.config_root / "pact-sessions" / "umbrella" / sid5
+            / "pact-session-context.json"
+        )
+        assert ctx_path.exists(), (
+            f"the real writer left no record; config root holds "
+            f"{sorted(str(p) for p in umbrella.config_root.rglob('*'))}"
+        )
+        recorded = json.loads(ctx_path.read_text(encoding="utf-8"))["project_dir"]
+        assert recorded == str(umbrella.project)
+
+        # The EXPORT half — and the exported == recorded invariant.
+        exported = source_export_line(env_file, "CLAUDE_PROJECT_DIR")
+        assert exported is not None, (
+            f"no CLAUDE_PROJECT_DIR export in the env file: "
+            f"{env_file.read_text(encoding='utf-8')!r}"
+        )
+        assert exported == recorded
+
+        # The spawned-Bash leg: the platform sources the env file, so the
+        # child sees os.environ['CLAUDE_PROJECT_DIR'] == the recorded value —
+        # and a write under it agrees with the record (no refusal).
+        bash_env = child_env(
+            umbrella.config_root, home=tmp_path, session_id=sid5,
+            project_dir=exported, memory_dir=tmp_path / "memdir2",
+        )
+        probe = subprocess.run(
+            [sys.executable, "-c",
+             "import os; v = os.environ['CLAUDE_PROJECT_DIR']; print(v)"],
+            capture_output=True, text=True, env=bash_env, cwd=str(umbrella.project),
+        )
+        assert probe.stdout.strip() == recorded, (
+            "the env-file value a spawned Bash inherits differs from the "
+            "session record — the exported == recorded invariant is broken"
+        )
+        store = tmp_path / "memory.db"
+        setup = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "setup", "--db-path", str(store)],
+            capture_output=True, text=True, env=bash_env, cwd=str(umbrella.project),
+            timeout=120,
+        )
+        assert setup.returncode == 0, f"store setup failed: {setup.stderr[:400]!r}"
+        save = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "save", "--db-path", str(store),
+             json.dumps({"context": "R5-EXPORTED", "goal": "g"})],
+            capture_output=True, text=True, env=bash_env, cwd=str(umbrella.project),
+            timeout=120,
+        )
+        assert save.returncode == 0, (
+            f"a write under the exported value refused despite record agreement: "
+            f"{save.stderr[:400]!r}"
+        )
+        assert _memory_store_scopes(store) == ["umbrella"]
+
+
+# ---------------------------------------------------------------------------
+# Edge: symlinked spellings — slug equality on reads, verbatim refusal on writes
+# ---------------------------------------------------------------------------
+
+class TestSymlinkEdges:
+    def test_symlinked_record_names_the_target(self, tmp_path, monkeypatch):
+        """A recorded SYMLINK path resolves to the target's basename for the
+        project name — one project, one key, however the session was launched."""
+        umbrella = make_umbrella(tmp_path)
+        link = tmp_path / "linked-umbrella"
+        link.symlink_to(umbrella.project)
+        _arm_record(monkeypatch, tmp_path, link)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        assert pact_session.get_project_dir_from_session_record() == str(link), (
+            "the reader must return the recorded value VERBATIM"
+        )
+        assert PACTMemory._detect_project_id() == "umbrella"
+
+    def test_symlinked_env_alias_of_the_record_refuses_on_writes(self, tmp_path, monkeypatch):
+        """The verbatim comparison's conservative direction: env naming a
+        SYMLINK ALIAS of the recorded dir disagrees textually, so writes REFUSE
+        although the target is identical. This is the designed trade — a loud
+        refusal with the remedy beats a silent derivation — and this pin is
+        what kills a mutation that 'fixes' the comparison by resolving both
+        sides."""
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        link = tmp_path / "alias"
+        link.symlink_to(umbrella.project)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(link))
+
+        memory = PACTMemory()  # constructed AFTER the env manipulation
+        with pytest.raises(ProjectScopeDisagreementError) as excinfo:
+            memory.save({"context": "c", "goal": "g"})
+        text = str(excinfo.value)
+        assert str(link) in text and str(umbrella.project) in text
+        assert "re-export CLAUDE_PROJECT_DIR" in text
+
+
+# ---------------------------------------------------------------------------
+# Edge: the sync CLI envelopes the refusal exactly like save
+# ---------------------------------------------------------------------------
+
+class TestSyncCliEnvelope:
+    def test_sync_cli_envelopes_the_refusal_on_stderr(self, tmp_path):
+        """The second CLI write path's envelope: cmd_sync catches
+        ProjectScopeDisagreementError into SCOPE_DISAGREEMENT on stderr,
+        naming both values."""
+        umbrella = make_umbrella(tmp_path)
+        _seed_claude_md(umbrella.project)
+        write_session_context(umbrella.config_root, SID, umbrella.project)
+        other = tmp_path / "other"
+        _seed_claude_md(other)  # a REAL writable target, so the refusal is non-vacuous
+        store = tmp_path / "memory.db"
+        env = child_env(
+            umbrella.config_root, home=tmp_path, session_id=SID,
+            project_dir=other, memory_dir=tmp_path / "memdir",
+        )
+        setup = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "setup", "--db-path", str(store)],
+            capture_output=True, text=True, env=env, cwd=str(tmp_path), timeout=120,
+        )
+        assert setup.returncode == 0, f"store setup failed: {setup.stderr[:400]!r}"
+        proc = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "sync", "--db-path", str(store)],
+            capture_output=True, text=True, env=env, cwd=str(tmp_path), timeout=120,
+        )
+        assert proc.returncode != 0, f"a disagreeing sync exited 0: {proc.stdout!r}"
+        assert "SCOPE_DISAGREEMENT" in proc.stderr, (
+            f"the envelope type is missing from stderr: {proc.stderr!r}"
+        )
+        assert other.name in proc.stderr and umbrella.project.name in proc.stderr, (
+            f"the refusal must name both values; stderr: {proc.stderr!r}"
+        )

--- a/pact-plugin/tests/test_project_dir_resolution.py
+++ b/pact-plugin/tests/test_project_dir_resolution.py
@@ -381,6 +381,22 @@ class TestWriteRefusalOnDisagreement:
             memory.sync()
         assert memory.last_sync_status == wm.SyncResult.REFUSED
 
+    def test_refusal_text_carries_the_textual_comparison_note(self, tmp_path, monkeypatch):
+        """F6: the remedy names the comparison rule (verbatim, not resolved),
+        so a symlinked/case-differing spelling's refusal is self-explanatory.
+        One assertion through one write path — the pin that makes an
+        F6-removal arm killable."""
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        other = tmp_path / "other"
+        other.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(other))
+
+        memory = PACTMemory()
+        with pytest.raises(ProjectScopeDisagreementError) as excinfo:
+            memory.save({"context": "c", "goal": "g"})
+        assert "comparison is textual" in str(excinfo.value)
+
     def test_agreement_with_a_trailing_slash_does_not_refuse(self, tmp_path, monkeypatch):
         """normpath collapses the spelling difference; the predicate — not a
         full save — is the unit under test here."""

--- a/pact-plugin/tests/test_project_dir_resolution.py
+++ b/pact-plugin/tests/test_project_dir_resolution.py
@@ -1,0 +1,551 @@
+"""
+Tests for the session-record rung of the project-scope read contract, the
+fail-closed env/record write refusal, and the home-scope warning.
+
+Location: pact-plugin/tests/test_project_dir_resolution.py
+
+Summary: Phase B of claude-project-dir-once. The read contract gains a
+session-record rung (env -> session record -> git -> cwd -> home-with-warning)
+shared by every consumer (memory_api._detect_project_id,
+working_memory's two CLAUDE.md resolvers, backlog.project_root), and WRITES
+(backlog set, memory save, WM sync) refuse when CLAUDE_PROJECT_DIR and the
+session record disagree.
+
+Used by/with:
+- skills/pact-memory/scripts/pact_session.py: the record reader + refusal
+  channel under test.
+- tests/fixtures/project_dir.py: umbrella factory, context writer, discovery
+  enabler, subprocess env builder.
+- tests/test_project_id.py: the replica/equivalence pins for the pre-existing
+  strategies; this file owns the record-rung coverage the replica deliberately
+  omits.
+
+HOW THE RECORD ROUTE IS EXERCISED: in-process rows use
+enable_record_discovery (the test_session_discovery_route pattern — the
+refusal reads os.environ, so deleting PYTEST_CURRENT_TEST supplies the REAL
+predicate a different input) plus a real context file written into the
+redirected tmp config root. No getter is monkeypatched: every row exercises
+the shipped discovery chain. The one subprocess row crosses the real process
+boundary with a constructed env (child_env), because Path.home patching does
+not cross it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from fixtures.project_dir import (
+    child_env,
+    enable_record_discovery,
+    make_umbrella,
+    write_session_context,
+)
+# EVERY import here goes through the `scripts.` package route, deliberately.
+# A bare `import working_memory` loads a SECOND module instance whose
+# `from pact_session import ...` binds a second copy of pact_session — with
+# its own discovery cache AND its own ProjectScopeDisagreementError class, so
+# the cache reset would miss the live cache and pytest.raises would miss the
+# raised class. The sibling files' bare-import convention is not safe for
+# this file's cross-module refusal assertions.
+from scripts import pact_session
+from scripts import working_memory as wm
+from scripts.memory_api import PACTMemory
+from scripts.pact_session import ProjectScopeDisagreementError
+from shared import backlog
+
+
+_MEMORY_CLI = (
+    Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts" / "cli.py"
+)
+SID = "record-rung-session-0001"
+
+
+def _seed_claude_md(root: Path) -> Path:
+    """A minimal syncable project CLAUDE.md (Working Memory section present)."""
+    claude_dir = root / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    claude_md = claude_dir / "CLAUDE.md"
+    claude_md.write_text(
+        "# Project\n\n## Working Memory\n"
+        "<!-- Auto-managed by pact-memory skill. -->\n\n",
+        encoding="utf-8",
+    )
+    return claude_md
+
+
+def _arm_record(monkeypatch, tmp_path, record_dir) -> None:
+    """Make the session record LIVE in-process: refusal off, env id set,
+    context file written into the redirected tmp config root."""
+    enable_record_discovery(monkeypatch, pact_session)
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", SID)
+    write_session_context(Path.home() / ".claude", SID, record_dir)
+
+
+def _git_repo(path: Path) -> Path:
+    """A fresh git repo (no commit needed for --git-common-dir)."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "-q", str(path)],
+        check=True,
+        capture_output=True,
+        env={**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull},
+    )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# The record reader's contract (pact_session.get_project_dir_from_session_record)
+# ---------------------------------------------------------------------------
+
+class TestSessionRecordReader:
+    """The reader never raises and fails open to "" on every ambiguous shape."""
+
+    def test_returns_the_recorded_absolute_project_dir(self, tmp_path, monkeypatch):
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        assert pact_session.get_project_dir_from_session_record() == str(umbrella.project)
+
+    def test_missing_context_file_yields_empty(self, tmp_path, monkeypatch):
+        enable_record_discovery(monkeypatch, pact_session)
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", SID)
+        assert pact_session.get_project_dir_from_session_record() == ""
+
+    def test_corrupt_context_file_yields_empty(self, tmp_path, monkeypatch):
+        enable_record_discovery(monkeypatch, pact_session)
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", SID)
+        write_session_context(Path.home() / ".claude", SID, tmp_path, body="{not json")
+        assert pact_session.get_project_dir_from_session_record() == ""
+
+    def test_two_matching_slugs_yield_empty(self, tmp_path, monkeypatch):
+        enable_record_discovery(monkeypatch, pact_session)
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", SID)
+        write_session_context(Path.home() / ".claude", SID, tmp_path, slug="project-a")
+        write_session_context(Path.home() / ".claude", SID, tmp_path, slug="project-b")
+        assert pact_session.get_project_dir_from_session_record() == ""
+
+    def test_non_string_project_dir_yields_empty(self, tmp_path, monkeypatch):
+        enable_record_discovery(monkeypatch, pact_session)
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", SID)
+        write_session_context(
+            Path.home() / ".claude", SID, tmp_path,
+            body=json.dumps({"session_id": SID, "project_dir": 12345}),
+        )
+        assert pact_session.get_project_dir_from_session_record() == ""
+
+    def test_relative_project_dir_is_rejected(self, tmp_path, monkeypatch):
+        """Pre-fix records can hold ".": resolving that HERE would alias the
+        record rung to the reader's cwd ABOVE the git rung — inverting the
+        precedence the rung exists to establish. Non-absolute reads as absent."""
+        enable_record_discovery(monkeypatch, pact_session)
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", SID)
+        write_session_context(
+            Path.home() / ".claude", SID, tmp_path,
+            body=json.dumps({"session_id": SID, "project_dir": "."}),
+        )
+        assert pact_session.get_project_dir_from_session_record() == ""
+
+    def test_second_call_is_served_from_the_cache(self, tmp_path, monkeypatch):
+        """The glob runs once per process per env id, not once per caller."""
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+
+        calls = []
+        real = pact_session._context_record_on_disk
+
+        def counting(env_session):
+            calls.append(1)
+            return real(env_session)
+
+        monkeypatch.setattr(pact_session, "_context_record_on_disk", counting)
+        first = pact_session.get_project_dir_from_session_record()
+        second = pact_session.get_project_dir_from_session_record()
+        assert first == second == str(umbrella.project)
+        assert len(calls) == 1, "record discovery must glob once per process"
+
+    def test_pytest_refusal_fires_with_a_live_record(self, tmp_path, monkeypatch):
+        """Non-vacuity leg: file present AND id set, so ONLY the refusal can
+        explain the empty answer."""
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        monkeypatch.setenv("PYTEST_CURRENT_TEST", "some_test (call)")
+        assert pact_session.get_project_dir_from_session_record() == ""
+
+    def test_absent_env_id_yields_empty_with_a_live_record(self, tmp_path, monkeypatch):
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+        assert pact_session.get_project_dir_from_session_record() == ""
+
+
+# ---------------------------------------------------------------------------
+# Precedence: _detect_project_id's Strategy 1.5 (record below env, above git)
+# ---------------------------------------------------------------------------
+
+class TestDetectProjectIdRecordRung:
+    def test_env_wins_over_a_disagreeing_record_on_reads(self, tmp_path, monkeypatch):
+        """READS FOLLOW ENV: a present CLAUDE_PROJECT_DIR declares the scope;
+        the record never overrides it and nothing refuses on a read path."""
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        repo = _git_repo(tmp_path / "declared-repo")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        assert PACTMemory._detect_project_id() == "declared-repo"
+
+    def test_record_outranks_the_cwd_git_root(self, tmp_path, monkeypatch):
+        """#1485's core shape as a unit row: cwd inside a git repo whose root
+        is the WRONG scope; the record names the umbrella. Without the rung
+        the git strategy would answer the repo's name, so a green here proves
+        the rung fired."""
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        repo = _git_repo(tmp_path / "foreign-repo")
+        monkeypatch.chdir(repo)
+        assert PACTMemory._detect_project_id() == "umbrella"
+
+    def test_record_fallthrough_to_git_when_absent(self, tmp_path, monkeypatch):
+        """No record (no env id) -> the git strategy answers exactly as before."""
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        repo = _git_repo(tmp_path / "plain-repo")
+        monkeypatch.chdir(repo)
+        assert PACTMemory._detect_project_id() == "plain-repo"
+
+    def test_record_in_a_worktree_names_the_main_repo(self, tmp_path, monkeypatch):
+        """The record leg shares Strategy 1's main-repo rewrite: a recorded
+        worktree path must key on the MAIN repo's basename, not the worktree's,
+        or one project fragments across its own checkouts."""
+        umbrella = make_umbrella(tmp_path)
+        main = _git_repo(tmp_path / "main-proj")
+        linked = tmp_path / "wt"
+        subprocess.run(
+            ["git", "-C", str(main), "worktree", "add", "-q", str(linked), "-b", "wt"],
+            check=True,
+            capture_output=True,
+            env={**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull},
+        )
+        _arm_record(monkeypatch, tmp_path, linked)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        # cwd must not contribute a repo answer: the guard-verified git-less
+        # umbrella keeps the arm hermetic even for a contributor whose TMPDIR
+        # sits under a repository.
+        monkeypatch.chdir(umbrella.project)
+        assert PACTMemory._detect_project_id() == "main-proj"
+
+
+# ---------------------------------------------------------------------------
+# Home scope warns (the last resort must not be silent)
+# ---------------------------------------------------------------------------
+
+class TestHomeScopeWarning:
+    def _force_cwd_resolution(self, monkeypatch, resolved_root: Path):
+        """Kill the env/record/git legs so Strategy 3 answers `resolved_root`.
+        The walk itself is not the thing under test — the warning branch is —
+        so _find_project_root is pinned to the answer directly."""
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+
+        def _no_git(*args, **kwargs):
+            raise FileNotFoundError("git unavailable in this arm")
+
+        monkeypatch.setattr("subprocess.run", _no_git)
+        monkeypatch.setattr(
+            PACTMemory, "_find_project_root",
+            staticmethod(lambda start: resolved_root),
+        )
+
+    def test_home_resolution_warns(self, tmp_path, monkeypatch, caplog):
+        home = Path.home().resolve()  # autouse-redirected to tmp_path
+        self._force_cwd_resolution(monkeypatch, home)
+        with caplog.at_level(logging.WARNING):
+            result = PACTMemory._detect_project_id()
+        assert result == home.name
+        assert any(
+            "HOME directory" in r.message and "CLAUDE_PROJECT_DIR" in r.message
+            for r in caplog.records
+        ), f"home scope resolved silently: {[r.message for r in caplog.records]}"
+
+    def test_project_resolution_does_not_warn(self, tmp_path, monkeypatch, caplog):
+        project = tmp_path / "a-real-project"
+        project.mkdir()
+        self._force_cwd_resolution(monkeypatch, project.resolve())
+        with caplog.at_level(logging.WARNING):
+            result = PACTMemory._detect_project_id()
+        assert result == "a-real-project"
+        assert not any("HOME directory" in r.message for r in caplog.records), (
+            "a project-root resolution raised the home-scope warning"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed writes: env vs record disagreement
+# ---------------------------------------------------------------------------
+
+class TestWriteRefusalOnDisagreement:
+    def test_memory_save_refuses_naming_both_values(self, tmp_path, monkeypatch):
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        other = tmp_path / "other"
+        other.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(other))
+
+        memory = PACTMemory()  # constructed AFTER the env manipulation
+        with pytest.raises(ProjectScopeDisagreementError) as excinfo:
+            memory.save({"context": "c", "goal": "g"})
+        text = str(excinfo.value)
+        assert str(other) in text, "the refusal does not name the env value"
+        assert str(umbrella.project) in text, "the refusal does not name the record"
+        assert "Nothing was written" in text
+        assert "re-export CLAUDE_PROJECT_DIR" in text, "the refusal names no remedy"
+
+    def test_memory_sync_refuses_naming_both_values(self, tmp_path, monkeypatch):
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        other = tmp_path / "other"
+        other.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(other))
+
+        memory = PACTMemory(project_id="proj")  # explicit id: the None guard is not the subject
+        with pytest.raises(ProjectScopeDisagreementError) as excinfo:
+            memory.sync()
+        assert str(other) in str(excinfo.value)
+        assert str(umbrella.project) in str(excinfo.value)
+
+    def test_agreement_with_a_trailing_slash_does_not_refuse(self, tmp_path, monkeypatch):
+        """normpath collapses the spelling difference; the predicate — not a
+        full save — is the unit under test here."""
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(umbrella.project) + "/")
+        assert pact_session.env_record_project_dir_disagreement() is None
+
+    def test_no_record_means_no_disagreement(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        # No session id in the env (autouse scrub) -> the record side is absent.
+        assert pact_session.env_record_project_dir_disagreement() is None
+
+
+class TestBacklogRecordRung:
+    def test_record_anchors_project_root_when_env_is_unset(self, tmp_path, monkeypatch):
+        """The #1613-curing arm: an umbrella session whose env var never
+        arrived resolves the session's own scope instead of refusing."""
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        assert backlog.project_root() == umbrella.project.resolve()
+
+    def test_record_naming_a_deleted_dir_refuses_with_the_right_source(self, tmp_path, monkeypatch):
+        gone = tmp_path / "deleted-between-sessions"
+        _arm_record(monkeypatch, tmp_path, gone)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        with pytest.raises(backlog.BacklogWriteError) as excinfo:
+            backlog.project_root()
+        text = str(excinfo.value)
+        assert "session record" in text, (
+            f"the refusal attributed the anchor to the wrong source: {text}"
+        )
+        assert str(gone) in text, "the refusal does not echo the rejected value"
+
+    def test_disagreement_refuses_before_any_write(self, tmp_path, monkeypatch):
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        other = tmp_path / "other"
+        other.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(other))
+        with pytest.raises(backlog.BacklogWriteError) as excinfo:
+            backlog.project_root()
+        text = str(excinfo.value)
+        assert str(other) in text and str(umbrella.project) in text
+        assert "Nothing was written" in text
+
+    def test_agreement_proceeds(self, tmp_path, monkeypatch):
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(umbrella.project) + "/")
+        assert backlog.project_root() == umbrella.project.resolve()
+
+    def test_cli_add_under_record_then_set_under_disagreement(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """End-to-end through backlog.main: the write keyed on the record
+        succeeds unprefixed (the umbrella acceptance shape), and the same
+        session with a disagreeing prefix refuses on stderr with exit 65."""
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        store = tmp_path / "store"
+        store.mkdir()
+
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        assert backlog.main(["--backlog-dir", str(store), "add", "umbrella item"]) == 0
+        written = store / "umbrella.json"
+        assert written.exists(), (
+            f"add did not key on the record basename; store holds {list(store.iterdir())}"
+        )
+        item_id = json.loads(written.read_text(encoding="utf-8"))["items"][0]["id"]
+        before = written.read_bytes()
+
+        other = tmp_path / "other"
+        other.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(other))
+        capsys.readouterr()  # drain the add output so the refusal text is isolated
+        rc = backlog.main(["--backlog-dir", str(store), "set", item_id, "--status", "active"])
+        assert rc == backlog._EXIT_REFUSED
+        err = capsys.readouterr().err
+        assert str(other) in err and str(umbrella.project) in err, (
+            f"the stderr refusal must name both values; got: {err!r}"
+        )
+        assert written.read_bytes() == before, "a refused set still mutated the file"
+
+
+# ---------------------------------------------------------------------------
+# Working-memory resolvers: the record rung preserves the existence coupling
+# ---------------------------------------------------------------------------
+
+class TestWorkingMemoryRecordRung:
+    def test_record_dir_is_probed_for_an_existing_claude_md(self, tmp_path, monkeypatch):
+        umbrella = make_umbrella(tmp_path)
+        claude_md = _seed_claude_md(umbrella.project)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+
+        assert wm._get_claude_md_path() == claude_md
+        path, base = wm._resolve_display_claude_md_with_base()
+        assert path == claude_md
+        assert base == umbrella.project, (
+            "the containment anchor must be the base the resolver USED — the "
+            "recorded dir — not a re-derivation"
+        )
+
+    def test_record_without_a_claude_md_falls_through_to_git(self, tmp_path, monkeypatch):
+        """The existence coupling is preserved: a record naming a dir with no
+        CLAUDE.md does NOT end resolution (this resolver never creates the
+        file); the git anchor answers as before."""
+        umbrella = make_umbrella(tmp_path)  # has ./CLAUDE.md at the root...
+        (umbrella.project / "CLAUDE.md").unlink()  # ...remove it: record probe must miss
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        repo = _git_repo(tmp_path / "repo-with-file")
+        git_file = _seed_claude_md(repo)
+        monkeypatch.chdir(repo)
+
+        assert wm._get_claude_md_path() == git_file
+
+
+class TestWorkingMemoryDisagreementGuard:
+    def test_ambient_sync_refuses_on_disagreement(self, tmp_path, monkeypatch):
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        other = tmp_path / "other"
+        other.mkdir()
+        env_file = _seed_claude_md(other)  # a REAL writable target, so the
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(other))  # refusal is non-vacuous
+
+        with pytest.raises(ProjectScopeDisagreementError) as excinfo:
+            wm.sync_to_claude_md({"context": "X", "goal": "g"}, None, "id")
+        assert str(other) in str(excinfo.value)
+        assert str(umbrella.project) in str(excinfo.value)
+        assert "X" not in env_file.read_text(encoding="utf-8"), (
+            "the refused sync still wrote to the env-resolved file"
+        )
+
+    def test_explicit_target_is_a_warrant_and_proceeds(self, tmp_path, monkeypatch):
+        """A caller that names its file has declared the scope; the ambient
+        disagreement is moot. Mirrors the sibling guards' warrant logic."""
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path / "other"))
+        target_root = tmp_path / "declared"
+        target = _seed_claude_md(target_root)
+
+        result = wm.sync_to_claude_md(
+            {"context": "DECLARED-TARGET", "goal": "g"}, None, "id", target=target
+        )
+        assert result.reason == wm.SyncResult.WROTE
+        assert "DECLARED-TARGET" in target.read_text(encoding="utf-8")
+
+    def test_claude_md_root_is_a_warrant_and_proceeds(self, tmp_path, monkeypatch):
+        umbrella = make_umbrella(tmp_path)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        anchor = tmp_path / "anchored"
+        _seed_claude_md(anchor)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(anchor))
+        # env == anchor, record == umbrella: a disagreement exists, but the
+        # declared containment anchor is a stronger warrant than the refusal.
+        result = wm.sync_to_claude_md(
+            {"context": "ANCHORED", "goal": "g"}, None, "id", claude_md_root=anchor
+        )
+        assert result.reason == wm.SyncResult.WROTE
+
+    def test_agreement_syncs_ambiently(self, tmp_path, monkeypatch):
+        umbrella = make_umbrella(tmp_path)
+        env_file = _seed_claude_md(umbrella.project)
+        _arm_record(monkeypatch, tmp_path, umbrella.project)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(umbrella.project))
+
+        result = wm.sync_to_claude_md({"context": "AGREED", "goal": "g"}, None, "id")
+        assert result.reason == wm.SyncResult.WROTE
+        assert "AGREED" in env_file.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Cross-process: the CLI envelope carries the refusal on stderr
+# ---------------------------------------------------------------------------
+
+class TestCliRefusalEnvelope:
+    def test_memory_save_cli_envelopes_the_refusal_on_stderr(self, tmp_path):
+        """The full boundary: a child process with a constructed env discovers
+        the record itself (no pytest marker crosses), and cmd_save's envelope
+        lands on stderr with both values. Asserting the envelope type and both
+        dir names — not the exit code alone — is what pins the refusal TEXT."""
+        umbrella = make_umbrella(tmp_path)
+        write_session_context(umbrella.config_root, SID, umbrella.project)
+        other = tmp_path / "other"
+        other.mkdir()
+        store = tmp_path / "memory.db"
+        env = child_env(
+            umbrella.config_root,
+            home=tmp_path,
+            session_id=SID,
+            project_dir=other,
+        )
+        setup = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "setup", "--db-path", str(store)],
+            capture_output=True, text=True, env=env, cwd=str(tmp_path), timeout=120,
+        )
+        assert setup.returncode == 0, f"store setup failed: {setup.stderr[:400]!r}"
+
+        proc = subprocess.run(
+            [sys.executable, str(_MEMORY_CLI), "save", "--db-path", str(store),
+             json.dumps({"context": "cross-process", "goal": "g"})],
+            capture_output=True, text=True, env=env, cwd=str(tmp_path), timeout=120,
+        )
+        assert proc.returncode != 0, f"a disagreeing save exited 0: {proc.stdout!r}"
+        assert "SCOPE_DISAGREEMENT" in proc.stderr, (
+            f"the envelope type is missing from stderr: {proc.stderr!r}"
+        )
+        # The envelope is home-scrubbed (~), so assert on the distinguishing
+        # basenames rather than the absolute paths.
+        assert other.name in proc.stderr and umbrella.project.name in proc.stderr, (
+            f"the refusal must name both values; stderr: {proc.stderr!r}"
+        )
+        assert not store.exists() or "cross-process" not in store.read_bytes().decode(
+            "utf-8", errors="ignore"
+        ), "a refused save left the row behind"
+
+    def test_child_env_defaults_delete_the_project_dir_var(self, tmp_path):
+        """Guard the env-builder itself: DELETE is the default and the pytest
+        marker never crosses — the two leaks that would make every row above
+        pass against the wrong state."""
+        env = child_env(tmp_path / ".claude", home=tmp_path)
+        assert "CLAUDE_PROJECT_DIR" not in env
+        assert "PYTEST_CURRENT_TEST" not in env
+        assert "CLAUDE_CODE_SESSION_ID" not in env
+        assert env["HOME"] == str(tmp_path)

--- a/pact-plugin/tests/test_project_id.py
+++ b/pact-plugin/tests/test_project_id.py
@@ -1,8 +1,12 @@
 """
-Tests for PACTMemory._detect_project_id() -- 3-strategy fallback detection.
+Tests for PACTMemory._detect_project_id() -- multi-strategy fallback detection.
 
 Tests cover:
 1. Strategy 1: CLAUDE_PROJECT_DIR env var
+1.5. Strategy 1.5: session-record project_dir (between env and git). NOT
+   exercised here: the record discovery refuses test processes, so the real
+   leg is inert in this suite and the replica below stays equivalent without
+   it. The leg's own coverage lives in test_project_dir_resolution.py.
 2. Strategy 2: git rev-parse --git-common-dir (worktree-safe repo root)
 3. Strategy 3: Current working directory basename
 4. Fallback ordering when strategies fail
@@ -122,6 +126,12 @@ def _detect_project_id_under_test():
     This function mirrors the implementation in memory_api.py. The
     test_source_equivalence test verifies that the source of the real
     method matches this replica, so any drift will be caught.
+
+    NO RECORD LEG, DELIBERATELY. The real method's Strategy 1.5 consults the
+    session record through pact_session, whose discovery refuses test
+    processes (PYTEST_CURRENT_TEST), so under this suite the leg is inert and
+    the replica is equivalent without it. Do not "repair" the replica by
+    adding one — the leg's coverage lives in test_project_dir_resolution.py.
     """
     import logging
     logger = logging.getLogger(__name__)
@@ -252,19 +262,30 @@ class TestSourceEquivalence:
         """The replica logic should match the real _detect_project_id method body.
 
         Verifies key implementation markers are present AND ordered correctly:
-        Strategy 1 (env var) before Strategy 2 (git) before Strategy 3 (cwd).
-        This catches accidental strategy reordering that substring checks alone miss.
+        Strategy 1 (env var) before Strategy 1.5 (session record) before
+        Strategy 2 (git) before Strategy 3 (cwd). This catches accidental
+        strategy reordering that substring checks alone miss. The 1.5 position
+        is load-bearing: BELOW env and ABOVE git, because in a multi-repo
+        workspace the cwd's git root can be the wrong scope.
         """
         real_source = _extract_method_body(_MEMORY_API_PATH, "_detect_project_id")
         assert real_source is not None, "Could not find _detect_project_id in memory_api.py"
 
         # Check key implementation lines are present
         assert 'os.environ.get("CLAUDE_PROJECT_DIR")' in real_source
-        # Strategies 1 and 2 reach git through the module-level main_repo_root()
-        # helper rather than each spawning their own subprocess. The subprocess
+        # The env and record strategies name a project from a declared directory
+        # through the shared _project_name_for_declared_dir helper; the git
+        # derivation markers that used to sit inline moved with it and are
+        # pinned on the helper by
+        # test_declared_dir_helper_carries_the_main_repo_rewrite.
+        assert "_project_name_for_declared_dir(project_dir," in real_source
+        # Strategy 1.5: the session-record rung between env and git.
+        assert "get_project_dir_from_session_record()" in real_source
+        assert "_project_name_for_declared_dir(record_dir," in real_source
+        # Strategy 2 reaches git through the module-level main_repo_root()
+        # helper rather than spawning its own subprocess. The subprocess
         # markers this assertion used to carry moved with it and are pinned on
         # the helper by test_main_repo_root_carries_the_git_derivation.
-        assert "main_repo_root(project_dir)" in real_source
         assert "repo_root = main_repo_root()" in real_source
         # Strategy 3 now walks up from cwd to find the nearest project marker.
         assert "_find_project_root(Path.cwd())" in real_source
@@ -272,17 +293,37 @@ class TestSourceEquivalence:
         # Verify strategy ordering in the CODE (not docstring).
         # Use code-specific markers that won't appear in the docstring.
         pos_env = real_source.index('os.environ.get("CLAUDE_PROJECT_DIR")')
+        pos_record = real_source.index("get_project_dir_from_session_record()")
         pos_git = real_source.index("repo_root = main_repo_root()")
         pos_cwd = real_source.index("_find_project_root(Path.cwd())")
 
-        assert pos_env < pos_git, (
+        assert pos_env < pos_record, (
             f"Strategy ordering violation: env var (pos {pos_env}) should appear "
-            f"before git (pos {pos_git})"
+            f"before the session record (pos {pos_record})"
+        )
+        assert pos_record < pos_git, (
+            f"Strategy ordering violation: session record (pos {pos_record}) "
+            f"should appear before git (pos {pos_git})"
         )
         assert pos_git < pos_cwd, (
             f"Strategy ordering violation: git (pos {pos_git}) should appear "
             f"before cwd (pos {pos_cwd})"
         )
+
+    def test_declared_dir_helper_carries_the_main_repo_rewrite(self):
+        """The extracted helper holds the worktree/main-repo rewrite both
+        declared-directory strategies (env, session record) share.
+
+        These markers moved out of _detect_project_id when Strategy 1's inline
+        derivation collapsed onto _project_name_for_declared_dir, so they are
+        pinned here rather than dropped — the same migration pattern as
+        test_main_repo_root_carries_the_git_derivation.
+        """
+        helper_body = _extract_method_body(_MEMORY_API_PATH, "_project_name_for_declared_dir")
+        assert helper_body is not None, "_project_name_for_declared_dir must exist in memory_api.py"
+        assert "main_repo_root(declared_dir)" in helper_body
+        assert "os.path.normcase" in helper_body
+        assert "declared_root or Path(declared_dir)" in helper_body
 
     def test_main_repo_root_carries_the_git_derivation(self):
         """The extracted helper holds what the two strategies used to duplicate.

--- a/pact-plugin/tests/test_session_init_env_file.py
+++ b/pact-plugin/tests/test_session_init_env_file.py
@@ -1,0 +1,141 @@
+"""Phase A env-file export pins for session_init's CLAUDE_ENV_FILE channel.
+
+Pins the contract of ``session_init._persist_project_dir_env`` and its call
+site in ``main()``:
+
+- export written when BOTH $CLAUDE_ENV_FILE and $CLAUDE_PROJECT_DIR are present
+- no-op when CLAUDE_ENV_FILE is unset (older platform versions fail open)
+- no append when CLAUDE_PROJECT_DIR is unset (the structural guard: an
+  env-absent frame's cwd-fallback value is never exported)
+- producer-side shlex.quote for paths with spaces / ``$`` (the env file is
+  sourced by a shell)
+- re-fire dedupe: an identical export line is never appended twice
+  (resume/compact/clear re-fires stay idempotent)
+- exported == recorded invariant: the value appended to the env file is the
+  same resolve-once value passed to build_context_cache (env verbatim when
+  present; absolute cwd on the env-absent leg, never the retired "." default)
+
+The main()-driven rows use the same injection-orthogonal stub set as
+test_config_injection_both_modes.py — the env-file write happens at main()
+top, before any stubbed collaborator runs.
+"""
+import io
+import json
+import os
+import shlex
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import session_init
+
+_PROJECT_DIR = "/Users/example/Sites/test-project"
+
+
+def _run_main(monkeypatch, tmp_path, frame=None):
+    """Drive real session_init.main() with heavy collaborators stubbed.
+    Returns (stdout additionalContext, recorded project_dir captured from the
+    build_context_cache call)."""
+    recorded = {}
+
+    def _capture_context_cache(*args, **kwargs):
+        # build_context_cache(team_name, session_id, project_dir, plugin_root, ...)
+        recorded["project_dir"] = args[2] if len(args) > 2 else kwargs.get("project_dir")
+        return (Path("/tmp/ctx.json"), {})
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    stdin_data = json.dumps({"source": "startup", "session_id": "33334444-0000-0000-0000-000000000000", **(frame or {})})
+    with patch("session_init.setup_plugin_symlinks", return_value=None), \
+         patch("session_init.ensure_project_memory_md", return_value=None), \
+         patch("session_init.check_pinned_staleness", return_value=None), \
+         patch("session_init.get_task_list", return_value=None), \
+         patch("session_init.restore_last_session", return_value=None), \
+         patch("session_init.build_context_cache", side_effect=_capture_context_cache), \
+         patch("session_init.persist_context", return_value=None), \
+         patch("session_init.append_event"), \
+         patch("session_init.update_session_info", return_value=None), \
+         patch("session_init.check_resume_state", return_value=None), \
+         patch("session_init._registry_resolve", return_value=None), \
+         patch("session_init.get_peer_context", return_value=None), \
+         patch("sys.stdin", io.StringIO(stdin_data)), \
+         patch("sys.stdout", new_callable=io.StringIO):
+        with pytest.raises(SystemExit) as exc:
+            session_init.main()
+    assert exc.value.code == 0
+    return recorded.get("project_dir")
+
+
+class TestEnvFileExport:
+    """main()-driven contract rows (call-site gate + helper)."""
+
+    def test_export_written_when_both_present(self, monkeypatch, tmp_path):
+        env_file = tmp_path / "session-env.sh"  # deliberately not pre-created
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", _PROJECT_DIR)
+        monkeypatch.setenv("CLAUDE_ENV_FILE", str(env_file))
+        recorded = _run_main(monkeypatch, tmp_path)
+        assert env_file.read_text(encoding="utf-8") == (
+            f"export CLAUDE_PROJECT_DIR={shlex.quote(_PROJECT_DIR)}\n"
+        )
+        assert recorded == _PROJECT_DIR
+
+    def test_noop_when_env_file_unset(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", _PROJECT_DIR)
+        monkeypatch.delenv("CLAUDE_ENV_FILE", raising=False)
+        # No env-file channel -> clean no-op, exit 0, record side unaffected.
+        recorded = _run_main(monkeypatch, tmp_path)
+        assert recorded == _PROJECT_DIR
+
+    def test_no_append_when_project_dir_unset(self, monkeypatch, tmp_path):
+        env_file = tmp_path / "session-env.sh"
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.setenv("CLAUDE_ENV_FILE", str(env_file))
+        recorded = _run_main(monkeypatch, tmp_path)
+        # Structural guard: env-absent frame never reaches the append...
+        assert not env_file.exists() or "CLAUDE_PROJECT_DIR" not in env_file.read_text(encoding="utf-8")
+        # ...and the record side gets the absolute cwd, never the retired "." default.
+        assert recorded == os.getcwd()
+        assert Path(recorded).is_absolute()
+
+    def test_spacey_dollar_path_is_quoted(self, monkeypatch, tmp_path):
+        spacey = "/Users/example/My Proj$ect/work"
+        env_file = tmp_path / "session-env.sh"
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", spacey)
+        monkeypatch.setenv("CLAUDE_ENV_FILE", str(env_file))
+        recorded = _run_main(monkeypatch, tmp_path)
+        assert env_file.read_text(encoding="utf-8") == (
+            f"export CLAUDE_PROJECT_DIR={shlex.quote(spacey)}\n"
+        )
+        assert recorded == spacey  # verbatim, not resolved
+
+
+class TestPersistProjectDirEnvHelper:
+    """Helper-level guards, exercised directly (no main() drive)."""
+
+    def test_refire_dedupe_appends_nothing_twice(self, monkeypatch, tmp_path):
+        env_file = tmp_path / "session-env.sh"
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", _PROJECT_DIR)
+        monkeypatch.setenv("CLAUDE_ENV_FILE", str(env_file))
+        session_init._persist_project_dir_env(_PROJECT_DIR)
+        session_init._persist_project_dir_env(_PROJECT_DIR)
+        lines = env_file.read_text(encoding="utf-8").splitlines()
+        assert lines == [f"export CLAUDE_PROJECT_DIR={shlex.quote(_PROJECT_DIR)}"]
+
+    def test_non_absolute_value_skipped(self, monkeypatch, tmp_path):
+        env_file = tmp_path / "session-env.sh"
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", _PROJECT_DIR)
+        monkeypatch.setenv("CLAUDE_ENV_FILE", str(env_file))
+        session_init._persist_project_dir_env("relative/dir")
+        assert not env_file.exists()
+
+    def test_env_var_unset_skips_even_with_arg(self, monkeypatch, tmp_path):
+        env_file = tmp_path / "session-env.sh"
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.setenv("CLAUDE_ENV_FILE", str(env_file))
+        session_init._persist_project_dir_env(_PROJECT_DIR)
+        assert not env_file.exists()
+
+    def test_env_file_unset_skips(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", _PROJECT_DIR)
+        monkeypatch.delenv("CLAUDE_ENV_FILE", raising=False)
+        session_init._persist_project_dir_env(_PROJECT_DIR)  # must not raise

--- a/pact-plugin/tests/test_session_init_env_file.py
+++ b/pact-plugin/tests/test_session_init_env_file.py
@@ -23,6 +23,7 @@ import io
 import json
 import os
 import shlex
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -139,3 +140,85 @@ class TestPersistProjectDirEnvHelper:
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", _PROJECT_DIR)
         monkeypatch.delenv("CLAUDE_ENV_FILE", raising=False)
         session_init._persist_project_dir_env(_PROJECT_DIR)  # must not raise
+
+    # -- Fail-open pins (the never-raises contract on the SessionStart hot path)
+    def test_env_file_in_nonexistent_directory_fails_open(self, monkeypatch, tmp_path):
+        """The append's open() raises FileNotFoundError when the parent is
+        missing; the helper must swallow it (OSError arm) — no raise, no file."""
+        env_file = tmp_path / "no-such-dir" / "session-env.sh"
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", _PROJECT_DIR)
+        monkeypatch.setenv("CLAUDE_ENV_FILE", str(env_file))
+        session_init._persist_project_dir_env(_PROJECT_DIR)  # must not raise
+        assert not env_file.exists()
+
+    def test_non_utf8_env_file_fails_open_without_appending(self, monkeypatch, tmp_path):
+        """A non-UTF-8 pre-existing env file raises UnicodeDecodeError on
+        read_text — a ValueError, NOT an OSError. The widened catch must
+        swallow it locally: no raise, and NO append (the whole body is
+        skipped, so the foreign bytes are preserved byte-identical)."""
+        env_file = tmp_path / "session-env.sh"
+        bad = b"\xff\xfe\x00not-utf8"
+        env_file.write_bytes(bad)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", _PROJECT_DIR)
+        monkeypatch.setenv("CLAUDE_ENV_FILE", str(env_file))
+        session_init._persist_project_dir_env(_PROJECT_DIR)  # must not raise
+        assert env_file.read_bytes() == bad, (
+            "a failed read must skip the append — foreign content is preserved"
+        )
+
+    # -- Foreign-content append shape (the channel file can carry other hooks' lines)
+    def test_append_after_unterminated_last_line_starts_on_its_own_line(
+        self, monkeypatch, tmp_path
+    ):
+        """An unterminated foreign last line gets its newline written FIRST —
+        the export never glues onto it, and the prior variable survives a real
+        shell source intact."""
+        env_file = tmp_path / "session-env.sh"
+        env_file.write_text("export PRIOR=1", encoding="utf-8")  # no trailing newline
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", _PROJECT_DIR)
+        monkeypatch.setenv("CLAUDE_ENV_FILE", str(env_file))
+        session_init._persist_project_dir_env(_PROJECT_DIR)
+        assert env_file.read_text(encoding="utf-8") == (
+            f"export PRIOR=1\nexport CLAUDE_PROJECT_DIR={shlex.quote(_PROJECT_DIR)}\n"
+        )
+        probe = subprocess.run(
+            ["bash", "-c", 'source "$1" && printf "%s|%s" "$PRIOR" "$CLAUDE_PROJECT_DIR"',
+             "_", str(env_file)],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert probe.returncode == 0, f"source failed: {probe.stderr!r}"
+        assert probe.stdout == f"1|{_PROJECT_DIR}", (
+            f"the glued-line corruption would read PRIOR=1export...; got {probe.stdout!r}"
+        )
+
+    def test_append_after_terminated_last_line_adds_no_blank_line(
+        self, monkeypatch, tmp_path
+    ):
+        env_file = tmp_path / "session-env.sh"
+        env_file.write_text("export PRIOR=1\n", encoding="utf-8")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", _PROJECT_DIR)
+        monkeypatch.setenv("CLAUDE_ENV_FILE", str(env_file))
+        session_init._persist_project_dir_env(_PROJECT_DIR)
+        assert env_file.read_text(encoding="utf-8") == (
+            f"export PRIOR=1\nexport CLAUDE_PROJECT_DIR={shlex.quote(_PROJECT_DIR)}\n"
+        )
+
+    def test_newline_bearing_value_refire_appends_no_duplicate(self, monkeypatch, tmp_path):
+        """A path containing a literal newline quotes to a MULTI-LINE
+        single-quoted string (valid when sourced). The dedupe must self-match
+        it on re-fire — raw-text match of the terminated logical line, not
+        splitlines() membership, which false-misses and accumulates a
+        duplicate on every resume/compact/clear re-fire."""
+        env_file = tmp_path / "session-env.sh"
+        newline_dir = "/Users/example/My\nProject"
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", newline_dir)
+        monkeypatch.setenv("CLAUDE_ENV_FILE", str(env_file))
+        session_init._persist_project_dir_env(newline_dir)
+        after_first = env_file.read_text(encoding="utf-8")
+        assert "CLAUDE_PROJECT_DIR" in after_first
+        session_init._persist_project_dir_env(newline_dir)
+        assert env_file.read_text(encoding="utf-8") == after_first, (
+            "re-fire appended a duplicate — the dedupe does not self-match a "
+            "newline-bearing value"
+        )
+        assert after_first.count("CLAUDE_PROJECT_DIR") == 1

--- a/pact-plugin/tests/test_session_init_integration.py
+++ b/pact-plugin/tests/test_session_init_integration.py
@@ -154,6 +154,9 @@ def _run_compact_main(tmp_path, monkeypatch, session_id,
         payload["agent_type"] = agent_type
 
     monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/test/project")
+    # session_init.main() now appends to $CLAUDE_ENV_FILE when both vars are
+    # present — keep these drives hermetic against an ambient env file.
+    monkeypatch.delenv("CLAUDE_ENV_FILE", raising=False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
     with patch("session_init.setup_plugin_symlinks", return_value=None), \

--- a/pact-plugin/tests/test_session_init_teammate_peer_inject.py
+++ b/pact-plugin/tests/test_session_init_teammate_peer_inject.py
@@ -74,6 +74,9 @@ def _run_main_capture(stdin_data, monkeypatch, tmp_path, *, peer_return=_PEER_SE
     from session_init import main
 
     monkeypatch.setenv("CLAUDE_PROJECT_DIR", _PROJECT_DIR)
+    # session_init.main() now appends to $CLAUDE_ENV_FILE when both vars are
+    # present — keep these drives hermetic against an ambient env file.
+    monkeypatch.delenv("CLAUDE_ENV_FILE", raising=False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
     with patch("session_init.setup_plugin_symlinks", return_value=None), \

--- a/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
+++ b/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
@@ -256,7 +256,10 @@ class TestProjectDirDivergenceResidual:
     def _resolve_under_root(self, wm, root: Path, monkeypatch):
         """Drive working_memory._get_claude_md_path so it resolves under
         ``root`` via the cwd fallback: env unset + git-root detection forced to
-        fail, so the resolver falls through env → git → cwd, landing on root."""
+        fail. The session-record rung between them is inert here (the discovery
+        refuses test processes, and no CLAUDE_CODE_SESSION_ID is set), so the
+        resolver falls through env -> record(absent) -> git -> cwd, landing on
+        root."""
         # env unset → skip the env-var branch
         monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
 


### PR DESCRIPTION
## Summary

Root fix for the mis-scope family: resolve the project directory once at session start and make it authoritative everywhere, in two layers.

- **Phase A** (`ec704e47`) — `session_init` resolves the project dir once (platform env value verbatim, else absolute cwd) and exports it via the platform's documented `CLAUDE_ENV_FILE` channel, so every subsequent Bash command and skill-spawned CLI inherits it. Probe evidence with control-leg causation: `pact-plugin/tests/runbooks/claude-env-file-probe.md`.
- **Phase B** (`278b5ee0`) — every consumer's resolution chain gains a session-record rung: **env > session record > git main-root > cwd marker walk > home scope (now warns)**. The record is located by the existing `CLAUDE_CODE_SESSION_ID` glob in `pact_session.py`, which previously read the field and discarded it. `backlog.project_root` keeps its refusal for session-less shells (the cross-project bleed guard). Fourteen stale `cannot import` comments amended to the real bootstrap rule.
- **TEST** (`aed9b4aa`) — R1–R5 verification matrix (one row per family issue) + 14-arm mutation pass + conftest env scrub.

Closes #1613, #1485, #1005, #1600.

## Deliberate behavior changes

- **Fail-closed writes**: a hand-set `CLAUDE_PROJECT_DIR` that DISAGREES with the session record is now refused on writes (`backlog set`, memory save, WM sync) with both values + remedy in stderr, instead of silently honored. Reads still follow env. Basis: the family's entire cost has been silent mis-scope (11+ hand re-scopes in #1485).
- **Home-scope fallback warns** (was silent).
- The `session_init` `'.'` fallback is retired: env-absent frames record the absolute cwd.

## Test evidence

- Gate: **15,714 passed, 0 failed, 0 errors** (full suite from `pact-plugin`, no path arg, summary line asserted).
- Mutation pass: 14 arms re-derived from shipped source; **13 killed by exactly the predicted tests**, 1 justified defense-in-depth survivor. Revert arms redden as predicted on both phase commits.
- The disagreement row asserts refusal TEXT (both values + remedy), not exit code alone.

## Dogfood tail (named, not blocking)

- Teammate-mode (in-process/tmux) env-file propagation is platform-unverified — those sessions are covered by the rung-2 contract regardless; the literal env leg is unclaimed there.
- First interactive dogfood of the merged build is the last-mile confirmation (pytest cannot observe the platform's env composition).
- Hardening surface for review: `update()`/`delete()` sit outside the three fail-closed write paths.

## Version

4.7.12 → 4.7.13 (PATCH: additive internal mechanism; no new/removed command/agent).