### PR TITLE
feat: teach agent CLIs with pasteable Examples

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.7.13",
+      "version": "4.7.14",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.7.13/     # Plugin version
+│               └── 4.7.14/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.7.13",
+  "version": "4.7.14",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.7.13
+> **Version**: 4.7.14,
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.7.14,
+> **Version**: 4.7.14
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/shared/backlog.py
+++ b/pact-plugin/hooks/shared/backlog.py
@@ -1214,7 +1214,7 @@ class _UsageErrorParser(argparse.ArgumentParser):
 
     def error(self, message):
         extra = (
-            f"\nExamples:\n  {self._teach_example}\n"
+            f"\n\nExamples:\n  {self._teach_example}\n"
             if self._teach_example
             else "\n"
         )
@@ -1228,11 +1228,13 @@ def build_parser() -> argparse.ArgumentParser:
     """Argument grammar, separated so it is testable without running anything."""
     prog = sys.argv[0]
     fmt = argparse.RawDescriptionHelpFormatter
-    show_ex = f"{prog} show"
-    archive_ex = f"{prog} archive item-id"
-    add_ex = f'{prog} add "title"'
-    set_ex = f"{prog} set item-id --status done"
-    repair_ex = f"{prog} repair"
+    # Interpreter-prefixed so a pasted example executes verbatim: the script
+    # has no shebang or exec bit, so the bare path is not shell-executable.
+    show_ex = f'python3 "{prog}" show'
+    archive_ex = f'python3 "{prog}" archive item-id'
+    add_ex = f'python3 "{prog}" add "title"'
+    set_ex = f'python3 "{prog}" set item-id --status done'
+    repair_ex = f'python3 "{prog}" repair'
 
     parser = _UsageErrorParser(
         prog=prog,

--- a/pact-plugin/hooks/shared/backlog.py
+++ b/pact-plugin/hooks/shared/backlog.py
@@ -1235,6 +1235,7 @@ def build_parser() -> argparse.ArgumentParser:
     repair_ex = f"{prog} repair"
 
     parser = _UsageErrorParser(
+        prog=prog,
         description="PACT cross-session backlog — the user's ordered intent, "
         "reconciled against git, the tracker and pact-memory.",
         formatter_class=fmt,

--- a/pact-plugin/hooks/shared/backlog.py
+++ b/pact-plugin/hooks/shared/backlog.py
@@ -1198,6 +1198,10 @@ def _branch_and_worktree_names(project_path: Any = None) -> Optional[List[str]]:
 # CLI
 # ---------------------------------------------------------------------------
 
+def _cli_examples(*lines: str) -> str:
+    return "Examples:\n" + "\n".join(f"  {line}" for line in lines)
+
+
 class _UsageErrorParser(argparse.ArgumentParser):
     """Exits `_EXIT_USAGE` on a malformed command line, not argparse's default 2.
 
@@ -1206,16 +1210,37 @@ class _UsageErrorParser(argparse.ArgumentParser):
     and a caller holding `build_parser()` gets it too.
     """
 
+    _teach_example = ""
+
     def error(self, message):
-        self.exit(_EXIT_USAGE, f"{self.format_usage()}{self.prog}: error: {message}\n")
+        extra = (
+            f"\nExamples:\n  {self._teach_example}\n"
+            if self._teach_example
+            else "\n"
+        )
+        self.exit(
+            _EXIT_USAGE,
+            f"{self.format_usage()}{self.prog}: error: {message}{extra}",
+        )
 
 
 def build_parser() -> argparse.ArgumentParser:
     """Argument grammar, separated so it is testable without running anything."""
+    prog = sys.argv[0]
+    fmt = argparse.RawDescriptionHelpFormatter
+    show_ex = f"{prog} show"
+    archive_ex = f"{prog} archive item-id"
+    add_ex = f'{prog} add "title"'
+    set_ex = f"{prog} set item-id --status done"
+    repair_ex = f"{prog} repair"
+
     parser = _UsageErrorParser(
         description="PACT cross-session backlog — the user's ordered intent, "
         "reconciled against git, the tracker and pact-memory.",
+        formatter_class=fmt,
+        epilog=_cli_examples(show_ex, archive_ex, add_ex, set_ex, repair_ex),
     )
+    parser._teach_example = show_ex
     parser.add_argument(
         "--backlog-dir",
         help="Override the store directory. Testing seam; omit in normal use.",
@@ -1223,7 +1248,13 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="command")
     sub.required = True
 
-    show = sub.add_parser("show", help="Report every item with its drift flags")
+    show = sub.add_parser(
+        "show",
+        help="Report every item with its drift flags",
+        formatter_class=fmt,
+        epilog=_cli_examples(show_ex),
+    )
+    show._teach_example = show_ex
     view = show.add_mutually_exclusive_group()
     view.add_argument(
         "--all",
@@ -1242,20 +1273,42 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     archive = sub.add_parser(
-        "archive", help="Move settled items into the archive"
+        "archive",
+        help="Move settled items into the archive",
+        formatter_class=fmt,
+        epilog=_cli_examples(archive_ex),
     )
+    archive._teach_example = archive_ex
     archive.add_argument("item_ids", nargs="+")
 
-    add = sub.add_parser("add", help="Add an item")
+    add = sub.add_parser(
+        "add",
+        help="Add an item",
+        formatter_class=fmt,
+        epilog=_cli_examples(add_ex),
+    )
+    add._teach_example = add_ex
     add.add_argument("title")
     _add_item_arguments(add)
 
-    update = sub.add_parser("set", help="Change fields on an existing item")
+    update = sub.add_parser(
+        "set",
+        help="Change fields on an existing item",
+        formatter_class=fmt,
+        epilog=_cli_examples(set_ex),
+    )
+    update._teach_example = set_ex
     update.add_argument("item_id")
     _add_item_arguments(update)
     update.add_argument("--title")
 
-    fix = sub.add_parser("repair", help="Move a corrupt backlog aside and start fresh")
+    fix = sub.add_parser(
+        "repair",
+        help="Move a corrupt backlog aside and start fresh",
+        formatter_class=fmt,
+        epilog=_cli_examples(repair_ex),
+    )
+    fix._teach_example = repair_ex
     fix.add_argument(
         "--force",
         action="store_true",

--- a/pact-plugin/hooks/shared/pact_harvest.py
+++ b/pact-plugin/hooks/shared/pact_harvest.py
@@ -235,7 +235,7 @@ class _TeachParser(argparse.ArgumentParser):
     def error(self, message):
         self.print_usage(sys.stderr)
         extra = (
-            f"\nExamples:\n  {self._teach_example}\n"
+            f"\n\nExamples:\n  {self._teach_example}\n"
             if self._teach_example
             else "\n"
         )
@@ -257,11 +257,15 @@ def main() -> int:
     """
     prog = sys.argv[0]
     fmt = argparse.RawDescriptionHelpFormatter
+    # Interpreter-prefixed so a pasted example executes verbatim: the script
+    # has no shebang or exec bit, so the bare path is not shell-executable.
     session_ex = (
-        f"{prog} resolve-session-dir --context-file /abs/pact-session-context.json"
+        f'python3 "{prog}" resolve-session-dir'
+        " --context-file /abs/pact-session-context.json"
     )
     artifacts_ex = (
-        f"{prog} resolve-artifacts --session-dir /abs/session --feature slug"
+        f'python3 "{prog}" resolve-artifacts'
+        " --session-dir /abs/session --feature slug"
     )
 
     parser = _TeachParser(

--- a/pact-plugin/hooks/shared/pact_harvest.py
+++ b/pact-plugin/hooks/shared/pact_harvest.py
@@ -265,6 +265,7 @@ def main() -> int:
     )
 
     parser = _TeachParser(
+        prog=prog,
         description="PACT harvest CLI — off-lead session-dir + artifact "
         "supersede resolutions for the pact-handoff-harvest skill.",
         formatter_class=fmt,

--- a/pact-plugin/hooks/shared/pact_harvest.py
+++ b/pact-plugin/hooks/shared/pact_harvest.py
@@ -223,6 +223,25 @@ def _session_dir_is_contained(session_dir: str) -> bool:
     return candidate == root or root in candidate.parents
 
 
+def _cli_examples(*lines: str) -> str:
+    return "Examples:\n" + "\n".join(f"  {line}" for line in lines)
+
+
+class _TeachParser(argparse.ArgumentParser):
+    """Usage errors stay exit 2 (STOP) and append one example on stderr only."""
+
+    _teach_example = ""
+
+    def error(self, message):
+        self.print_usage(sys.stderr)
+        extra = (
+            f"\nExamples:\n  {self._teach_example}\n"
+            if self._teach_example
+            else "\n"
+        )
+        self.exit(2, f"{self.prog}: error: {message}{extra}")
+
+
 def main() -> int:
     """CLI entry point for harvest-domain resolutions.
 
@@ -236,18 +255,33 @@ def main() -> int:
         0 ok (incl. legitimately-empty), 2 unresolved/bad-input (skill stop
         trigger), 1 reserved for an uncaught internal error.
     """
-    parser = argparse.ArgumentParser(
+    prog = sys.argv[0]
+    fmt = argparse.RawDescriptionHelpFormatter
+    session_ex = (
+        f"{prog} resolve-session-dir --context-file /abs/pact-session-context.json"
+    )
+    artifacts_ex = (
+        f"{prog} resolve-artifacts --session-dir /abs/session --feature slug"
+    )
+
+    parser = _TeachParser(
         description="PACT harvest CLI — off-lead session-dir + artifact "
         "supersede resolutions for the pact-handoff-harvest skill.",
+        formatter_class=fmt,
+        epilog=_cli_examples(session_ex, artifacts_ex),
     )
-    sub = parser.add_subparsers(dest="command")
+    parser._teach_example = session_ex
+    sub = parser.add_subparsers(dest="command", parser_class=_TeachParser)
     sub.required = True
 
     # --- resolve-session-dir ---
     session_p = sub.add_parser(
         "resolve-session-dir",
         help="Reconstruct the absolute session dir from a context file",
+        formatter_class=fmt,
+        epilog=_cli_examples(session_ex),
     )
+    session_p._teach_example = session_ex
     session_p.add_argument(
         "--context-file",
         required=True,
@@ -258,7 +292,10 @@ def main() -> int:
     artifacts_p = sub.add_parser(
         "resolve-artifacts",
         help="Emit the superseded artifact paths-by-workflow for a feature",
+        formatter_class=fmt,
+        epilog=_cli_examples(artifacts_ex),
     )
+    artifacts_p._teach_example = artifacts_ex
     artifacts_p.add_argument(
         "--session-dir",
         required=True,

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -1683,6 +1683,7 @@ def _build_cli():
     )
 
     parser = _TeachParser(
+        prog=prog,
         description="Session journal CLI — append and query JSONL events.",
         formatter_class=fmt,
         epilog=_cli_examples(write_ex, read_ex, last_ex),

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -46,7 +46,6 @@ Directory permissions: 0o700 (owner only)
 
 from __future__ import annotations
 
-import argparse
 import fcntl
 import json
 import os
@@ -1654,37 +1653,27 @@ def _atomic_write(path: Path, data: bytes) -> bool:
 # --- CLI ---
 
 
-def _cli_examples(*lines: str) -> str:
-    return "Examples:\n" + "\n".join(f"  {line}" for line in lines)
+def _build_cli():
+    """Build the journal CLI. argparse stays off the hook import path."""
+    import argparse
 
+    def _cli_examples(*lines: str) -> str:
+        return "Examples:\n" + "\n".join(f"  {line}" for line in lines)
 
-class _TeachParser(argparse.ArgumentParser):
-    """Usage errors stay exit 2 and append one pasteable example on stderr."""
+    class _TeachParser(argparse.ArgumentParser):
+        """Usage errors stay exit 2 and append one pasteable example on stderr."""
 
-    _teach_example = ""
+        _teach_example = ""
 
-    def error(self, message):
-        self.print_usage(sys.stderr)
-        extra = (
-            f"\nExamples:\n  {self._teach_example}\n"
-            if self._teach_example
-            else "\n"
-        )
-        self.exit(2, f"{self.prog}: error: {message}{extra}")
+        def error(self, message):
+            self.print_usage(sys.stderr)
+            extra = (
+                f"\nExamples:\n  {self._teach_example}\n"
+                if self._teach_example
+                else "\n"
+            )
+            self.exit(2, f"{self.prog}: error: {message}{extra}")
 
-
-def main() -> int:
-    """
-    CLI entry point for session journal operations.
-
-    Subcommands:
-        write  — Append an event via make_event() + append_event()
-        read   — Read events, optionally filtered by type, output JSON
-        read-last — Read the most recent event of a given type, output JSON
-
-    Returns:
-        0 on success, 1 on error.
-    """
     prog = sys.argv[0]
     fmt = argparse.RawDescriptionHelpFormatter
     write_ex = f"{prog} write --type decision --session-dir /abs/session --stdin"
@@ -1763,8 +1752,22 @@ def main() -> int:
     last_p.add_argument("--since", default=None,
                         help="Arc-scope lower bound (inclusive): only consider "
                              "events with ts >= this ISO-8601 UTC timestamp.")
+    return parser
 
-    args = parser.parse_args()
+
+def main() -> int:
+    """
+    CLI entry point for session journal operations.
+
+    Subcommands:
+        write  — Append an event via make_event() + append_event()
+        read   — Read events, optionally filtered by type, output JSON
+        read-last — Read the most recent event of a given type, output JSON
+
+    Returns:
+        0 on success, 1 on error.
+    """
+    args = _build_cli().parse_args()
 
     if args.command == "write":
         # Resolve the JSON payload from either --stdin or --data. The

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -1668,7 +1668,7 @@ def _build_cli():
         def error(self, message):
             self.print_usage(sys.stderr)
             extra = (
-                f"\nExamples:\n  {self._teach_example}\n"
+                f"\n\nExamples:\n  {self._teach_example}\n"
                 if self._teach_example
                 else "\n"
             )
@@ -1676,10 +1676,16 @@ def _build_cli():
 
     prog = sys.argv[0]
     fmt = argparse.RawDescriptionHelpFormatter
-    write_ex = f"{prog} write --type decision --session-dir /abs/session --stdin"
-    read_ex = f"{prog} read --session-dir /abs/session"
+    # Interpreter-prefixed so a pasted example executes verbatim: the script
+    # has no shebang or exec bit, so the bare path is not shell-executable.
+    write_ex = (
+        f'python3 "{prog}" write'
+        " --type decision --session-dir /abs/session --stdin"
+    )
+    read_ex = f'python3 "{prog}" read --session-dir /abs/session'
     last_ex = (
-        f"{prog} read-last --type phase_transition --session-dir /abs/session"
+        f'python3 "{prog}" read-last'
+        " --type phase_transition --session-dir /abs/session"
     )
 
     parser = _TeachParser(

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -46,6 +46,7 @@ Directory permissions: 0o700 (owner only)
 
 from __future__ import annotations
 
+import argparse
 import fcntl
 import json
 import os
@@ -1653,6 +1654,25 @@ def _atomic_write(path: Path, data: bytes) -> bool:
 # --- CLI ---
 
 
+def _cli_examples(*lines: str) -> str:
+    return "Examples:\n" + "\n".join(f"  {line}" for line in lines)
+
+
+class _TeachParser(argparse.ArgumentParser):
+    """Usage errors stay exit 2 and append one pasteable example on stderr."""
+
+    _teach_example = ""
+
+    def error(self, message):
+        self.print_usage(sys.stderr)
+        extra = (
+            f"\nExamples:\n  {self._teach_example}\n"
+            if self._teach_example
+            else "\n"
+        )
+        self.exit(2, f"{self.prog}: error: {message}{extra}")
+
+
 def main() -> int:
     """
     CLI entry point for session journal operations.
@@ -1665,16 +1685,31 @@ def main() -> int:
     Returns:
         0 on success, 1 on error.
     """
-    import argparse
-
-    parser = argparse.ArgumentParser(
-        description="Session journal CLI — append and query JSONL events.",
+    prog = sys.argv[0]
+    fmt = argparse.RawDescriptionHelpFormatter
+    write_ex = f"{prog} write --type decision --session-dir /abs/session --stdin"
+    read_ex = f"{prog} read --session-dir /abs/session"
+    last_ex = (
+        f"{prog} read-last --type phase_transition --session-dir /abs/session"
     )
-    sub = parser.add_subparsers(dest="command")
+
+    parser = _TeachParser(
+        description="Session journal CLI — append and query JSONL events.",
+        formatter_class=fmt,
+        epilog=_cli_examples(write_ex, read_ex, last_ex),
+    )
+    parser._teach_example = write_ex
+    sub = parser.add_subparsers(dest="command", parser_class=_TeachParser)
     sub.required = True
 
     # --- write ---
-    write_p = sub.add_parser("write", help="Append an event to the journal")
+    write_p = sub.add_parser(
+        "write",
+        help="Append an event to the journal",
+        formatter_class=fmt,
+        epilog=_cli_examples(write_ex),
+    )
+    write_p._teach_example = write_ex
     write_p.add_argument("--type", required=True, dest="event_type",
                          help="Event type string (e.g. phase_transition)")
     write_p.add_argument("--session-dir", required=True,
@@ -1697,7 +1732,13 @@ def main() -> int:
                                  "(mutually exclusive with --data)")
 
     # --- read ---
-    read_p = sub.add_parser("read", help="Read events (JSON array to stdout)")
+    read_p = sub.add_parser(
+        "read",
+        help="Read events (JSON array to stdout)",
+        formatter_class=fmt,
+        epilog=_cli_examples(read_ex),
+    )
+    read_p._teach_example = read_ex
     read_p.add_argument("--session-dir", required=True,
                         help="Session directory path")
     read_p.add_argument("--type", default=None, dest="event_type",
@@ -1708,8 +1749,13 @@ def main() -> int:
                              "not string-compared; fail-open on unparseable.")
 
     # --- read-last ---
-    last_p = sub.add_parser("read-last",
-                            help="Read the most recent event of a type")
+    last_p = sub.add_parser(
+        "read-last",
+        help="Read the most recent event of a type",
+        formatter_class=fmt,
+        epilog=_cli_examples(last_ex),
+    )
+    last_p._teach_example = last_ex
     last_p.add_argument("--session-dir", required=True,
                         help="Session directory path")
     last_p.add_argument("--type", required=True, dest="event_type",

--- a/pact-plugin/hooks/shared/session_registry.py
+++ b/pact-plugin/hooks/shared/session_registry.py
@@ -384,15 +384,49 @@ def _read_lead_session_id(team: str) -> str:
 
 if __name__ == "__main__":
     import argparse
+    import sys
 
-    parser = argparse.ArgumentParser(
-        description="PACT teammate session registry (self-registration)."
+    # Teach helpers live inside __main__ (argparse stays off the module import
+    # path — this is a hooks/shared leaf imported by other hooks).
+    def _cli_examples(*lines: str) -> str:
+        return "Examples:\n" + "\n".join(f"  {line}" for line in lines)
+
+    class _TeachParser(argparse.ArgumentParser):
+        """Usage errors stay argparse exit 2 and append one pasteable example."""
+
+        _teach_example = ""
+
+        def error(self, message):
+            self.print_usage(sys.stderr)
+            extra = (
+                f"\n\nExamples:\n  {self._teach_example}\n"
+                if self._teach_example
+                else "\n"
+            )
+            self.exit(2, f"{self.prog}: error: {message}{extra}")
+
+    # Interpreter-prefixed so a pasted example executes verbatim: the script
+    # has no shebang or exec bit, so the bare path is not shell-executable.
+    prog = sys.argv[0]
+    fmt = argparse.RawDescriptionHelpFormatter
+    register_ex = f'python3 "{prog}" register --name "<name>@<team>"'
+
+    parser = _TeachParser(
+        prog=prog,
+        description="PACT teammate session registry (self-registration).",
+        formatter_class=fmt,
+        epilog=_cli_examples(register_ex),
     )
-    subparsers = parser.add_subparsers(dest="command")
+    parser._teach_example = register_ex
+    subparsers = parser.add_subparsers(dest="command", parser_class=_TeachParser)
     subparsers.required = True
     reg = subparsers.add_parser(
-        "register", help="register own session_id -> name@team"
+        "register",
+        help="register own session_id -> name@team",
+        formatter_class=fmt,
+        epilog=_cli_examples(register_ex),
     )
+    reg._teach_example = register_ex
     reg.add_argument(
         "--name", required=True, help="the teammate's own '<name>@<team>' value"
     )

--- a/pact-plugin/skills/pact-coding-standards/SKILL.md
+++ b/pact-plugin/skills/pact-coding-standards/SKILL.md
@@ -470,18 +470,6 @@ Before completing CODE phase:
 
 ## Scripts
 
-### Lint Check Script
-
-A helper script is available at `scripts/lint-check.sh` to run project linters.
-
-```bash
-# From within the skill directory:
-chmod +x scripts/lint-check.sh
-
-# Run (legacy whole-tree mode — project-type detection over a directory)
-./scripts/lint-check.sh
-```
-
 ### Import Hygiene Check (--files mode)
 
 Behavioral tests cannot see an unused import — a dead `import os` passes
@@ -497,6 +485,18 @@ One separately quoted absolute path per file, never one quoted list — a filena
 
 (When your dispatch names a plugin root, the script lives at
 `<plugin-root>/skills/pact-coding-standards/scripts/lint-check.sh`.)
+
+A bare `lint-check.sh` with no arguments is refused. Do not present it as a lint command.
+
+### Lint Check Script (legacy directory mode)
+
+Whole-tree project-type detection is reachable only with a directory argument:
+
+```bash
+# From within the skill directory:
+chmod +x scripts/lint-check.sh
+./scripts/lint-check.sh /path/to/project
+```
 
 **Verdict-line contract** — the LAST stdout line is always exactly one of:
 

--- a/pact-plugin/skills/pact-coding-standards/SKILL.md
+++ b/pact-plugin/skills/pact-coding-standards/SKILL.md
@@ -529,6 +529,17 @@ linter is installed it falls back to the stdlib AST checker
 imports treated as advisory). A checker crash degrades to `SKIPPED` — the
 check fails open and never blocks you on its own breakage.
 
+### Teach examples for agent-facing CLIs
+
+When you add or change an agent-facing CLI, teach it with examples that
+paste-execute verbatim: build every example as
+`python3 "<script-path>" <verb> ...` — bare `python3`, never a pinned
+interpreter, and always quote the script path. In `--help`, the epilog lists
+all of the CLI's examples; a usage error appends exactly one example — the
+offending subcommand's own — separated from the error line by a blank line.
+Keep each CLI's pre-existing usage-error exit code; teaching examples never
+changes an exit contract.
+
 ---
 
 ## Detailed References

--- a/pact-plugin/skills/pact-coding-standards/scripts/lint-check.sh
+++ b/pact-plugin/skills/pact-coding-standards/scripts/lint-check.sh
@@ -25,12 +25,55 @@
 # ============================================================================
 
 # ────────────────────────────────────────────────────────────────────────────
+# Teach prefix: --help / -h, bare refuse, and `--files` plus only help flags.
+# Runs BEFORE --files mode and BEFORE `set -e`. Empty remaining after --files
+# is NOT help (vacuous all-help would steal the SKIPPED contract).
+# ────────────────────────────────────────────────────────────────────────────
+_print_lint_help() {
+    cat <<EOF
+Usage: $0 --files FILE.py [FILE.py ...]
+       $0 DIRECTORY
+
+Examples:
+  $0 --files /abs/path/to/modified.py
+
+--files checks exactly the named .py files (import-hygiene).
+DIRECTORY is legacy whole-tree mode. A bare run (no arguments) is refused.
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    _print_lint_help
+    exit 0
+fi
+
+if [ "$#" -eq 0 ]; then
+    echo "error: lint-check.sh requires --files FILE.py [FILE.py ...] (or a directory for legacy whole-tree mode)" >&2
+    echo "Examples:" >&2
+    echo "  $0 --files /abs/path/to/modified.py" >&2
+    exit 2
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
 # Import-hygiene mode (--files). Runs BEFORE `set -e` is enabled: this mode
 # owns its error handling explicitly so that a probe failure or checker crash
 # can never kill the process before the verdict line is printed (fail-open
 # verdict contract).
 # ────────────────────────────────────────────────────────────────────────────
 if [ "$1" = "--files" ]; then
+    if [ "$#" -gt 1 ]; then
+        _all_help=1
+        for _arg in "${@:2}"; do
+            if [ "$_arg" != "--help" ] && [ "$_arg" != "-h" ]; then
+                _all_help=0
+                break
+            fi
+        done
+        if [ "$_all_help" -eq 1 ]; then
+            _print_lint_help
+            exit 0
+        fi
+    fi
     shift
     SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/pact-plugin/skills/pact-coding-standards/scripts/lint-check.sh
+++ b/pact-plugin/skills/pact-coding-standards/scripts/lint-check.sh
@@ -22,6 +22,9 @@
 # Usage:
 #   ./lint-check.sh --files FILE.py [FILE.py ...]   # import-hygiene mode
 #   ./lint-check.sh DIRECTORY                       # legacy whole-tree mode
+#   ./lint-check.sh --help | -h                     # usage + example, exit 0
+#   A bare run (no arguments, or an empty first argument) is refused:
+#   usage error + example on stderr, exit 2.
 # ============================================================================
 
 # ────────────────────────────────────────────────────────────────────────────
@@ -228,8 +231,9 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# Directory to check (default to current)
-DIR="${1:-.}"
+# Directory to check. Never defaulted: a bare or empty first argument is
+# refused by the teach prefix above, so $1 is always a non-empty string here.
+DIR="${1}"
 
 echo "Running lint check in: $DIR"
 echo "----------------------------------------"

--- a/pact-plugin/skills/pact-coding-standards/scripts/lint-check.sh
+++ b/pact-plugin/skills/pact-coding-standards/scripts/lint-check.sh
@@ -21,7 +21,7 @@
 #     the --files shape).
 # Usage:
 #   ./lint-check.sh --files FILE.py [FILE.py ...]   # import-hygiene mode
-#   ./lint-check.sh [directory]                     # legacy whole-tree mode
+#   ./lint-check.sh DIRECTORY                       # legacy whole-tree mode
 # ============================================================================
 
 # ────────────────────────────────────────────────────────────────────────────
@@ -47,7 +47,7 @@ if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
     exit 0
 fi
 
-if [ "$#" -eq 0 ]; then
+if [ "$#" -eq 0 ] || [ -z "${1}" ]; then
     echo "error: lint-check.sh requires --files FILE.py [FILE.py ...] (or a directory for legacy whole-tree mode)" >&2
     echo "Examples:" >&2
     echo "  $0 --files /abs/path/to/modified.py" >&2

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -816,6 +816,25 @@ def _positive_int(value):
     return ivalue
 
 
+def _cli_examples(*lines: str) -> str:
+    return "Examples:\n" + "\n".join(f"  {line}" for line in lines)
+
+
+class _TeachParser(argparse.ArgumentParser):
+    """Usage errors stay argparse exit 2 and append one pasteable example."""
+
+    _teach_example = ""
+
+    def error(self, message):
+        self.print_usage(sys.stderr)
+        extra = (
+            f"\nExamples:\n  {self._teach_example}\n"
+            if self._teach_example
+            else "\n"
+        )
+        self.exit(2, f"{self.prog}: error: {message}{extra}")
+
+
 def build_parser():
     """Build the argparse parser with all subcommands."""
     # Shared parent parser for the hidden --db-path flag.
@@ -826,17 +845,39 @@ def build_parser():
         help=argparse.SUPPRESS,  # Hidden flag for testing
     )
 
-    parser = argparse.ArgumentParser(
+    prog = sys.argv[0]
+    fmt = argparse.RawDescriptionHelpFormatter
+    examples = {
+        "save": f"{prog} save --stdin",
+        "search": f'{prog} search "query"',
+        "list": f"{prog} list",
+        "get": f"{prog} get <memory-id>",
+        "status": f"{prog} status",
+        "setup": f"{prog} setup",
+        "update": f"{prog} update <memory-id> --stdin",
+        "delete": f"{prog} delete <memory-id>",
+        "sync": f"{prog} sync",
+    }
+
+    parser = _TeachParser(
         prog="pact-memory",
         description="PACT Memory CLI — persistent memory for PACT agents",
+        formatter_class=fmt,
+        epilog=_cli_examples(*examples.values()),
     )
+    parser._teach_example = examples["save"]
 
-    subparsers = parser.add_subparsers(dest="command")
+    subparsers = parser.add_subparsers(dest="command", parser_class=_TeachParser)
 
     # save
     save_parser = subparsers.add_parser(
-        "save", help="Save a memory object", parents=[parent]
+        "save",
+        help="Save a memory object",
+        parents=[parent],
+        formatter_class=fmt,
+        epilog=_cli_examples(examples["save"]),
     )
+    save_parser._teach_example = examples["save"]
     save_parser.add_argument("json_data", nargs="?", help="JSON memory object")
     save_parser.add_argument(
         "--stdin", action="store_true", help="Read JSON from stdin"
@@ -863,8 +904,13 @@ def build_parser():
 
     # search
     search_parser = subparsers.add_parser(
-        "search", help="Search memories", parents=[parent]
+        "search",
+        help="Search memories",
+        parents=[parent],
+        formatter_class=fmt,
+        epilog=_cli_examples(examples["search"]),
     )
+    search_parser._teach_example = examples["search"]
     search_parser.add_argument("query", help="Search query text")
     search_parser.add_argument(
         "--limit", type=_positive_int, default=5, help="Max results (default: 5)"
@@ -888,8 +934,13 @@ def build_parser():
 
     # list
     list_parser = subparsers.add_parser(
-        "list", help="List recent memories", parents=[parent]
+        "list",
+        help="List recent memories",
+        parents=[parent],
+        formatter_class=fmt,
+        epilog=_cli_examples(examples["list"]),
     )
+    list_parser._teach_example = examples["list"]
     list_parser.add_argument(
         "--limit", type=_positive_int, default=20, help="Max results (default: 20)"
     )
@@ -909,21 +960,34 @@ def build_parser():
             "returns NOT_FOUND. Prefix is case-insensitive."
         ),
         parents=[parent],
+        formatter_class=fmt,
+        epilog=_cli_examples(examples["get"]),
     )
+    get_parser._teach_example = examples["get"]
     get_parser.add_argument(
         "memory_id",
         help="Full 32-char memory ID, or a unique prefix of >= 7 characters",
     )
 
     # status
-    subparsers.add_parser(
-        "status", help="Show memory system status", parents=[parent]
+    status_parser = subparsers.add_parser(
+        "status",
+        help="Show memory system status",
+        parents=[parent],
+        formatter_class=fmt,
+        epilog=_cli_examples(examples["status"]),
     )
+    status_parser._teach_example = examples["status"]
 
     # setup
-    subparsers.add_parser(
-        "setup", help="Initialize the memory system", parents=[parent]
+    setup_parser = subparsers.add_parser(
+        "setup",
+        help="Initialize the memory system",
+        parents=[parent],
+        formatter_class=fmt,
+        epilog=_cli_examples(examples["setup"]),
     )
+    setup_parser._teach_example = examples["setup"]
 
     # update
     update_parser = subparsers.add_parser(
@@ -937,7 +1001,10 @@ def build_parser():
             "returns NOT_FOUND. Prefix is case-insensitive."
         ),
         parents=[parent],
+        formatter_class=fmt,
+        epilog=_cli_examples(examples["update"]),
     )
+    update_parser._teach_example = examples["update"]
     update_parser.add_argument(
         "memory_id",
         help="Full 32-char memory ID, or a unique prefix of >= 7 characters",
@@ -968,7 +1035,10 @@ def build_parser():
             "returns NOT_FOUND. Prefix is case-insensitive."
         ),
         parents=[parent],
+        formatter_class=fmt,
+        epilog=_cli_examples(examples["delete"]),
     )
+    delete_parser._teach_example = examples["delete"]
     delete_parser.add_argument(
         "memory_id",
         help="Full 32-char memory ID, or a unique prefix of >= 7 characters",
@@ -986,7 +1056,10 @@ def build_parser():
             "sync_status 'empty' and leaves the file untouched."
         ),
         parents=[parent],
+        formatter_class=fmt,
+        epilog=_cli_examples(examples["sync"]),
     )
+    sync_parser._teach_example = examples["sync"]
     sync_parser.add_argument(
         "--claude-md-root",
         default=None,

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -828,7 +828,7 @@ class _TeachParser(argparse.ArgumentParser):
     def error(self, message):
         self.print_usage(sys.stderr)
         extra = (
-            f"\nExamples:\n  {self._teach_example}\n"
+            f"\n\nExamples:\n  {self._teach_example}\n"
             if self._teach_example
             else "\n"
         )
@@ -847,16 +847,18 @@ def build_parser():
 
     prog = sys.argv[0]
     fmt = argparse.RawDescriptionHelpFormatter
+    # Interpreter-prefixed so a pasted example executes verbatim: the script
+    # has no shebang or exec bit, so the bare path is not shell-executable.
     examples = {
-        "save": f"{prog} save --stdin",
-        "search": f'{prog} search "query"',
-        "list": f"{prog} list",
-        "get": f"{prog} get <memory-id>",
-        "status": f"{prog} status",
-        "setup": f"{prog} setup",
-        "update": f"{prog} update <memory-id> --stdin",
-        "delete": f"{prog} delete <memory-id>",
-        "sync": f"{prog} sync",
+        "save": f'python3 "{prog}" save --stdin',
+        "search": f'python3 "{prog}" search "query"',
+        "list": f'python3 "{prog}" list',
+        "get": f'python3 "{prog}" get <memory-id>',
+        "status": f'python3 "{prog}" status',
+        "setup": f'python3 "{prog}" setup',
+        "update": f'python3 "{prog}" update <memory-id> --stdin',
+        "delete": f'python3 "{prog}" delete <memory-id>',
+        "sync": f'python3 "{prog}" sync',
     }
 
     parser = _TeachParser(

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -860,6 +860,7 @@ def build_parser():
     }
 
     parser = _TeachParser(
+        prog=prog,
         description="PACT Memory CLI — persistent memory for PACT agents",
         formatter_class=fmt,
         epilog=_cli_examples(*examples.values()),

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -860,7 +860,6 @@ def build_parser():
     }
 
     parser = _TeachParser(
-        prog="pact-memory",
         description="PACT Memory CLI — persistent memory for PACT agents",
         formatter_class=fmt,
         epilog=_cli_examples(*examples.values()),

--- a/pact-plugin/tests/conftest.py
+++ b/pact-plugin/tests/conftest.py
@@ -269,33 +269,51 @@ def _resync_staleness_resolver_bindings():
 
 
 @pytest.fixture(autouse=True)
-def _restore_claude_project_dir_env():
-    """Snapshot + restore ``os.environ['CLAUDE_PROJECT_DIR']`` around every test
-    (#930). Runs for EVERY test (autouse).
+def _scrub_claude_project_dir_env():
+    """Pop + restore ``os.environ['CLAUDE_PROJECT_DIR']`` around every test.
+    Runs for EVERY test (autouse).
 
-    Some concurrency tests (test_working_memory_concurrency*.py) set
-    ``os.environ['CLAUDE_PROJECT_DIR']`` via DIRECT assignment (NOT
-    ``monkeypatch.setenv``), so it is never restored and LEAKS into later tests
-    — an order-dependent pollution vector. A leaked ``CLAUDE_PROJECT_DIR``
-    redirects ``CLAUDE_PROJECT_DIR``-keyed resolvers (e.g.
-    ``staleness.get_project_claude_md_path``) away from the test's intended root,
-    so a later test silently resolves the wrong project dir. ``monkeypatch``-
-    based env tests are immune (auto-revert); the leak is the direct-assignment
-    ones specifically.
+    Two hazards, one variable:
 
-    This fixture SNAPSHOTS the var at setup and RESTORES it at teardown
-    (set-to-original, or DELETE if it was originally unset) — an unconditional
-    restore, immune to dirty-baseline chains, and a no-op for the vast majority
-    of tests that never touch it. Co-located with the other env/module-state
-    autouse resets (``_reset_pact_context_state`` / ``_reset_specialist_registry_cache``
-    / ``_resync_staleness_resolver_bindings``). CLAUDE_PROJECT_DIR is the
-    CONFIRMED leaker (the only ``CLAUDE_*`` the working_memory tests set); if a
-    sibling direct-assignment leak is ever confirmed (e.g. ``CLAUDE_PLUGIN_ROOT``
-    in test_plugin_manifest.py), generalize this snapshot to the ``CLAUDE_*``
-    namespace.
+    1. CROSS-TEST LEAK (#930). Some concurrency tests
+       (test_working_memory_concurrency*.py) set ``CLAUDE_PROJECT_DIR`` via
+       DIRECT assignment (NOT ``monkeypatch.setenv``), so it is never restored
+       and LEAKS into later tests — an order-dependent pollution vector that
+       redirects ``CLAUDE_PROJECT_DIR``-keyed resolvers (e.g.
+       ``staleness.get_project_claude_md_path``) away from the test's intended
+       root. The setup-time POP makes every test start from a
+       guaranteed-unset baseline regardless of what an earlier test left
+       behind — strictly stronger than the snapshot/restore-only posture this
+       fixture used before (a leaked value could survive into the next test's
+       setup when the snapshot recorded it).
+
+    2. AMBIENT-ENV LEAK (the machine-state family). ``CLAUDE_PROJECT_DIR`` is
+       a LIVE input to production code under test: ``pact_context.init()``
+       derives the session context path from it, and
+       ``backlog.project_root()`` anchors project resolution on it (NOT the
+       process cwd). Running the suite inside a shell that exports the var
+       (a Claude Code hook process, or a developer shell that sourced one)
+       therefore flips environment-sensitive tests from deterministic to
+       machine-dependent: measured as three pre-existing red failures on dev
+       machines that are green on CI (where the var is unset) —
+       test_backlog's "refusal: no root" exit-code arm (reconcile
+       unexpectedly succeeds against the real repo), and both
+       test_bootstrap_prompt_gate no-session tests (init() re-derives a
+       path the test's ``_context_path = None`` patch cannot prevent, and
+       the heal path can then WRITE a context file through the live root).
+       Same posture as the sibling ``_scrub_claude_plugin_root_env`` /
+       ``_scrub_claude_env_file_env``: POP at setup, restore the original
+       ambient value at teardown. Tests that exercise the var set it
+       explicitly via ``monkeypatch.setenv`` (which overrides the scrub for
+       that test); the direct-assignment concurrency tests are unaffected
+       (they set it after setup, inside the test body).
+
+    Co-located with the other env/module-state autouse resets
+    (``_reset_pact_context_state`` / ``_reset_specialist_registry_cache`` /
+    ``_resync_staleness_resolver_bindings``).
     """
     _UNSET = object()
-    original = os.environ.get("CLAUDE_PROJECT_DIR", _UNSET)
+    original = os.environ.pop("CLAUDE_PROJECT_DIR", _UNSET)
     yield
     if original is _UNSET:
         os.environ.pop("CLAUDE_PROJECT_DIR", None)

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -5844,3 +5844,35 @@ def test_file_local_flags_requires_the_subject_pool_argument():
 
     with _pytest.raises(TypeError, match="subject_pool"):
         backlog_store.file_local_flags({"items": []})
+
+
+class TestBacklogTeachExamples:
+    def test_every_subcommand_help_contains_examples(self, tmp_path):
+        script = Path(__file__).parent.parent / "hooks" / "shared" / "backlog.py"
+        for verb in ("show", "archive", "add", "set", "repair"):
+            r = subprocess.run(
+                [sys.executable, str(script), verb, "--help"],
+                capture_output=True, text=True,
+            )
+            assert r.returncode == 0, verb
+            assert "Examples:" in r.stdout, verb
+
+    def test_archive_help_has_item_id_example(self):
+        script = Path(__file__).parent.parent / "hooks" / "shared" / "backlog.py"
+        r = subprocess.run(
+            [sys.executable, str(script), "archive", "--help"],
+            capture_output=True, text=True,
+        )
+        assert r.returncode == 0
+        assert "Examples:" in r.stdout
+        assert "archive" in r.stdout
+
+    def test_archive_without_ids_exits_usage_with_example(self):
+        script = Path(__file__).parent.parent / "hooks" / "shared" / "backlog.py"
+        r = subprocess.run(
+            [sys.executable, str(script), "archive"],
+            capture_output=True, text=True,
+        )
+        assert r.returncode == backlog._EXIT_USAGE
+        assert "Examples:" in r.stderr
+        assert "archive" in r.stderr

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -5847,29 +5847,64 @@ def test_file_local_flags_requires_the_subject_pool_argument():
 
 
 class TestBacklogTeachExamples:
-    def test_every_subcommand_help_contains_examples(self):
-        for verb in ("show", "archive", "add", "set", "repair"):
+    # Full example lines, content-pinned. prog is the invoked script path
+    # (BACKLOG_CLI), so each rendered example is the exact pasteable string:
+    # interpreter-prefixed, quoted script path, concrete flags. The epilog is
+    # unwrapped (RawDescriptionHelpFormatter), so a full-line assertion is
+    # width-safe at any COLUMNS.
+    _EXAMPLES = {
+        "show": f'python3 "{BACKLOG_CLI}" show',
+        "archive": f'python3 "{BACKLOG_CLI}" archive item-id',
+        "add": f'python3 "{BACKLOG_CLI}" add "title"',
+        "set": f'python3 "{BACKLOG_CLI}" set item-id --status done',
+        "repair": f'python3 "{BACKLOG_CLI}" repair',
+    }
+
+    def test_top_level_help_lists_every_example_line(self):
+        r = subprocess.run(
+            [sys.executable, BACKLOG_CLI, "--help"],
+            capture_output=True, text=True,
+        )
+        assert r.returncode == 0
+        for line in self._EXAMPLES.values():
+            assert line in r.stdout, line
+
+    def test_every_subcommand_help_carries_its_own_example(self):
+        for verb, line in self._EXAMPLES.items():
             r = subprocess.run(
                 [sys.executable, BACKLOG_CLI, verb, "--help"],
                 capture_output=True, text=True,
             )
             assert r.returncode == 0, verb
-            assert "Examples:" in r.stdout, verb
+            assert line in r.stdout, verb
 
-    def test_archive_help_has_item_id_example(self):
-        r = subprocess.run(
-            [sys.executable, BACKLOG_CLI, "archive", "--help"],
-            capture_output=True, text=True,
-        )
-        assert r.returncode == 0
-        assert "Examples:" in r.stdout
-        assert "archive item-id" in r.stdout
-
-    def test_archive_without_ids_exits_usage_with_example(self):
+    def test_archive_without_ids_exits_usage_with_its_example(self):
         r = subprocess.run(
             [sys.executable, BACKLOG_CLI, "archive"],
             capture_output=True, text=True,
         )
         assert r.returncode == backlog._EXIT_USAGE
-        assert "Examples:" in r.stderr
-        assert "archive" in r.stderr
+        # One blank line between the error line and the example.
+        assert (
+            f"\n\nExamples:\n  {self._EXAMPLES['archive']}\n" in r.stderr
+        )
+
+    def test_bare_invocation_is_usage_error_with_one_example(self):
+        r = subprocess.run(
+            [sys.executable, BACKLOG_CLI],
+            capture_output=True, text=True,
+        )
+        assert r.returncode == backlog._EXIT_USAGE
+        assert r.stdout == ""
+        assert "error:" in r.stderr
+        assert self._EXAMPLES["show"] in r.stderr
+
+    def test_unknown_top_level_flag_is_usage_error_with_one_example(self):
+        r = subprocess.run(
+            [sys.executable, BACKLOG_CLI, "--nope"],
+            capture_output=True, text=True,
+        )
+        assert r.returncode == backlog._EXIT_USAGE
+        assert r.stdout == ""
+        assert "error:" in r.stderr
+        assert self._EXAMPLES["show"] in r.stderr

--- a/pact-plugin/tests/test_backlog.py
+++ b/pact-plugin/tests/test_backlog.py
@@ -5847,30 +5847,27 @@ def test_file_local_flags_requires_the_subject_pool_argument():
 
 
 class TestBacklogTeachExamples:
-    def test_every_subcommand_help_contains_examples(self, tmp_path):
-        script = Path(__file__).parent.parent / "hooks" / "shared" / "backlog.py"
+    def test_every_subcommand_help_contains_examples(self):
         for verb in ("show", "archive", "add", "set", "repair"):
             r = subprocess.run(
-                [sys.executable, str(script), verb, "--help"],
+                [sys.executable, BACKLOG_CLI, verb, "--help"],
                 capture_output=True, text=True,
             )
             assert r.returncode == 0, verb
             assert "Examples:" in r.stdout, verb
 
     def test_archive_help_has_item_id_example(self):
-        script = Path(__file__).parent.parent / "hooks" / "shared" / "backlog.py"
         r = subprocess.run(
-            [sys.executable, str(script), "archive", "--help"],
+            [sys.executable, BACKLOG_CLI, "archive", "--help"],
             capture_output=True, text=True,
         )
         assert r.returncode == 0
         assert "Examples:" in r.stdout
-        assert "archive" in r.stdout
+        assert "archive item-id" in r.stdout
 
     def test_archive_without_ids_exits_usage_with_example(self):
-        script = Path(__file__).parent.parent / "hooks" / "shared" / "backlog.py"
         r = subprocess.run(
-            [sys.executable, str(script), "archive"],
+            [sys.executable, BACKLOG_CLI, "archive"],
             capture_output=True, text=True,
         )
         assert r.returncode == backlog._EXIT_USAGE

--- a/pact-plugin/tests/test_conftest_config_root_isolation.py
+++ b/pact-plugin/tests/test_conftest_config_root_isolation.py
@@ -25,6 +25,12 @@ from shared.paths import get_claude_config_dir
 # "there was nothing to scrub", which absence alone cannot distinguish.
 _AMBIENT_SESSION_ID = os.environ.get("CLAUDE_CODE_SESSION_ID")
 
+# Same import-time capture discipline for the CLAUDE_PROJECT_DIR scrub pin
+# below: on a machine whose shell exports the var (a Claude Code hook process
+# or a developer shell that sourced one) the ambient-removal cell
+# discriminates; on CI it skips by the same logic as the session-id cell.
+_AMBIENT_PROJECT_DIR = os.environ.get("CLAUDE_PROJECT_DIR")
+
 
 class TestAutouseConfigRootIsolationPinned:
     """Pin the autouse ``_isolate_config_root_to_tmp`` fixture's closure.
@@ -122,3 +128,62 @@ class TestAutouseConfigRootIsolationPinned:
             "did not fire, and a test resolving the developer's live session id "
             "can compute and write paths that belong to it."
         )
+
+
+class TestAutouseProjectDirScrubPinned:
+    """Pin the autouse ``_scrub_claude_project_dir_env`` fixture's scrub.
+
+    ``CLAUDE_PROJECT_DIR`` is a live production input, not just test plumbing:
+    ``pact_context.init()`` derives the session context path from it and
+    ``backlog.project_root()`` anchors project resolution on it (NOT the
+    process cwd). An ambient value leaking into the suite flips
+    environment-sensitive tests from deterministic to machine-dependent — the
+    measured shape was three dev-machine-red / CI-green failures
+    (test_backlog's "refusal: no root" exit-code arm; both
+    test_bootstrap_prompt_gate no-session tests, where init() re-derives a
+    path the test's ``_context_path = None`` patch cannot prevent). This
+    class is the delete-the-fix counter-test for the scrub: restore the old
+    snapshot/restore-only posture (or remove the setup POP) under an
+    exporting shell and the cells below go red.
+    """
+
+    def test_scrub_removes_an_ambient_project_dir(self):
+        """Same skip-unless-ambient discipline as the session-id cell: absence
+        alone cannot tell "the scrub fired" from "there was nothing to
+        scrub", so skip (visible in the header) when the ambient was clean.
+        """
+        if _AMBIENT_PROJECT_DIR is None:
+            pytest.skip(
+                "no ambient CLAUDE_PROJECT_DIR was present at collection, so "
+                "this cell cannot discriminate a working scrub from an absent "
+                "input — it is meaningful only when the suite runs under a "
+                "shell that exports one"
+            )
+
+        assert "CLAUDE_PROJECT_DIR" not in os.environ, (
+            "CLAUDE_PROJECT_DIR survived into the test body although the "
+            "ambient environment carried one at collection — the autouse scrub "
+            "did not fire, and env-keyed resolvers (pact_context.init, "
+            "backlog.project_root) are resolving against the developer's live "
+            "project instead of the test's inputs."
+        )
+
+    def test_init_cannot_derive_a_context_path_from_ambient_env(self):
+        """Mechanism pin for the measured failure mode: with the var scrubbed,
+        ``pact_context.init()`` must leave ``_context_path`` None for an input
+        carrying only a session_id — the exact precondition the
+        bootstrap no-session tests rely on (no session dir -> no-op gate).
+        """
+        import shared.pact_context as ctx
+
+        ctx.reset_for_tests()
+        try:
+            ctx.init({"session_id": "probe-no-project-dir"})
+            assert ctx._context_path is None, (
+                f"init() derived a context path ({ctx._context_path!r}) from "
+                "an input with no project-dir axis — an ambient "
+                "CLAUDE_PROJECT_DIR leaked through the autouse scrub and "
+                "re-anchored session resolution onto the live machine state."
+            )
+        finally:
+            ctx.reset_for_tests()

--- a/pact-plugin/tests/test_lint_check_help.py
+++ b/pact-plugin/tests/test_lint_check_help.py
@@ -71,3 +71,16 @@ class TestLintCheckHelp:
         assert proc.returncode == 0
         lines = [line for line in proc.stdout.splitlines() if line]
         assert lines[-1] == "IMPORT-HYGIENE: SKIPPED (no arguments given)"
+
+    def test_files_mixed_with_real_path_and_help_is_files_mode(self):
+        # Mixed args: a real .py plus --help. The all-help gate does NOT
+        # fire (the .py path is not a help flag), so the run degrades to
+        # normal --files mode: --help is reported as a non-.py argument on
+        # stderr and the checked file still gets a verdict line.
+        target = _SCRIPT.parent / "check_unused_imports.py"
+        proc = _run("--files", str(target), "--help")
+        assert proc.returncode in (0, 1)
+        assert "Examples:" not in (proc.stdout + proc.stderr)
+        assert "not a .py path, ignored: --help" in proc.stderr
+        lines = [line for line in proc.stdout.splitlines() if line]
+        assert lines[-1].startswith("IMPORT-HYGIENE: ")

--- a/pact-plugin/tests/test_lint_check_help.py
+++ b/pact-plugin/tests/test_lint_check_help.py
@@ -45,10 +45,20 @@ class TestLintCheckHelp:
     def test_bare_run_exits_two_with_files_example_no_verdict(self):
         proc = _run()
         assert proc.returncode == 2
+        assert "Examples:" in proc.stderr
         assert "--files" in proc.stderr
+        assert ".py" in proc.stderr
         assert "IMPORT-HYGIENE:" not in proc.stdout
         assert "IMPORT-HYGIENE:" not in proc.stderr
         assert "Running lint check in:" not in proc.stdout
+
+    def test_empty_directory_arg_refuses_like_bare_run(self):
+        proc = _run("")
+        assert proc.returncode == 2
+        assert "Examples:" in proc.stderr
+        assert "--files" in proc.stderr
+        assert "IMPORT-HYGIENE:" not in proc.stdout
+        assert "Running lint check in:" not in (proc.stdout + proc.stderr)
 
     def test_files_help_only_is_help_not_skipped(self):
         proc = _run("--files", "--help")

--- a/pact-plugin/tests/test_lint_check_help.py
+++ b/pact-plugin/tests/test_lint_check_help.py
@@ -1,0 +1,63 @@
+"""
+Location: pact-plugin/tests/test_lint_check_help.py
+Summary: Help, bare-refuse, and `--files` plus only help flags for lint-check.sh.
+Used by: pytest suite. The --files last-line verdict contract stays in
+         test_lint_check_files_mode.py; this file pins the teach prefix.
+"""
+
+import subprocess
+from pathlib import Path
+
+_SCRIPT = (
+    Path(__file__).parent.parent
+    / "skills"
+    / "pact-coding-standards"
+    / "scripts"
+    / "lint-check.sh"
+)
+
+
+def _run(*argv):
+    return subprocess.run(
+        ["bash", str(_SCRIPT), *argv],
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestLintCheckHelp:
+    def test_help_long_exits_zero_with_examples_no_verdict(self):
+        proc = _run("--help")
+        assert proc.returncode == 0
+        text = proc.stdout + proc.stderr
+        assert "Examples:" in text
+        assert "--files" in text
+        assert "IMPORT-HYGIENE:" not in proc.stdout
+        assert "IMPORT-HYGIENE:" not in proc.stderr
+        assert "Running lint check in:" not in text
+
+    def test_help_short_exits_zero(self):
+        proc = _run("-h")
+        assert proc.returncode == 0
+        assert "Examples:" in (proc.stdout + proc.stderr)
+        assert "IMPORT-HYGIENE:" not in proc.stdout
+
+    def test_bare_run_exits_two_with_files_example_no_verdict(self):
+        proc = _run()
+        assert proc.returncode == 2
+        assert "--files" in proc.stderr
+        assert "IMPORT-HYGIENE:" not in proc.stdout
+        assert "IMPORT-HYGIENE:" not in proc.stderr
+        assert "Running lint check in:" not in proc.stdout
+
+    def test_files_help_only_is_help_not_skipped(self):
+        proc = _run("--files", "--help")
+        assert proc.returncode == 0
+        assert "Examples:" in (proc.stdout + proc.stderr)
+        assert "IMPORT-HYGIENE:" not in proc.stdout
+
+    def test_files_zero_paths_still_skipped(self):
+        proc = _run("--files")
+        assert proc.returncode == 0
+        lines = [line for line in proc.stdout.splitlines() if line]
+        assert lines[-1] == "IMPORT-HYGIENE: SKIPPED (no arguments given)"

--- a/pact-plugin/tests/test_lint_check_help.py
+++ b/pact-plugin/tests/test_lint_check_help.py
@@ -48,6 +48,9 @@ class TestLintCheckHelp:
         assert "Examples:" in proc.stderr
         assert "--files" in proc.stderr
         assert ".py" in proc.stderr
+        # Full example line, content-pinned: the pasteable unit itself, not
+        # tokens that also occur in the usage/error lines above it.
+        assert f"  {_SCRIPT} --files /abs/path/to/modified.py" in proc.stderr
         assert "IMPORT-HYGIENE:" not in proc.stdout
         assert "IMPORT-HYGIENE:" not in proc.stderr
         assert "Running lint check in:" not in proc.stdout

--- a/pact-plugin/tests/test_memory_cli.py
+++ b/pact-plugin/tests/test_memory_cli.py
@@ -176,7 +176,7 @@ class TestCliArgParsing:
     def test_build_parser_returns_parser(self):
         parser = build_parser()
         assert parser is not None
-        assert parser.prog == "pact-memory"
+        assert parser.prog == sys.argv[0]
 
     def test_save_subcommand_parsed(self):
         parser = build_parser()
@@ -2572,7 +2572,8 @@ class TestCliHelpOutput:
             main(["--help"])
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
-        assert "pact-memory" in captured.out
+        assert "PACT Memory" in captured.out
+        assert "Examples:" in captured.out
 
     def test_main_help_lists_subcommands(self, capsys):
         with pytest.raises(SystemExit) as exc_info:

--- a/pact-plugin/tests/test_memory_cli.py
+++ b/pact-plugin/tests/test_memory_cli.py
@@ -186,6 +186,9 @@ class TestCliArgParsing:
         help_text = parser.format_help()
         assert invoked in help_text
         assert "Examples:" in help_text
+        # The example line carries the executable shape: interpreter prefix
+        # and the quoted invoked path.
+        assert f'python3 "{invoked}" save --stdin' in help_text
 
     def test_save_subcommand_parsed(self):
         parser = build_parser()
@@ -2613,19 +2616,21 @@ class TestCliHelpOutput:
             main(["--help"])
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
-        assert "Examples:" in captured.out
+        # Full example lines, content-pinned. In-process the examples are
+        # argv[0]-relative: the parser is built inside main() with the test
+        # process's argv[0], so the known constant is sys.argv[0]. The epilog
+        # is unwrapped (RawDescriptionHelpFormatter), so full-line assertions
+        # are width-safe at any COLUMNS.
+        for line in self._example_lines().values():
+            assert line in captured.out, line
 
     def test_every_subcommand_help_contains_examples(self, capsys):
-        verbs = (
-            "save", "search", "list", "get", "status",
-            "setup", "update", "delete", "sync",
-        )
-        for verb in verbs:
+        for verb in self._example_lines():
             with pytest.raises(SystemExit) as exc_info:
                 main([verb, "--help"])
             assert exc_info.value.code == 0, verb
             captured = capsys.readouterr()
-            assert "Examples:" in captured.out, verb
+            assert self._example_lines()[verb] in captured.out, verb
 
     def test_get_without_id_is_argparse_usage_with_example(self, capsys):
         with pytest.raises(SystemExit) as exc_info:
@@ -2633,10 +2638,50 @@ class TestCliHelpOutput:
         assert exc_info.value.code == 2
         captured = capsys.readouterr()
         assert captured.out == ""
-        assert "Examples:" in captured.err
-        assert "get" in captured.err
+        # One blank line between the error line and the example.
+        assert (
+            f"\n\nExamples:\n  {self._example_lines()['get']}\n"
+            in captured.err
+        )
         with pytest.raises(json.JSONDecodeError):
             json.loads(captured.err)
+
+    def test_bare_invocation_prints_help_with_examples_exit_one(self, capsys):
+        # This CLI's pre-existing bare contract: subparsers are not required,
+        # so main() prints the full help (epilog Examples included) to stderr
+        # and exits 1 — not the argparse usage-error path.
+        with pytest.raises(SystemExit) as exc_info:
+            main([])
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert self._example_lines()["save"] in captured.err
+
+    def test_unknown_top_level_flag_is_usage_error_with_one_example(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--nope"])
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "error:" in captured.err
+        assert self._example_lines()["save"] in captured.err
+
+    @staticmethod
+    def _example_lines():
+        # Interpreter-prefixed, quoted script path, concrete flags: the exact
+        # strings build_parser() renders as pasteable examples.
+        prog = sys.argv[0]
+        return {
+            "save": f'python3 "{prog}" save --stdin',
+            "search": f'python3 "{prog}" search "query"',
+            "list": f'python3 "{prog}" list',
+            "get": f'python3 "{prog}" get <memory-id>',
+            "status": f'python3 "{prog}" status',
+            "setup": f'python3 "{prog}" setup',
+            "update": f'python3 "{prog}" update <memory-id> --stdin',
+            "delete": f'python3 "{prog}" delete <memory-id>',
+            "sync": f'python3 "{prog}" sync',
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_memory_cli.py
+++ b/pact-plugin/tests/test_memory_cli.py
@@ -178,6 +178,15 @@ class TestCliArgParsing:
         assert parser is not None
         assert parser.prog == sys.argv[0]
 
+    def test_build_parser_prog_keeps_invoked_directory(self, monkeypatch):
+        invoked = "/abs/path/to/cli.py"
+        monkeypatch.setattr(sys, "argv", [invoked])
+        parser = build_parser()
+        assert parser.prog == invoked
+        help_text = parser.format_help()
+        assert invoked in help_text
+        assert "Examples:" in help_text
+
     def test_save_subcommand_parsed(self):
         parser = build_parser()
         args = parser.parse_args(["save", '{"context": "test"}'])

--- a/pact-plugin/tests/test_memory_cli.py
+++ b/pact-plugin/tests/test_memory_cli.py
@@ -2598,6 +2598,36 @@ class TestCliHelpOutput:
         assert "--limit" in captured.out
         assert "query" in captured.out.lower()
 
+    def test_main_help_contains_examples(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--help"])
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "Examples:" in captured.out
+
+    def test_every_subcommand_help_contains_examples(self, capsys):
+        verbs = (
+            "save", "search", "list", "get", "status",
+            "setup", "update", "delete", "sync",
+        )
+        for verb in verbs:
+            with pytest.raises(SystemExit) as exc_info:
+                main([verb, "--help"])
+            assert exc_info.value.code == 0, verb
+            captured = capsys.readouterr()
+            assert "Examples:" in captured.out, verb
+
+    def test_get_without_id_is_argparse_usage_with_example(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main(["get"])
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "Examples:" in captured.err
+        assert "get" in captured.err
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(captured.err)
+
 
 # ---------------------------------------------------------------------------
 # save(sync_to_claude=...) — the Working Memory projection, made optional

--- a/pact-plugin/tests/test_pact_harvest_cli.py
+++ b/pact-plugin/tests/test_pact_harvest_cli.py
@@ -678,21 +678,55 @@ class TestParseTsTrailingZAnchor:
 
 
 class TestHarvestTeachExamples:
-    def test_both_subcommand_helps_contain_examples(self):
-        for verb in ("resolve-session-dir", "resolve-artifacts"):
+    # Full example lines, content-pinned. prog is the invoked script path
+    # (_CLI), so each rendered example is the exact pasteable string:
+    # interpreter-prefixed, quoted script path, concrete flags. The epilog is
+    # unwrapped (RawDescriptionHelpFormatter), so a full-line assertion is
+    # width-safe at any COLUMNS.
+    _EXAMPLES = {
+        "resolve-session-dir": (
+            f'python3 "{_CLI}" resolve-session-dir'
+            " --context-file /abs/pact-session-context.json"
+        ),
+        "resolve-artifacts": (
+            f'python3 "{_CLI}" resolve-artifacts'
+            " --session-dir /abs/session --feature slug"
+        ),
+    }
+
+    def test_top_level_help_lists_every_example_line(self):
+        r = _run_cli("--help")
+        assert r.returncode == 0
+        for line in self._EXAMPLES.values():
+            assert line in r.stdout, line
+
+    def test_every_subcommand_help_carries_its_own_example(self):
+        for verb, line in self._EXAMPLES.items():
             r = _run_cli(verb, "--help")
             assert r.returncode == 0, verb
-            assert "Examples:" in r.stdout, verb
-
-    def test_resolve_session_dir_help_names_context_file(self):
-        r = _run_cli("resolve-session-dir", "--help")
-        assert r.returncode == 0
-        assert "--context-file" in r.stdout
-        assert "Examples:" in r.stdout
+            assert line in r.stdout, verb
 
     def test_missing_context_file_usage_has_example_empty_stdout(self):
         r = _run_cli("resolve-session-dir")
         assert r.returncode == 2
         assert r.stdout == ""
-        assert "Examples:" in r.stderr
-        assert "resolve-session-dir" in r.stderr
+        assert "error:" in r.stderr
+        # One blank line between the error line and the example.
+        assert (
+            f"\n\nExamples:\n  {self._EXAMPLES['resolve-session-dir']}\n"
+            in r.stderr
+        )
+
+    def test_bare_invocation_is_usage_error_with_one_example(self):
+        r = _run_cli()
+        assert r.returncode == 2
+        assert r.stdout == ""
+        assert "error:" in r.stderr
+        assert self._EXAMPLES["resolve-session-dir"] in r.stderr
+
+    def test_unknown_top_level_flag_is_usage_error_with_one_example(self):
+        r = _run_cli("--nope")
+        assert r.returncode == 2
+        assert r.stdout == ""
+        assert "error:" in r.stderr
+        assert self._EXAMPLES["resolve-session-dir"] in r.stderr

--- a/pact-plugin/tests/test_pact_harvest_cli.py
+++ b/pact-plugin/tests/test_pact_harvest_cli.py
@@ -675,3 +675,24 @@ class TestParseTsTrailingZAnchor:
         # A string with NO trailing Z is returned byte-for-byte unchanged.
         assert _normalize_trailing_z(
             "2026-06-25T00:00:00+00:00") == "2026-06-25T00:00:00+00:00"
+
+
+class TestHarvestTeachExamples:
+    def test_both_subcommand_helps_contain_examples(self):
+        for verb in ("resolve-session-dir", "resolve-artifacts"):
+            r = _run_cli(verb, "--help")
+            assert r.returncode == 0, verb
+            assert "Examples:" in r.stdout, verb
+
+    def test_resolve_session_dir_help_names_context_file(self):
+        r = _run_cli("resolve-session-dir", "--help")
+        assert r.returncode == 0
+        assert "--context-file" in r.stdout
+        assert "Examples:" in r.stdout
+
+    def test_missing_context_file_usage_has_example_empty_stdout(self):
+        r = _run_cli("resolve-session-dir")
+        assert r.returncode == 2
+        assert r.stdout == ""
+        assert "Examples:" in r.stderr
+        assert "resolve-session-dir" in r.stderr

--- a/pact-plugin/tests/test_session_journal.py
+++ b/pact-plugin/tests/test_session_journal.py
@@ -5189,3 +5189,35 @@ class TestArcScopingMalformedResilience:
         # prior(1) excluded by ts; malformed skipped; missing-ts(4) fail-open
         # included; current(2,3) ts-scoped in
         assert task_ids == ["2", "3", "4"]
+
+
+class TestJournalTeachExamples:
+    """First-cut Examples: on --help and one pasteable line on usage errors."""
+
+    def test_write_help_contains_examples_and_stdin(self):
+        result = subprocess.run(
+            [sys.executable, _SJ_SCRIPT, "write", "--help"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert "Examples:" in result.stdout
+        assert "--stdin" in result.stdout or "--type" in result.stdout
+
+    def test_every_subcommand_help_contains_examples(self):
+        for verb in ("write", "read", "read-last"):
+            result = subprocess.run(
+                [sys.executable, _SJ_SCRIPT, verb, "--help"],
+                capture_output=True, text=True,
+            )
+            assert result.returncode == 0, verb
+            assert "Examples:" in result.stdout, verb
+
+    def test_write_missing_flags_exits_2_with_example(self):
+        result = subprocess.run(
+            [sys.executable, _SJ_SCRIPT, "write"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 2
+        assert "write" in result.stderr
+        assert "Examples:" in result.stderr
+        assert result.stdout == ""

--- a/pact-plugin/tests/test_session_journal.py
+++ b/pact-plugin/tests/test_session_journal.py
@@ -5192,8 +5192,6 @@ class TestArcScopingMalformedResilience:
 
 
 class TestJournalTeachExamples:
-    """First-cut Examples: on --help and one pasteable line on usage errors."""
-
     def test_write_help_contains_examples_and_stdin(self):
         result = subprocess.run(
             [sys.executable, _SJ_SCRIPT, "write", "--help"],

--- a/pact-plugin/tests/test_session_journal.py
+++ b/pact-plugin/tests/test_session_journal.py
@@ -5192,23 +5192,40 @@ class TestArcScopingMalformedResilience:
 
 
 class TestJournalTeachExamples:
-    def test_write_help_contains_examples_and_stdin(self):
+    # Full example lines, content-pinned. prog is the invoked script path
+    # (_SJ_SCRIPT), so each rendered example is the exact pasteable string:
+    # interpreter-prefixed, quoted script path, concrete flags. The epilog is
+    # unwrapped (RawDescriptionHelpFormatter), so a full-line assertion is
+    # width-safe at any COLUMNS.
+    _EXAMPLES = {
+        "write": (
+            f'python3 "{_SJ_SCRIPT}" write'
+            " --type decision --session-dir /abs/session --stdin"
+        ),
+        "read": f'python3 "{_SJ_SCRIPT}" read --session-dir /abs/session',
+        "read-last": (
+            f'python3 "{_SJ_SCRIPT}" read-last'
+            " --type phase_transition --session-dir /abs/session"
+        ),
+    }
+
+    def test_top_level_help_lists_every_example_line(self):
         result = subprocess.run(
-            [sys.executable, _SJ_SCRIPT, "write", "--help"],
+            [sys.executable, _SJ_SCRIPT, "--help"],
             capture_output=True, text=True,
         )
         assert result.returncode == 0
-        assert "Examples:" in result.stdout
-        assert "--stdin" in result.stdout or "--type" in result.stdout
+        for line in self._EXAMPLES.values():
+            assert line in result.stdout, line
 
-    def test_every_subcommand_help_contains_examples(self):
-        for verb in ("write", "read", "read-last"):
+    def test_every_subcommand_help_carries_its_own_example(self):
+        for verb, line in self._EXAMPLES.items():
             result = subprocess.run(
                 [sys.executable, _SJ_SCRIPT, verb, "--help"],
                 capture_output=True, text=True,
             )
             assert result.returncode == 0, verb
-            assert "Examples:" in result.stdout, verb
+            assert line in result.stdout, verb
 
     def test_write_missing_flags_exits_2_with_example(self):
         result = subprocess.run(
@@ -5216,6 +5233,27 @@ class TestJournalTeachExamples:
             capture_output=True, text=True,
         )
         assert result.returncode == 2
-        assert "write" in result.stderr
-        assert "Examples:" in result.stderr
+        assert "error:" in result.stderr
         assert result.stdout == ""
+        # One blank line between the error line and the example.
+        assert f"\n\nExamples:\n  {self._EXAMPLES['write']}\n" in result.stderr
+
+    def test_bare_invocation_is_usage_error_with_one_example(self):
+        result = subprocess.run(
+            [sys.executable, _SJ_SCRIPT],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 2
+        assert result.stdout == ""
+        assert "error:" in result.stderr
+        assert self._EXAMPLES["write"] in result.stderr
+
+    def test_unknown_top_level_flag_is_usage_error_with_one_example(self):
+        result = subprocess.run(
+            [sys.executable, _SJ_SCRIPT, "--nope"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 2
+        assert result.stdout == ""
+        assert "error:" in result.stderr
+        assert self._EXAMPLES["write"] in result.stderr

--- a/pact-plugin/tests/test_session_registry.py
+++ b/pact-plugin/tests/test_session_registry.py
@@ -9,6 +9,9 @@ tests live in commit G's test files; this file is the module's own unit suite.)
 """
 
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -325,3 +328,86 @@ class TestConfigRootInlineParity:
             "CLAUDE_CONFIG_DIR — the containment anchor is not co-routed through the "
             "inline _config_root() (register() would silently bail)"
         )
+
+
+# ---------------------------------------------------------------------------
+# CLI teach examples (main block via subprocess)
+# ---------------------------------------------------------------------------
+
+_SR_SCRIPT = str(
+    Path(__file__).parent.parent / "hooks" / "shared" / "session_registry.py"
+)
+
+
+class TestRegistryTeachExamples:
+    # Full example line, content-pinned. prog is the invoked script path
+    # (_SR_SCRIPT), so the rendered example is the exact pasteable string:
+    # interpreter-prefixed, quoted script path, concrete flags. The epilog is
+    # unwrapped (RawDescriptionHelpFormatter), so a full-line assertion is
+    # width-safe at any COLUMNS.
+    _EXAMPLE = f'python3 "{_SR_SCRIPT}" register --name "<name>@<team>"'
+
+    def test_top_level_help_lists_the_example_line(self):
+        r = subprocess.run(
+            [sys.executable, _SR_SCRIPT, "--help"],
+            capture_output=True, text=True,
+        )
+        assert r.returncode == 0
+        assert self._EXAMPLE in r.stdout
+
+    def test_register_help_carries_the_example_line(self):
+        r = subprocess.run(
+            [sys.executable, _SR_SCRIPT, "register", "--help"],
+            capture_output=True, text=True,
+        )
+        assert r.returncode == 0
+        assert self._EXAMPLE in r.stdout
+
+    def test_missing_name_exits_2_with_example(self):
+        r = subprocess.run(
+            [sys.executable, _SR_SCRIPT, "register"],
+            capture_output=True, text=True,
+        )
+        assert r.returncode == 2
+        assert r.stdout == ""
+        assert "error:" in r.stderr
+        # One blank line between the error line and the example.
+        assert f"\n\nExamples:\n  {self._EXAMPLE}\n" in r.stderr
+
+    def test_bare_invocation_is_usage_error_with_one_example(self):
+        r = subprocess.run(
+            [sys.executable, _SR_SCRIPT],
+            capture_output=True, text=True,
+        )
+        assert r.returncode == 2
+        assert r.stdout == ""
+        assert "error:" in r.stderr
+        assert self._EXAMPLE in r.stderr
+
+    def test_unknown_top_level_flag_is_usage_error_with_one_example(self):
+        r = subprocess.run(
+            [sys.executable, _SR_SCRIPT, "--nope"],
+            capture_output=True, text=True,
+        )
+        assert r.returncode == 2
+        assert r.stdout == ""
+        assert "error:" in r.stderr
+        assert self._EXAMPLE in r.stderr
+
+    def test_pasted_example_executes_hermetically(self, tmp_path, monkeypatch):
+        # The one live paste-execute the bar allows: hermetic by
+        # construction — CLAUDE_CONFIG_DIR redirected into the sandbox and
+        # $CLAUDE_CODE_SESSION_ID removed, so register() takes its documented
+        # session-absent no-op and writes nothing. Proves the rendered line
+        # is shell-executable verbatim (interpreter prefix + quoted path).
+        env = {
+            k: v for k, v in os.environ.items()
+            if k != "CLAUDE_CODE_SESSION_ID"
+        }
+        env["CLAUDE_CONFIG_DIR"] = str(tmp_path)
+        r = subprocess.run(
+            self._EXAMPLE, shell=True, capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+        assert "Permission denied" not in r.stderr
+        assert list(tmp_path.rglob("*")) == []


### PR DESCRIPTION
## Summary

Agents that copied `--help` or a usage error from the high-traffic CLIs got argparse syntax, not a command they could paste. Bare `lint-check.sh` treated `--help` as a directory and lints `.`.

`--help` and usage failures on `lint-check.sh`, `session_journal.py`, `pact_harvest.py`, `backlog.py`, and pact-memory `cli.py` now print a shell-pasteable `Examples:` line that uses the invoked script path. A bare or empty-string `lint-check.sh` refuses with exit 2 and no `IMPORT-HYGIENE:` line. `pact-coding-standards/SKILL.md` leads with `--files`.

Unchanged on purpose: harvest 0/2/1, the `--files` last-line verdict, pact-memory JSON `_error` envelopes, and per-CLI usage exits (journal/harvest 2, backlog 64, memory no-command 1). Teach helpers stay per-CLI (no shared module).

Session-settled decisions carried from planning: first-cut only (user-directed, over findings 3–6); harvest usage stays exit 2 (user-approved, over changing STOP codes); keep the `--files` last-line verdict (user-approved, over rewriting `--files`).

## Test plan

- [x] New `test_lint_check_help.py` pins `--help`/`-h`, bare refuse, empty `$1`, `--files --help`, and zero-path SKIPPED
- [x] Teach/example tests on journal, harvest, backlog, and pact-memory
- [x] Existing `--files` and harvest STOP tests kept
- [ ] CI: `cd pact-plugin && python3 -m pytest -q` (no path argument)

## Version

4.7.13 → 4.7.14 (PATCH: additive help/errors; no new command or agent). Rebase onto main already at 4.7.13.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)