### PR TITLE
Accept Claude Code login for the Cloud Agent smoke test

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -65,4 +65,4 @@ fi
 
 echo "PACT plugin environment ready. Activate with: source .venv/bin/activate"
 echo "Run the suite with: cd pact-plugin && python -m pytest -ra"
-echo "Live plugin smoke test: bash .cursor/smoke-test.sh (needs ANTHROPIC_API_KEY for the live phase)"
+echo "Live plugin smoke test: bash .cursor/smoke-test.sh (needs ANTHROPIC_API_KEY or a Claude Code login for the live phase)"

--- a/.cursor/smoke-test.sh
+++ b/.cursor/smoke-test.sh
@@ -6,22 +6,38 @@
 # Two phases:
 #   1. Offline: `claude plugin validate` on the plugin + marketplace (no auth).
 #   2. Live:    a single headless `-p` turn with the plugin loaded and the
-#               orchestrator persona selected. Requires ANTHROPIC_API_KEY.
+#               orchestrator persona selected.
 #
-# The live phase is skipped (not failed) when ANTHROPIC_API_KEY is absent, so
-# the offline phase still runs in environments without the secret.
+# Live auth is either ANTHROPIC_API_KEY (Cloud Agents) or an existing Claude
+# Code login (`claude auth status`). The live phase is skipped (not failed)
+# when neither is present, so the offline phase still runs without credentials.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PLUGIN_DIR="$REPO_ROOT/pact-plugin"
 
-# Resolve the claude CLI (user-local npm prefix from install.sh, or PATH).
-export PATH="$HOME/.npm-global/bin:$PATH"
+# Resolve the claude CLI: local installs (~/.local/bin), Cloud Agent npm
+# prefix from install.sh, then PATH.
+export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"
 if ! command -v claude >/dev/null 2>&1; then
   echo "FAIL: claude CLI not found. Run .cursor/install.sh first." >&2
   exit 1
 fi
 echo "claude version: $(claude --version)"
+
+claude_logged_in() {
+  # Parse only the boolean; never print status (it includes email/org).
+  local status
+  status="$(claude auth status --json 2>/dev/null)" || return 1
+  printf '%s' "$status" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+sys.exit(0 if data.get("loggedIn") is True else 1)
+' 2>/dev/null
+}
 
 echo
 echo "== Phase 1: offline plugin + marketplace validation =="
@@ -30,10 +46,18 @@ claude plugin validate "$REPO_ROOT"
 
 echo
 echo "== Phase 2: live headless session =="
-if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-  echo "SKIP: ANTHROPIC_API_KEY not set — offline validation passed; skipping live model call."
+LIVE_AUTH=""
+if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+  LIVE_AUTH="ANTHROPIC_API_KEY"
+elif claude_logged_in; then
+  LIVE_AUTH="Claude Code login"
+fi
+
+if [ -z "$LIVE_AUTH" ]; then
+  echo "SKIP: no ANTHROPIC_API_KEY and Claude Code is not logged in — offline validation passed; skipping live model call."
   exit 0
 fi
+echo "live auth: $LIVE_AUTH"
 
 # Prerequisites the plugin documents for agent operation.
 export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1


### PR DESCRIPTION
## Summary
- Live phase of `.cursor/smoke-test.sh` now runs when `ANTHROPIC_API_KEY` is set **or** Claude Code is logged in (`claude auth status`), instead of skipping on a missing API key.
- Still skips (does not fail) when neither credential is present, so Cloud Agent environments without the secret stay green after offline `claude plugin validate`.
- Resolves `claude` from `~/.local/bin` as well as the Cloud Agent npm prefix.

## Test plan
- [x] `bash .cursor/smoke-test.sh` locally with Claude Code login (no `ANTHROPIC_API_KEY`): `live auth: Claude Code login`, marker `PACT_SMOKE_OK`, PASS
- [ ] Cloud Agent with `ANTHROPIC_API_KEY`: live phase still uses the API key
- [ ] Environment with neither key nor login: phase 1 validates, phase 2 SKIP, exit 0