### PR TITLE
chore: restructure test imports — conftest centralization + vestigial sys.path sweep

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.7.18",
+      "version": "4.7.19",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.7.18/     # Plugin version
+│               └── 4.7.19/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.7.18",
+  "version": "4.7.19",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.7.18
+> **Version**: 4.7.19
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/conftest.py
+++ b/pact-plugin/conftest.py
@@ -43,7 +43,7 @@ if _tests_dir not in sys.path:
     sys.path.insert(0, _tests_dir)
 
 from import_identity_map import (  # noqa: E402
-    pytest_collection_modifyitems,
-    pytest_sessionfinish,
-    pytest_sessionstart,
+    pytest_collection_modifyitems,  # noqa: F401 — hook-registration re-export; pytest's name-based discovery is the consumer, the linter can't see it
+    pytest_sessionfinish,  # noqa: F401 — hook-registration re-export
+    pytest_sessionstart,  # noqa: F401 — hook-registration re-export
 )

--- a/pact-plugin/conftest.py
+++ b/pact-plugin/conftest.py
@@ -31,3 +31,19 @@ for _scripts_dir in sorted(Path(__file__).parent.glob("skills/*/scripts")):
 _plugin_root = str(Path(__file__).parent)
 if _plugin_root not in sys.path:
     sys.path.insert(0, _plugin_root)
+
+# Import-identity harness registration (layer 4 guard). tests/ is inserted so
+# the harness module resolves at conftest load; the insert is a guarded no-op
+# once tests/conftest.py has run. The harness is stdlib-only, so this import
+# cannot trip the no-import charter's optional-dependency failure mode.
+# Name-based hook discovery picks up the re-exported callables session-wide
+# (this conftest's tree spans both tests/ and the skills-adjacent files).
+_tests_dir = str(Path(__file__).parent / "tests")
+if _tests_dir not in sys.path:
+    sys.path.insert(0, _tests_dir)
+
+from import_identity_map import (  # noqa: E402
+    pytest_collection_modifyitems,
+    pytest_sessionfinish,
+    pytest_sessionstart,
+)

--- a/pact-plugin/conftest.py
+++ b/pact-plugin/conftest.py
@@ -10,9 +10,9 @@ membership guard keeps the overlap a no-op when both conftests load in one
 run.
 
 Used by: pytest (loaded for every run rooted at or below pact-plugin/).
-Its presence at the plugin root also puts pact-plugin/ itself on sys.path
-(pytest prepends a conftest's basedir), which is what the telegram test
-family's plugin-root inserts rely on.
+The plugin root itself is inserted explicitly below (lead-ruled: deliberate
+source, not reliance on pytest's conftest-basedir mechanics); the telegram
+test family's `from telegram.X import ...` imports resolve through it.
 
 NO-IMPORT CHARTER: this file path-INSERTS only. Never import from a scripts
 dir at conftest scope — a missing optional dependency there becomes a total
@@ -26,3 +26,8 @@ for _scripts_dir in sorted(Path(__file__).parent.glob("skills/*/scripts")):
     _entry = str(_scripts_dir)
     if _entry not in sys.path:
         sys.path.insert(0, _entry)
+
+# The plugin root itself, for the telegram test family's package imports.
+_plugin_root = str(Path(__file__).parent)
+if _plugin_root not in sys.path:
+    sys.path.insert(0, _plugin_root)

--- a/pact-plugin/conftest.py
+++ b/pact-plugin/conftest.py
@@ -1,0 +1,28 @@
+"""Plugin-root conftest for the PACT plugin suite.
+
+Location: pact-plugin/conftest.py
+
+Summary: Owns skills-adjacent coverage ONLY. Pin test files living beside
+skill artifacts (skills/<skill>/test_*.py) sit outside tests/conftest.py's
+subtree, so this conftest guarantees every skills/*/scripts dir is importable
+for them. tests/conftest.py owns the full path block for tests/; the
+membership guard keeps the overlap a no-op when both conftests load in one
+run.
+
+Used by: pytest (loaded for every run rooted at or below pact-plugin/).
+Its presence at the plugin root also puts pact-plugin/ itself on sys.path
+(pytest prepends a conftest's basedir), which is what the telegram test
+family's plugin-root inserts rely on.
+
+NO-IMPORT CHARTER: this file path-INSERTS only. Never import from a scripts
+dir at conftest scope — a missing optional dependency there becomes a total
+suite collection failure.
+"""
+
+import sys
+from pathlib import Path
+
+for _scripts_dir in sorted(Path(__file__).parent.glob("skills/*/scripts")):
+    _entry = str(_scripts_dir)
+    if _entry not in sys.path:
+        sys.path.insert(0, _entry)

--- a/pact-plugin/tests/conftest.py
+++ b/pact-plugin/tests/conftest.py
@@ -26,8 +26,10 @@ sys.path.insert(0, str(Path(__file__).parent))
 # Add hooks directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
-# Add pact-memory scripts to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
+# Add pact-memory scripts to path (normalized: package-route imports build
+# module __file__ from this entry, and instruments that string-compare
+# __file__/co_filename against a resolved path break on a literal '..')
+sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "pact-memory"))
 
 # Add the pact-memory scripts dir itself to path (bare-module imports)
 sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"))

--- a/pact-plugin/tests/conftest.py
+++ b/pact-plugin/tests/conftest.py
@@ -29,6 +29,15 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 # Add pact-memory scripts to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
 
+# Add the pact-memory scripts dir itself to path (bare-module imports)
+sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"))
+
+# Add pact-coding-standards scripts to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "pact-coding-standards" / "scripts"))
+
+# Add plugin-level scripts to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
 
 # Name of the environment variable that relocates the PACT memory store.
 #

--- a/pact-plugin/tests/conftest.py
+++ b/pact-plugin/tests/conftest.py
@@ -2,7 +2,8 @@
 Shared test fixtures and infrastructure.
 
 This conftest.py is intentionally thin. It owns:
-- sys.path setup for tests/, hooks/, skills/pact-memory/
+- sys.path setup for tests/, hooks/, skills/pact-memory/ (and its scripts/
+  dir), skills/pact-coding-standards/scripts/, and plugin-level scripts/
 - the genuinely cross-cutting ``pact_context`` fixture
 
 Concern-specific helpers live in tests/fixtures/<concern>.py and are
@@ -30,6 +31,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 # module __file__ from this entry, and instruments that string-compare
 # __file__/co_filename against a resolved path break on a literal '..')
 sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "pact-memory"))
+
+# New-skill scripts coverage is owned by the plugin-root conftest's
+# skills/*/scripts glob; the two explicit skill-scripts lines below remain as belt.
 
 # Add the pact-memory scripts dir itself to path (bare-module imports)
 sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"))

--- a/pact-plugin/tests/fixtures/pin_negative_path_mutations.py
+++ b/pact-plugin/tests/fixtures/pin_negative_path_mutations.py
@@ -1,0 +1,22 @@
+"""Negative fixture for tests/test_path_setup_pin.py — one sys.path mutation
+per matcher leg (insert / append / extend / slice-assign / augmented assign).
+
+This file is DELIBERATE VIOLATION EVIDENCE, not path setup:
+- It is exempt from the pin's population arms via _NEGATIVE_FIXTURE, and the
+  pin's self-test asserts the matcher flags each mutation line below exactly.
+- Editing this file shifts line numbers and FAILS the self-test — that is the
+  point: update the expected lines in the same commit as any edit here.
+- pytest never collects it (no test_ prefix) and nothing imports it; all
+  paths are nonexistent so even an accidental import only adds dead entries.
+
+The expected line numbers live in
+test_path_setup_pin.py::test_negative_fixture_flags_every_matcher_leg.
+"""
+
+import sys
+
+sys.path.insert(0, "/nonexistent-pin-fixture-insert")
+sys.path.append("/nonexistent-pin-fixture-append")
+sys.path.extend(["/nonexistent-pin-fixture-extend"])
+sys.path[0:0] = ["/nonexistent-pin-fixture-slice"]
+sys.path += ["/nonexistent-pin-fixture-augassign"]

--- a/pact-plugin/tests/import_identity_baseline.json
+++ b/pact-plugin/tests/import_identity_baseline.json
@@ -1,1345 +1,3456 @@
 {
   "map": {
-    "skills/pact-agent-teams/test_skill_loading_agent_teams.py": {},
-    "skills/pact-handoff-harvest/test_skill_loading_harvest.py": {},
+    "skills/pact-agent-teams/test_skill_loading_agent_teams.py": {
+      "pathlib.Path": null
+    },
+    "skills/pact-handoff-harvest/test_skill_loading_harvest.py": {
+      "pathlib.Path": null
+    },
     "tests/test_628_coverage.py": {
+      "pathlib.Path": null,
       "peer_inject": "hooks/peer_inject.py",
-      "shared": "hooks/shared/__init__.py"
+      "peer_inject._TEACHBACK_REMINDER": null,
+      "shared": "hooks/shared/__init__.py",
+      "shared.BOOTSTRAP_MARKER_NAME": null
     },
     "tests/test_agent_handoff_emitter_integration.py": {
+      "__future__.annotations": null,
       "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
-      "shared.session_journal": "hooks/shared/session_journal.py"
+      "pathlib.Path": null,
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_journal.read_events": null
     },
     "tests/test_agent_handoff_marker.py": {
-      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py"
+      "pathlib.Path": null,
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.agent_handoff_marker.already_emitted": null,
+      "shared.agent_handoff_marker.handoff_already_emitted": null,
+      "shared.agent_handoff_marker.is_signal_task": null,
+      "shared.agent_handoff_marker.occupant_hash": null,
+      "shared.agent_handoff_marker.sanitize_path_component": null,
+      "shared.agent_handoff_marker.unclaim": null
     },
     "tests/test_agent_handoff_ts_caller_property.py": {
-      "shared.session_journal": "hooks/shared/session_journal.py"
+      "pathlib.Path": null,
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_journal.make_event": null
     },
-    "tests/test_agent_memory_cap_single_source.py": {},
-    "tests/test_agent_memory_leaf_construction.py": {},
-    "tests/test_agent_state_model.py": {},
+    "tests/test_agent_memory_cap_single_source.py": {
+      "collections.namedtuple": null,
+      "functools.lru_cache": null,
+      "pathlib.Path": null
+    },
+    "tests/test_agent_memory_leaf_construction.py": {
+      "pathlib.Path": null
+    },
+    "tests/test_agent_state_model.py": {
+      "pathlib.Path": null
+    },
     "tests/test_agents_structure.py": {
-      "helpers": "tests/helpers.py"
+      "helpers": "tests/helpers.py",
+      "helpers.frontmatter_block": null,
+      "helpers.parse_frontmatter": null,
+      "pathlib.Path": null
     },
     "tests/test_archive_pin.py": {
       "archive_pin": "scripts/archive_pin.py",
       "helpers": "tests/helpers.py",
+      "helpers.make_claude_md_with_pins": null,
+      "helpers.make_pin_entry": null,
+      "pathlib.Path": null,
       "pin_caps": "hooks/pin_caps.py",
       "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
+      "scripts.config.MEMORY_DIR_ENV": null,
+      "scripts.config.STORE_ORIGIN_HOME": null,
+      "scripts.config.resolve_db_path": null,
+      "scripts.config.store_path_origin": null,
       "staleness": "hooks/staleness.py"
     },
     "tests/test_archive_pin_emit.py": {
       "archive_pin": "scripts/archive_pin.py",
       "helpers": "tests/helpers.py",
+      "helpers.make_claude_md_with_pins": null,
+      "helpers.make_pin_entry": null,
+      "pathlib.Path": null,
       "staleness": "hooks/staleness.py"
     },
-    "tests/test_archive_pin_raise_census.py": {},
+    "tests/test_archive_pin_raise_census.py": {
+      "pathlib.Path": null
+    },
     "tests/test_archive_pin_resolver.py": {
-      "archive_pin": "scripts/archive_pin.py"
+      "archive_pin": "scripts/archive_pin.py",
+      "pathlib.Path": null
     },
     "tests/test_artifact_paths_durability.py": {
+      "__future__.annotations": null,
+      "datetime.datetime": null,
+      "pathlib.Path": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
       "shared.paths": "hooks/shared/paths.py",
       "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_journal.append_event": null,
+      "shared.session_journal.make_event": null,
+      "shared.session_journal.read_events": null,
+      "shared.session_journal.read_events_from": null,
+      "shared.session_journal.read_last_event_from": null,
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
-    "tests/test_audit_protocol.py": {},
+    "tests/test_audit_protocol.py": {
+      "pathlib.Path": null,
+      "pathlib.PurePosixPath": null
+    },
     "tests/test_audit_summary_overwrite_906.py": {
+      "pathlib.Path": null,
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_backlog.py": {
+      "datetime.datetime": null,
+      "datetime.timedelta": null,
+      "datetime.timezone": null,
+      "pathlib.Path": null,
       "session_init": "hooks/session_init.py",
-      "shared": "hooks/shared/__init__.py"
-    },
-    "tests/test_bin_pact_launcher.py": {},
-    "tests/test_bootstrap_gate.py": {
-      "bootstrap_gate": "hooks/bootstrap_gate.py",
       "shared": "hooks/shared/__init__.py",
+      "shared.backlog": "hooks/shared/backlog.py",
+      "shared.backlog_store": "hooks/shared/backlog_store.py",
+      "unittest.mock.patch": null
+    },
+    "tests/test_bin_pact_launcher.py": {
+      "pathlib.Path": null
+    },
+    "tests/test_bootstrap_gate.py": {
+      "__future__.annotations": null,
+      "bootstrap_gate": "hooks/bootstrap_gate.py",
+      "bootstrap_gate._BLOCKED_TOOLS": null,
+      "bootstrap_gate._DEGRADED_ASK_TOOLS": null,
+      "bootstrap_gate._DENY_REASON": null,
+      "bootstrap_gate._ERROR_TEXT_MAX": null,
+      "bootstrap_gate._READ_ONLY_TOOLS": null,
+      "bootstrap_gate._SUPPRESS_OUTPUT": null,
+      "bootstrap_gate._check_tool_allowed": null,
+      "bootstrap_gate._emit_degraded_warning": null,
+      "bootstrap_gate._emit_load_failure_deny": null,
+      "bootstrap_gate._is_canonical_secretary_spawn": null,
+      "bootstrap_gate._secretary_in_members": null,
+      "bootstrap_gate.is_marker_set": null,
+      "bootstrap_gate.main": null,
+      "pathlib.Path": null,
+      "shared": "hooks/shared/__init__.py",
+      "shared.BOOTSTRAP_MARKER_NAME": null,
       "shared.marker_schema": "hooks/shared/marker_schema.py",
-      "shared.pact_context": "hooks/shared/pact_context.py"
+      "shared.marker_schema.MARKER_SCHEMA_VERSION": null,
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "unittest.mock.patch": null
     },
     "tests/test_bootstrap_marker_writer.py": {
       "bootstrap_gate": "hooks/bootstrap_gate.py",
+      "bootstrap_gate.is_marker_set": null,
       "bootstrap_marker_writer": "hooks/bootstrap_marker_writer.py",
+      "bootstrap_marker_writer._debug_log_if_derived_team_dir_missing": null,
+      "bootstrap_marker_writer._emit_load_failure_advisory": null,
+      "bootstrap_marker_writer._read_plugin_version": null,
+      "bootstrap_marker_writer._resolve_event_name": null,
+      "bootstrap_marker_writer._suppress_output": null,
+      "bootstrap_marker_writer._team_has_secretary": null,
+      "bootstrap_marker_writer._try_write_marker": null,
+      "bootstrap_marker_writer._write_marker": null,
+      "bootstrap_marker_writer.main": null,
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
+      "shared.BOOTSTRAP_MARKER_NAME": null,
       "shared.marker_schema": "hooks/shared/marker_schema.py",
-      "shared.pact_context": "hooks/shared/pact_context.py"
+      "shared.marker_schema.MARKER_SCHEMA_VERSION": null,
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "unittest.mock.patch": null
     },
     "tests/test_bootstrap_prompt_gate.py": {
       "bootstrap_prompt_gate": "hooks/bootstrap_prompt_gate.py",
+      "bootstrap_prompt_gate._SUPPRESS_OUTPUT": null,
+      "bootstrap_prompt_gate._check_bootstrap_needed": null,
+      "bootstrap_prompt_gate._detect_stale_session_block": null,
+      "bootstrap_prompt_gate._emit_load_failure_advisory": null,
+      "bootstrap_prompt_gate.main": null,
       "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "fixtures.role_frames.captured_teammate_sessionstart": null,
+      "fixtures.role_frames.teammate_frame": null,
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
+      "shared.BOOTSTRAP_MARKER_NAME": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
-      "shared.pact_context": "hooks/shared/pact_context.py"
+      "shared.claude_md_manager.resolve_project_claude_md_path": null,
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "unittest.mock.patch": null
     },
     "tests/test_calibration_schema.py": {
-      "shared.variety_scorer": "hooks/shared/variety_scorer.py"
+      "pathlib.Path": null,
+      "shared.variety_scorer": "hooks/shared/variety_scorer.py",
+      "shared.variety_scorer.MAX_SCORE": null,
+      "shared.variety_scorer.MIN_SCORE": null
     },
     "tests/test_caller_commits_before_embedding.py": {
+      "__future__.annotations": null,
       "helpers": "tests/helpers.py",
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py"
+      "helpers.create_test_schema": null,
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api.PACTMemory": null,
+      "unittest.mock.patch": null
     },
     "tests/test_caller_path_is_not_created.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.database": "tests/../skills/pact-memory/scripts/database.py"
+      "scripts.cli": "tests/../skills/pact-memory/scripts/cli.py",
+      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database.get_connection": null
     },
-    "tests/test_canary_checklist_count.py": {},
+    "tests/test_canary_checklist_count.py": {
+      "pathlib.Path": null
+    },
     "tests/test_canonical_journal_frame_gate.py": {
+      "pathlib.Path": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_canonical_json_contract.py": {
-      "shared.canonical_json": "hooks/shared/canonical_json.py"
+      "shared.canonical_json": "hooks/shared/canonical_json.py",
+      "shared.canonical_json.canonical_bytes": null
     },
     "tests/test_canonical_json_identity_certification.py": {
+      "pathlib.Path": null,
       "shared.canonical_json": "hooks/shared/canonical_json.py"
     },
     "tests/test_catchup_reason_is_read.py": {
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py"
+      "__future__.annotations": null,
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
+      "scripts.embedding_catchup": "tests/../skills/pact-memory/scripts/embedding_catchup.py",
+      "unittest.mock.patch": null
     },
     "tests/test_check_pin_caps.py": {
       "check_pin_caps": "scripts/check_pin_caps.py",
+      "datetime.datetime": null,
+      "datetime.timedelta": null,
+      "datetime.timezone": null,
       "helpers": "tests/helpers.py",
+      "helpers.make_claude_md_with_pins": null,
+      "helpers.make_pin_entry": null,
+      "pathlib.Path": null,
       "pin_caps": "hooks/pin_caps.py",
-      "staleness": "hooks/staleness.py"
+      "staleness": "hooks/staleness.py",
+      "unittest.mock.patch": null
     },
-    "tests/test_check_unused_imports.py": {},
-    "tests/test_ci_collection_scope.py": {},
+    "tests/test_check_unused_imports.py": {
+      "pathlib.Path": null
+    },
+    "tests/test_ci_collection_scope.py": {
+      "pathlib.Path": null
+    },
     "tests/test_ci_env_truthiness.py": {
-      "memory_init": "tests/../skills/pact-memory/scripts/memory_init.py"
+      "memory_init": "tests/../skills/pact-memory/scripts/memory_init.py",
+      "memory_init._ci_is_declared": null,
+      "memory_init.check_and_install_dependencies": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_claude_md_manager.py": {
+      "__future__.annotations": null,
+      "contextlib.contextmanager": null,
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
-      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py"
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.MANAGED_END_MARKER": null,
+      "shared.claude_md_manager.MANAGED_START_MARKER": null,
+      "shared.claude_md_manager.MANAGED_TITLE": null,
+      "shared.claude_md_manager.MEMORY_END_MARKER": null,
+      "shared.claude_md_manager.MEMORY_START_MARKER": null,
+      "shared.claude_md_manager._build_migrated_content": null,
+      "shared.claude_md_manager._strip_legacy_lines": null,
+      "shared.claude_md_manager.ensure_dot_claude_parent": null,
+      "shared.claude_md_manager.ensure_project_memory_md": null,
+      "shared.claude_md_manager.extract_managed_region": null,
+      "shared.claude_md_manager.file_lock": null,
+      "shared.claude_md_manager.migrate_to_managed_structure": null,
+      "shared.claude_md_manager.resolve_project_claude_md_path": null,
+      "shared.claude_md_manager.strip_orphan_kernel_block": null,
+      "unittest.mock.patch": null
     },
     "tests/test_claude_md_resolver_parity.py": {
+      "pathlib.Path": null,
       "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api.PACTMemory": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.resolve_project_claude_md_path": null,
       "staleness": "hooks/staleness.py",
-      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+      "staleness.get_project_claude_md_path": null,
+      "typing.Optional": null,
+      "working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "working_memory._get_claude_md_path": null,
+      "working_memory._resolve_display_claude_md_path": null
     },
-    "tests/test_claudemd_write_prohibition_guard.py": {},
-    "tests/test_cli_output_purity.py": {},
+    "tests/test_claudemd_write_prohibition_guard.py": {
+      "pathlib.Path": null
+    },
+    "tests/test_cli_output_purity.py": {
+      "pathlib.Path": null
+    },
     "tests/test_commands_structure.py": {
       "dispatch_gate": "hooks/dispatch_gate.py",
       "helpers": "tests/helpers.py",
+      "helpers.parse_frontmatter": null,
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
-      "shared.intentional_wait": "hooks/shared/intentional_wait.py"
+      "shared.backlog": "hooks/shared/backlog.py",
+      "shared.intentional_wait": "hooks/shared/intentional_wait.py",
+      "shared.intentional_wait.KNOWN_RESOLVERS": null
     },
-    "tests/test_compact_summary_archive_contract.py": {},
+    "tests/test_compact_summary_archive_contract.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null
+    },
     "tests/test_compact_summary_session_scope.py": {
+      "pathlib.Path": null,
       "postcompact_archive": "hooks/postcompact_archive.py",
+      "postcompact_archive.main": null,
       "session_init": "hooks/session_init.py",
+      "session_init._archive_own_dir_stale_summary": null,
+      "session_init._archive_stale_compact_summary": null,
+      "session_init._resume_own_summary_clause": null,
       "shared.constants": "hooks/shared/constants.py",
+      "shared.constants.COMPACT_SUMMARY_NAME": null,
+      "shared.constants.get_compact_summary_path": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
-      "shared.session_journal": "hooks/shared/session_journal.py"
+      "shared.pact_context.resolve_compact_summary_path": null,
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_journal.make_event": null,
+      "unittest.mock.patch": null
     },
-    "tests/test_concurrent_auditor_wake.py": {},
+    "tests/test_concurrent_auditor_wake.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
+      "typing.Iterator": null,
+      "typing.List": null,
+      "typing.Set": null,
+      "typing.Tuple": null
+    },
     "tests/test_config_dir_comprehensive.py": {
+      "pathlib.Path": null,
       "session_init": "hooks/session_init.py",
+      "session_init._validate_under_pact_sessions": null,
+      "session_init.check_additional_directories": null,
       "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py",
+      "shared.dispatch_helpers.has_task_assigned": null,
       "shared.plugin_manifest": "hooks/shared/plugin_manifest.py",
+      "shared.plugin_manifest._resolve_plugin_root": null,
       "shared.session_registry": "hooks/shared/session_registry.py"
     },
     "tests/test_config_dir_dispatch_integration.py": {
-      "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py"
+      "pathlib.Path": null,
+      "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py",
+      "shared.dispatch_helpers.has_task_assigned": null
     },
-    "tests/test_config_dir_migration_completeness.py": {},
+    "tests/test_config_dir_migration_completeness.py": {
+      "pathlib.Path": null
+    },
     "tests/test_config_injection_both_modes.py": {
       "fixtures.role_frames": "tests/fixtures/role_frames.py",
-      "session_init": "hooks/session_init.py"
+      "fixtures.role_frames.captured_lead_sessionstart_qualified": null,
+      "fixtures.role_frames.captured_lead_sessionstart_unqualified": null,
+      "fixtures.role_frames.captured_plain_sessionstart": null,
+      "fixtures.role_frames.captured_teammate_sessionstart": null,
+      "fixtures.role_frames.lead_frame_qualified": null,
+      "fixtures.role_frames.teammate_frame": null,
+      "pathlib.Path": null,
+      "session_init": "hooks/session_init.py",
+      "unittest.mock.patch": null
     },
     "tests/test_conftest_config_root_isolation.py": {
       "shared.pact_context": "hooks/shared/pact_context.py",
-      "shared.paths": "hooks/shared/paths.py"
+      "shared.paths": "hooks/shared/paths.py",
+      "shared.paths.get_claude_config_dir": null
     },
     "tests/test_connection_transaction_mode.py": {
-      "scripts.database": "tests/../skills/pact-memory/scripts/database.py"
+      "__future__.annotations": null,
+      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database.get_connection": null,
+      "scripts.database.sqlite3": null
     },
     "tests/test_containment_certification.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "session_init": "hooks/session_init.py",
+      "session_init.check_pinned_staleness": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.migrate_to_managed_structure": null,
       "shared.session_resume": "hooks/shared/session_resume.py",
+      "shared.session_resume.update_session_info": null,
+      "unittest.mock.patch": null,
       "working_memory": "skills/pact-memory/scripts/working_memory.py"
     },
     "tests/test_containment_guard.py": {
+      "pathlib.Path": null,
       "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
       "session_init": "hooks/session_init.py",
+      "session_init.check_pinned_staleness": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.ContainmentError": null,
+      "shared.claude_md_manager._atomic_write_text": null,
+      "shared.claude_md_manager.ensure_project_memory_md": null,
+      "shared.claude_md_manager.migrate_to_managed_structure": null,
+      "shared.claude_md_manager.strip_orphan_kernel_block": null,
       "shared.paths": "hooks/shared/paths.py",
-      "shared.session_resume": "hooks/shared/session_resume.py"
+      "shared.paths.get_claude_config_dir": null,
+      "shared.session_resume": "hooks/shared/session_resume.py",
+      "shared.session_resume.update_session_info": null,
+      "unittest.mock.patch": null
     },
     "tests/test_count_word_guard.py": {
-      "hooks.shared.variety_divergence": "hooks/shared/variety_divergence.py"
+      "hooks.shared.variety_divergence": "hooks/shared/variety_divergence.py",
+      "hooks.shared.variety_divergence.extract_final_dispatch_coverage": null,
+      "pathlib.Path": null
     },
     "tests/test_create_ingress_guard.py": {
+      "__future__.annotations": null,
       "helpers": "tests/helpers.py",
+      "helpers.create_test_schema": null,
       "memory_repair": "scripts/memory_repair/__init__.py",
-      "scripts.database": "tests/../skills/pact-memory/scripts/database.py"
+      "memory_repair.shred_detect": "scripts/memory_repair/shred_detect.py",
+      "pathlib.Path": null,
+      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database.DICT_LIST_FIELDS": null,
+      "scripts.database.LIST_FIELDS": null,
+      "scripts.database.create_memory": null,
+      "scripts.database.get_memory": null,
+      "scripts.database.update_memory": null,
+      "unittest.mock.patch": null
     },
-    "tests/test_cross_references.py": {},
+    "tests/test_cross_references.py": {
+      "pathlib.Path": null
+    },
     "tests/test_cybernetic_cross_references.py": {
-      "shared.variety_scorer": "hooks/shared/variety_scorer.py"
+      "pathlib.Path": null,
+      "shared.variety_scorer": "hooks/shared/variety_scorer.py",
+      "shared.variety_scorer.LEARNING_II_MIN_MATCHES": null
     },
     "tests/test_declared_anchor_contract.py": {
+      "pathlib.Path": null,
       "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py"
+      "scripts.cli": "tests/../skills/pact-memory/scripts/cli.py",
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory.ContainmentError": null,
+      "scripts.working_memory.SyncResult": null,
+      "scripts.working_memory._atomic_write_text": null,
+      "scripts.working_memory.sync_to_claude_md": null,
+      "types.SimpleNamespace": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_dispatch_emission_prose.py": {
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
-      "shared.constants": "hooks/shared/constants.py"
+      "shared.constants": "hooks/shared/constants.py",
+      "shared.constants.VARIETY_ASSESSED_DISPATCH_SCOPE": null,
+      "shared.session_journal": "hooks/shared/session_journal.py"
     },
     "tests/test_dispatch_gate.py": {
       "dispatch_gate": "hooks/dispatch_gate.py",
+      "dispatch_gate.main": null,
+      "pathlib.Path": null,
       "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py",
+      "shared.dispatch_helpers._specialist_registry": null,
+      "shared.dispatch_helpers.has_task_assigned": null,
       "shared.intentional_wait": "hooks/shared/intentional_wait.py",
+      "shared.intentional_wait.SELF_COMPLETE_EXEMPT_AGENT_TYPES": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
       "shared.session_journal": "hooks/shared/session_journal.py",
-      "shared.task_utils": "hooks/shared/task_utils.py"
+      "shared.task_utils": "hooks/shared/task_utils.py",
+      "shared.task_utils.read_task_json": null,
+      "unittest.mock.patch": null
     },
     "tests/test_dispatch_gate_cause_enumeration.py": {
       "dispatch_gate": "hooks/dispatch_gate.py",
+      "dispatch_gate._CAUSE_ENUMERATION": null,
+      "dispatch_gate._MISSING_DENY_REASON": null,
+      "dispatch_gate._STALE_REALIGN_HINT": null,
+      "dispatch_gate._compose_deny_diagnosis": null,
+      "pathlib.Path": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
-      "test_dispatch_gate": "tests/test_dispatch_gate.py"
+      "test_dispatch_gate": "tests/test_dispatch_gate.py",
+      "test_dispatch_gate._NAME": null,
+      "test_dispatch_gate._TEAM": null,
+      "test_dispatch_gate._capture_journal": null,
+      "test_dispatch_gate._full_setup": null,
+      "test_dispatch_gate._make_input": null,
+      "test_dispatch_gate._run_main": null
     },
     "tests/test_dispatch_gate_integration.py": {
-      "dispatch_gate": "hooks/dispatch_gate.py"
+      "__future__.annotations": null,
+      "dispatch_gate": "hooks/dispatch_gate.py",
+      "pathlib.Path": null
     },
     "tests/test_dispatch_gate_smoke.py": {
       "dispatch_gate": "hooks/dispatch_gate.py",
+      "dispatch_gate.main": null,
+      "pathlib.Path": null,
       "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py",
       "shared.pact_context": "hooks/shared/pact_context.py",
-      "shared.session_journal": "hooks/shared/session_journal.py"
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "unittest.mock.patch": null
     },
     "tests/test_dispatch_gate_stale_diagnosis.py": {
       "dispatch_gate": "hooks/dispatch_gate.py",
+      "dispatch_gate._STALE_REALIGN_HINT": null,
+      "pathlib.Path": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
-      "test_dispatch_gate": "tests/test_dispatch_gate.py"
+      "test_dispatch_gate": "tests/test_dispatch_gate.py",
+      "test_dispatch_gate._TEAM": null,
+      "test_dispatch_gate._full_setup": null,
+      "test_dispatch_gate._make_input": null,
+      "test_dispatch_gate._run_main": null,
+      "test_dispatch_gate._seed_team": null
     },
     "tests/test_dispatch_helpers.py": {
-      "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py"
+      "pathlib.Path": null,
+      "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py",
+      "shared.dispatch_helpers.is_owner_bearing_write": null,
+      "shared.dispatch_helpers.is_owner_wiring_shape": null,
+      "shared.dispatch_helpers.variety_stamp_as_of_write": null
     },
     "tests/test_dispatch_site_emit.py": {
+      "pathlib.Path": null,
       "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.agent_handoff_marker.already_emitted": null,
       "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py",
       "shared.pact_context": "hooks/shared/pact_context.py",
       "shared.session_journal": "hooks/shared/session_journal.py",
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
-    "tests/test_dispatch_variety_deny_honor_probe.py": {},
+    "tests/test_dispatch_variety_deny_honor_probe.py": {
+      "pathlib.Path": null
+    },
     "tests/test_dispatch_variety_teachback_ack_emit.py": {
+      "pathlib.Path": null,
       "shared.session_journal": "hooks/shared/session_journal.py",
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_dogfood_livelock_invariant.py": {
       "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
-      "fixtures.emitter": "tests/fixtures/emitter.py"
+      "agent_handoff_emitter.main": null,
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "fixtures.emitter.WRITABLE_TEST_JOURNAL": null,
+      "pathlib.Path": null,
+      "unittest.mock.patch": null
     },
-    "tests/test_dual_channel_acceptance_pinned.py": {},
+    "tests/test_dual_channel_acceptance_pinned.py": {
+      "pathlib.Path": null
+    },
     "tests/test_embedding_catchup.py": {
-      "embeddings": "skills/pact-memory/scripts/embeddings.py"
+      "embeddings": "skills/pact-memory/scripts/embeddings.py",
+      "embeddings.MIN_CATCHUP_RAM_MB": null,
+      "embeddings.generate_embedding": null,
+      "embeddings.generate_embedding_text": null,
+      "io.StringIO": null,
+      "pathlib.Path": null,
+      "types.ModuleType": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_embedding_status_contract.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py"
+      "scripts.cli": "tests/../skills/pact-memory/scripts/cli.py",
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api.PACTMemory": null,
+      "types.SimpleNamespace": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.call": null,
+      "unittest.mock.patch": null
     },
     "tests/test_embedding_status_wiring.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py"
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api.PACTMemory": null,
+      "unittest.mock.patch": null
     },
     "tests/test_embedding_window.py": {
-      "scripts.embeddings": "tests/../skills/pact-memory/scripts/embeddings.py"
+      "__future__.annotations": null,
+      "pathlib.Path": null,
+      "scripts.embeddings": "tests/../skills/pact-memory/scripts/embeddings.py",
+      "scripts.embeddings.EMBEDDING_MAX_TOKENS": null,
+      "scripts.embeddings.EmbeddingService": null,
+      "scripts.embeddings.MEASURED_MEDIAN_TOKENS": null
     },
     "tests/test_emit_skip_accounting.py": {
+      "pathlib.Path": null,
       "shared.session_journal": "hooks/shared/session_journal.py",
-      "shared.variety_divergence": "hooks/shared/variety_divergence.py"
+      "shared.session_journal.SKIP_CAUSE_RAISED": null,
+      "shared.session_journal.SKIP_CAUSE_RETURNED_FALSE": null,
+      "shared.session_journal.append_event_checked": null,
+      "shared.variety_divergence": "hooks/shared/variety_divergence.py",
+      "shared.variety_divergence.count_emit_skips": null
     },
     "tests/test_emitter_happy_and_gates.py": {
-      "fixtures.emitter": "tests/fixtures/emitter.py"
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "fixtures.emitter.VALID_HANDOFF": null,
+      "fixtures.emitter._run_main": null
     },
     "tests/test_emitter_idempotency.py": {
       "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
+      "agent_handoff_emitter.main": null,
       "fixtures.emitter": "tests/fixtures/emitter.py",
-      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py"
+      "fixtures.emitter.VALID_HANDOFF": null,
+      "fixtures.emitter.VALID_HANDOFF_CONTENT_KEY": null,
+      "fixtures.emitter.WRITABLE_TEST_JOURNAL": null,
+      "fixtures.emitter._run_main": null,
+      "pathlib.Path": null,
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.agent_handoff_marker.already_emitted": null,
+      "shared.agent_handoff_marker.occupant_hash": null,
+      "unittest.mock.patch": null
     },
     "tests/test_emitter_path_sanitization.py": {
       "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
       "fixtures.emitter": "tests/fixtures/emitter.py",
+      "fixtures.emitter.VALID_HANDOFF": null,
+      "fixtures.emitter._run_main": null,
+      "pathlib.Path": null,
       "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
-      "shared.pact_context": "hooks/shared/pact_context.py"
+      "shared.agent_handoff_marker.handoff_already_emitted": null,
+      "shared.agent_handoff_marker.handoff_content_key": null,
+      "shared.agent_handoff_marker.occupant_hash": null,
+      "shared.agent_handoff_marker.sanitize_path_component": null,
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.pact_context.generate_team_name": null,
+      "unittest.mock.patch": null
     },
     "tests/test_emitter_race_regression.py": {
       "fixtures.emitter": "tests/fixtures/emitter.py",
-      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py"
+      "fixtures.emitter.VALID_HANDOFF": null,
+      "fixtures.emitter.VALID_HANDOFF_CONTENT_KEY": null,
+      "fixtures.emitter._run_main": null,
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.agent_handoff_marker.occupant_hash": null
     },
     "tests/test_emitter_real_disk.py": {
       "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
+      "agent_handoff_emitter.main": null,
       "fixtures.emitter": "tests/fixtures/emitter.py",
-      "shared": "hooks/shared/__init__.py"
+      "fixtures.emitter.VALID_HANDOFF": null,
+      "fixtures.emitter.WRITABLE_TEST_JOURNAL": null,
+      "fixtures.emitter._run_main": null,
+      "shared": "hooks/shared/__init__.py",
+      "shared.task_utils": "hooks/shared/task_utils.py",
+      "unittest.mock.patch": null
     },
     "tests/test_emitter_resolution.py": {
-      "fixtures.emitter": "tests/fixtures/emitter.py"
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "fixtures.emitter.VALID_HANDOFF": null,
+      "fixtures.emitter._run_main": null
     },
     "tests/test_emitter_robustness.py": {
       "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
-      "fixtures.emitter": "tests/fixtures/emitter.py"
+      "agent_handoff_emitter.main": null,
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "fixtures.emitter.VALID_HANDOFF": null,
+      "fixtures.emitter._run_main": null,
+      "unittest.mock.patch": null
     },
     "tests/test_environment_drift.py": {
-      "file_tracker": "hooks/file_tracker.py"
+      "file_tracker": "hooks/file_tracker.py",
+      "file_tracker.get_environment_delta": null,
+      "pathlib.Path": null
     },
-    "tests/test_environment_drift_convention.py": {},
+    "tests/test_environment_drift_convention.py": {
+      "pathlib.Path": null
+    },
     "tests/test_error_output.py": {
       "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
+      "agent_handoff_emitter.main": null,
       "file_tracker": "hooks/file_tracker.py",
+      "file_tracker.main": null,
       "git_commit_check": "hooks/git_commit_check.py",
+      "git_commit_check.main": null,
       "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_post.main": null,
+      "pathlib.Path": null,
       "peer_inject": "hooks/peer_inject.py",
+      "peer_inject.main": null,
       "postcompact_archive": "hooks/postcompact_archive.py",
+      "postcompact_archive.main": null,
       "precompact_state_reminder": "hooks/precompact_state_reminder.py",
+      "precompact_state_reminder.main": null,
       "session_end": "hooks/session_end.py",
+      "session_end.main": null,
       "session_init": "hooks/session_init.py",
+      "session_init.main": null,
       "shared": "hooks/shared/__init__.py",
       "shared.error_output": "hooks/shared/error_output.py",
+      "shared.error_output._ERROR_MAX_CHARS": null,
+      "shared.error_output._HOOK_NAME_MAX_CHARS": null,
+      "shared.error_output.hook_error_json": null,
+      "shared.hook_error_json": null,
       "teammate_idle": "hooks/teammate_idle.py",
+      "teammate_idle.main": null,
       "track_files": "hooks/track_files.py",
-      "validate_handoff": "hooks/validate_handoff.py"
+      "track_files.main": null,
+      "unittest.mock.patch": null,
+      "validate_handoff": "hooks/validate_handoff.py",
+      "validate_handoff.main": null
     },
     "tests/test_exemption_policy_tripwires.py": {
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
       "shared.intentional_wait": "hooks/shared/intentional_wait.py",
-      "test_harvest_trigger_coherence": "tests/test_harvest_trigger_coherence.py"
+      "shared.intentional_wait.SELF_COMPLETE_EXEMPT_AGENT_TYPES": null,
+      "shared.intentional_wait.TEACHBACK_EXEMPT_AGENT_TYPES": null,
+      "shared.intentional_wait.is_self_complete_exempt": null,
+      "shared.intentional_wait.is_teachback_exempt": null,
+      "test_harvest_trigger_coherence": "tests/test_harvest_trigger_coherence.py",
+      "test_harvest_trigger_coherence._claimed_boundaries": null
     },
     "tests/test_failure_cause_convention.py": {
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
       "shared.failure_cause": "hooks/shared/failure_cause.py",
-      "shared.session_resume": "hooks/shared/session_resume.py"
+      "shared.failure_cause.failure_cause": null,
+      "shared.session_resume": "hooks/shared/session_resume.py",
+      "shared.session_resume.update_session_info": null,
+      "shared.symlinks": "hooks/shared/symlinks.py",
+      "unittest.mock.patch": null
     },
     "tests/test_failure_log.py": {
+      "contextlib.contextmanager": null,
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
-      "shared.failure_log": "hooks/shared/failure_log.py"
+      "shared.error_output": "hooks/shared/error_output.py",
+      "shared.failure_log": "hooks/shared/failure_log.py",
+      "shared.failure_log.MAX_ENTRIES": null,
+      "shared.failure_log.append_failure": null,
+      "shared.failure_log.read_failures": null
     },
     "tests/test_file_permissions.py": {
+      "pathlib.Path": null,
       "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
-      "scripts.setup_memory": "tests/../skills/pact-memory/scripts/setup_memory.py"
+      "scripts.database.get_connection": null,
+      "scripts.database.get_db_path": null,
+      "scripts.setup_memory": "tests/../skills/pact-memory/scripts/setup_memory.py",
+      "scripts.setup_memory.ensure_directories": null,
+      "unittest.mock.patch": null
     },
     "tests/test_file_tracker.py": {
-      "file_tracker": "hooks/file_tracker.py"
+      "file_tracker": "hooks/file_tracker.py",
+      "file_tracker._normalize_path": null,
+      "file_tracker.check_conflict": null,
+      "file_tracker.main": null,
+      "file_tracker.track_edit": null,
+      "pathlib.Path": null,
+      "unittest.mock.patch": null
     },
     "tests/test_file_tracker_composite_key_edges.py": {
-      "file_tracker": "hooks/file_tracker.py"
+      "file_tracker": "hooks/file_tracker.py",
+      "file_tracker.check_conflict": null,
+      "file_tracker.track_edit": null
     },
-    "tests/test_first_observable_write_misfire_invariant.py": {},
+    "tests/test_first_observable_write_misfire_invariant.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null
+    },
     "tests/test_gate_crashpath_hardening.py": {
       "bootstrap_gate": "hooks/bootstrap_gate.py",
+      "pathlib.Path": null,
       "shared.session_journal": "hooks/shared/session_journal.py",
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py",
-      "tests.test_bootstrap_gate": "tests/test_bootstrap_gate.py"
+      "tests.test_bootstrap_gate": "tests/test_bootstrap_gate.py",
+      "tests.test_bootstrap_gate._make_input": null,
+      "tests.test_bootstrap_gate._setup_pact_session": null
     },
-    "tests/test_gate_invalid_mode_resolution.py": {},
+    "tests/test_gate_invalid_mode_resolution.py": {
+      "pathlib.Path": null
+    },
     "tests/test_gh_helpers.py": {
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
-      "shared.gh_helpers": "hooks/shared/gh_helpers.py"
+      "shared.gh_helpers": "hooks/shared/gh_helpers.py",
+      "shared.gh_helpers.check_pr_state": null,
+      "shared.gh_helpers.run_gh": null,
+      "shared.session_resume": "hooks/shared/session_resume.py",
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_git_commit_check.py": {
-      "git_commit_check": "hooks/git_commit_check.py"
+      "git_commit_check": "hooks/git_commit_check.py",
+      "git_commit_check.check_direct_api_calls": null,
+      "git_commit_check.check_env_file_in_gitignore": null,
+      "git_commit_check.check_frontend_credentials": null,
+      "git_commit_check.check_hardcoded_secrets": null,
+      "git_commit_check.check_security": null,
+      "git_commit_check.get_staged_file_content": null,
+      "git_commit_check.get_staged_files": null,
+      "git_commit_check.main": null,
+      "pathlib.Path": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_git_helpers.py": {
-      "shared.git_helpers": "hooks/shared/git_helpers.py"
+      "__future__.annotations": null,
+      "shared.git_helpers": "hooks/shared/git_helpers.py",
+      "shared.git_helpers.run_git": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_handoff_917_captured_regression.py": {
       "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
       "fixtures.emitter": "tests/fixtures/emitter.py",
+      "fixtures.emitter.VALID_HANDOFF": null,
+      "fixtures.emitter.VALID_HANDOFF_CONTENT_KEY": null,
       "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "fixtures.role_frames.captured_lead_posttooluse_taskupdate_completed": null,
+      "fixtures.role_frames.captured_lead_taskcompleted": null,
+      "fixtures.role_frames.captured_teammate_taskcompleted": null,
+      "pathlib.Path": null,
       "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.agent_handoff_marker.occupant_hash": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.pact_context.is_lead": null,
       "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_journal.get_journal_path": null,
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_handoff_advisories.py": {
+      "__future__.annotations": null,
       "fixtures.emitter": "tests/fixtures/emitter.py",
+      "fixtures.emitter.VALID_HANDOFF": null,
+      "pathlib.Path": null,
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_handoff_b1_b2_dedup.py": {
       "fixtures.emitter": "tests/fixtures/emitter.py",
+      "fixtures.emitter.VALID_HANDOFF": null,
+      "fixtures.emitter._run_main": null,
+      "pathlib.Path": null,
       "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.agent_handoff_marker.occupant_hash": null,
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_handoff_census.py": {
-      "handoff_census": "scripts/handoff_census.py"
+      "__future__.annotations": null,
+      "handoff_census": "scripts/handoff_census.py",
+      "pathlib.Path": null
     },
     "tests/test_handoff_content_discrimination.py": {
       "fixtures.emitter": "tests/fixtures/emitter.py",
-      "shared.canonical_json": "hooks/shared/canonical_json.py"
+      "fixtures.emitter._run_main": null,
+      "shared.canonical_json": "hooks/shared/canonical_json.py",
+      "shared.canonical_json.canonical_bytes": null
     },
     "tests/test_handoff_eligibility_parity.py": {
       "fixtures.emitter": "tests/fixtures/emitter.py",
+      "fixtures.emitter.VALID_HANDOFF": null,
+      "fixtures.emitter._run_main": null,
+      "pathlib.Path": null,
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_handoff_key_annotation_pinned.py": {
-      "shared.handoff_schema": "hooks/shared/handoff_schema.py"
+      "pathlib.Path": null,
+      "shared.handoff_schema": "hooks/shared/handoff_schema.py",
+      "shared.handoff_schema.HANDOFF_CANONICAL_FIELDS": null
     },
     "tests/test_handoff_ordering_gate.py": {
       "handoff_ordering_gate": "hooks/handoff_ordering_gate.py",
+      "pathlib.Path": null,
       "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py",
+      "shared.dispatch_helpers.is_pact_specialist_owner": null,
       "shared.pact_context": "hooks/shared/pact_context.py"
     },
     "tests/test_handoff_schema.py": {
+      "__future__.annotations": null,
       "fixtures.emitter": "tests/fixtures/emitter.py",
-      "shared.handoff_schema": "hooks/shared/handoff_schema.py"
+      "fixtures.emitter.VALID_HANDOFF": null,
+      "pathlib.Path": null,
+      "shared.handoff_schema": "hooks/shared/handoff_schema.py",
+      "shared.handoff_schema.HANDOFF_CANONICAL_FIELDS": null,
+      "shared.handoff_schema.HANDOFF_LEGACY_ALIASES": null,
+      "shared.handoff_schema.HANDOFF_RECOMMENDED_FIELDS": null,
+      "shared.handoff_schema.HANDOFF_REQUIRED_FIELDS": null,
+      "shared.handoff_schema.HANDOFF_SCHEMA_ECHO": null,
+      "shared.handoff_schema.resolve_handoff_field": null,
+      "shared.handoff_schema.validate_handoff_schema": null
     },
     "tests/test_handoff_unclaim_twin_917.py": {
       "fixtures.emitter": "tests/fixtures/emitter.py",
+      "fixtures.emitter.VALID_HANDOFF": null,
+      "fixtures.emitter.VALID_HANDOFF_CONTENT_KEY": null,
+      "pathlib.Path": null,
       "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.agent_handoff_marker.occupant_hash": null,
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_handoff_writability_parity.py": {
       "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
-      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+      "pathlib.Path": null,
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py",
+      "unittest.mock.patch": null
     },
     "tests/test_handoff_write_after_completion_backstop.py": {
+      "pathlib.Path": null,
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_harness_aware_bootstrap.py": {
       "bootstrap_marker_writer": "hooks/bootstrap_marker_writer.py",
+      "bootstrap_marker_writer._team_has_secretary": null,
+      "bootstrap_marker_writer.main": null,
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
-      "shared.pact_context": "hooks/shared/pact_context.py"
+      "shared.BOOTSTRAP_MARKER_NAME": null,
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "unittest.mock.patch": null
     },
-    "tests/test_harvest_ledger_read_contract.py": {},
-    "tests/test_harvest_prune_foreign_root.py": {},
-    "tests/test_harvest_trigger_coherence.py": {},
+    "tests/test_harvest_ledger_read_contract.py": {
+      "pathlib.Path": null
+    },
+    "tests/test_harvest_prune_foreign_root.py": {
+      "pathlib.Path": null
+    },
+    "tests/test_harvest_trigger_coherence.py": {
+      "collections.Counter": null,
+      "pathlib.Path": null
+    },
     "tests/test_hook_emitted_config_root.py": {
       "bootstrap_gate": "hooks/bootstrap_gate.py",
+      "pathlib.Path": null,
       "session_init": "hooks/session_init.py",
-      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py"
+      "session_init.check_additional_directories": null,
+      "session_init.check_settings_well_formed": null,
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.strip_orphan_kernel_block": null,
+      "unittest.mock.patch": null
     },
     "tests/test_hook_infra_classifier.py": {
-      "shared.hook_infra_classifier": "hooks/shared/hook_infra_classifier.py"
+      "__future__.annotations": null,
+      "pathlib.Path": null,
+      "shared.hook_infra_classifier": "hooks/shared/hook_infra_classifier.py",
+      "shared.hook_infra_classifier.L3_LIVE_PROBE_HOOKS": null,
+      "shared.hook_infra_classifier.SEAM_DEPENDENT_HOOKS": null,
+      "shared.hook_infra_classifier.SEAM_READING_HELPERS": null,
+      "shared.hook_infra_classifier._SEAM_HOOK_HELPER_CLOSURE": null,
+      "shared.hook_infra_classifier.classify_diff": null
     },
-    "tests/test_hook_schema_compliance.py": {},
-    "tests/test_hooks_json.py": {},
+    "tests/test_hook_schema_compliance.py": {
+      "__future__.annotations": null
+    },
+    "tests/test_hooks_json.py": {
+      "pathlib.Path": null
+    },
     "tests/test_idle_preamble.py": {
-      "teammate_idle": "hooks/teammate_idle.py"
+      "pathlib.Path": null,
+      "teammate_idle": "hooks/teammate_idle.py",
+      "teammate_idle.IDLE_PREAMBLE": null,
+      "teammate_idle.main": null,
+      "unittest.mock.patch": null
     },
-    "tests/test_import_bar_cause_presence.py": {},
-    "tests/test_import_hygiene.py": {},
+    "tests/test_import_bar_cause_presence.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null
+    },
+    "tests/test_import_hygiene.py": {
+      "pathlib.Path": null
+    },
     "tests/test_import_identity_map.py": {
-      "import_identity_map": "tests/import_identity_map.py"
+      "import_identity_map": "tests/import_identity_map.py",
+      "import_identity_map.capture_map": null,
+      "import_identity_map.diff_maps": null,
+      "import_identity_map.imported_names": null,
+      "import_identity_map.resolve_origins": null
     },
-    "tests/test_index_append_method_pinned.py": {},
+    "tests/test_index_append_method_pinned.py": {
+      "pathlib.Path": null
+    },
     "tests/test_ingress_guard_mechanisms.py": {
+      "__future__.annotations": null,
       "helpers": "tests/helpers.py",
-      "scripts.database": "tests/../skills/pact-memory/scripts/database.py"
+      "helpers.create_test_schema": null,
+      "pathlib.Path": null,
+      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database.create_memory": null,
+      "unittest.mock.patch": null
     },
     "tests/test_intentional_wait.py": {
+      "datetime.datetime": null,
+      "datetime.timedelta": null,
+      "datetime.timezone": null,
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
-      "shared.intentional_wait": "hooks/shared/intentional_wait.py"
+      "shared.intentional_wait": "hooks/shared/intentional_wait.py",
+      "shared.intentional_wait.DEFAULT_THRESHOLD_MINUTES": null,
+      "shared.intentional_wait.KNOWN_REASONS": null,
+      "shared.intentional_wait.KNOWN_RESOLVERS": null,
+      "shared.intentional_wait.SELF_COMPLETE_EXEMPT_AGENT_TYPES": null,
+      "shared.intentional_wait.TEACHBACK_EXEMPT_AGENT_TYPES": null,
+      "shared.intentional_wait._is_exempt_agent_type": null,
+      "shared.intentional_wait.canonical_since": null,
+      "shared.intentional_wait.is_self_complete_exempt": null,
+      "shared.intentional_wait.is_teachback_exempt": null,
+      "shared.intentional_wait.validate_wait": null,
+      "shared.intentional_wait.wait_stale": null,
+      "shared.wait_stale": null
     },
     "tests/test_is_lead.py": {
       "fixtures.role_frames": "tests/fixtures/role_frames.py",
-      "shared.pact_context": "hooks/shared/pact_context.py"
+      "fixtures.role_frames.lead_frame_qualified": null,
+      "fixtures.role_frames.lead_frame_unqualified": null,
+      "fixtures.role_frames.plain_frame": null,
+      "fixtures.role_frames.teammate_frame": null,
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.pact_context.LEAD_AGENT_TYPES": null,
+      "shared.pact_context.classify_session_role": null,
+      "shared.pact_context.is_lead": null
     },
-    "tests/test_lazy_load_cross_references.py": {},
-    "tests/test_lead_discriminator_invariant.py": {},
+    "tests/test_lazy_load_cross_references.py": {
+      "pathlib.Path": null
+    },
+    "tests/test_lead_discriminator_invariant.py": {
+      "pathlib.Path": null
+    },
     "tests/test_lead_side_handoff_emit.py": {
       "fixtures.emitter": "tests/fixtures/emitter.py",
+      "fixtures.emitter.VALID_HANDOFF": null,
+      "pathlib.Path": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
-    "tests/test_learning_ii.py": {},
-    "tests/test_lint_check_argument_accounting.py": {},
-    "tests/test_lint_check_files_mode.py": {},
-    "tests/test_lint_check_help.py": {},
+    "tests/test_learning_ii.py": {
+      "pathlib.Path": null
+    },
+    "tests/test_lint_check_argument_accounting.py": {
+      "pathlib.Path": null
+    },
+    "tests/test_lint_check_files_mode.py": {
+      "pathlib.Path": null
+    },
+    "tests/test_lint_check_help.py": {
+      "pathlib.Path": null
+    },
     "tests/test_lock_identity_certification.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
       "working_memory": "skills/pact-memory/scripts/working_memory.py"
     },
     "tests/test_managed_comment_emitted.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager._build_migrated_content": null,
+      "shared.claude_md_manager.ensure_project_memory_md": null,
       "shared.session_resume": "hooks/shared/session_resume.py",
+      "shared.session_resume.update_session_info": null,
       "working_memory": "skills/pact-memory/scripts/working_memory.py"
     },
-    "tests/test_managed_comment_mirror.py": {},
+    "tests/test_managed_comment_mirror.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null
+    },
     "tests/test_marker_helper_twin_drift.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "shared.pin_markers": "hooks/shared/pin_markers.py",
       "tests": "tests/__init__.py",
+      "tests.test_staleness": "tests/test_staleness.py",
       "working_memory": "skills/pact-memory/scripts/working_memory.py"
     },
     "tests/test_marker_namespace.py": {
+      "pathlib.Path": null,
       "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
-      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py"
+      "shared.agent_handoff_marker._DEFAULT_MARKER_NAMESPACE": null,
+      "shared.agent_handoff_marker._marker_dir": null,
+      "shared.agent_handoff_marker.already_emitted": null,
+      "shared.agent_handoff_marker.unclaim": null,
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py",
+      "shared.task_metadata_snapshot.SNAPSHOT_MARKER_NAMESPACE": null,
+      "shared.task_metadata_snapshot.snapshot_already_emitted": null,
+      "shared.task_metadata_snapshot.snapshot_unclaim": null
     },
     "tests/test_marker_schema.py": {
       "bootstrap_gate": "hooks/bootstrap_gate.py",
-      "shared.marker_schema": "hooks/shared/marker_schema.py"
+      "bootstrap_gate._BLOCKED_TOOLS": null,
+      "pathlib.Path": null,
+      "shared.marker_schema": "hooks/shared/marker_schema.py",
+      "shared.marker_schema.MARKER_MAX_BYTES": null,
+      "shared.marker_schema.MARKER_SCHEMA_VERSION": null,
+      "shared.marker_schema.expected_marker_signature": null
     },
-    "tests/test_memory_api_import_time_reach.py": {},
+    "tests/test_memory_api_import_time_reach.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null
+    },
     "tests/test_memory_cli.py": {
       "helpers": "tests/helpers.py",
+      "helpers.create_test_schema": null,
+      "helpers.make_cli_memory_dict": null,
+      "io.StringIO": null,
+      "pathlib.Path": null,
       "scripts.cli": "tests/../skills/pact-memory/scripts/cli.py",
+      "scripts.cli._COMMANDS": null,
+      "scripts.cli._best_effort_report": null,
+      "scripts.cli._error": null,
+      "scripts.cli._own_stderr_for_envelope": null,
+      "scripts.cli._refuse_live_db_under_pytest": null,
+      "scripts.cli._success": null,
+      "scripts.cli.build_parser": null,
+      "scripts.cli.cmd_delete": null,
+      "scripts.cli.cmd_get": null,
+      "scripts.cli.cmd_list": null,
+      "scripts.cli.cmd_save": null,
+      "scripts.cli.cmd_search": null,
+      "scripts.cli.cmd_setup": null,
+      "scripts.cli.cmd_status": null,
+      "scripts.cli.cmd_update": null,
+      "scripts.cli.main": null,
       "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database.AmbiguousPrefixError": null,
+      "scripts.database.MEMORY_ID_LENGTH": null,
+      "scripts.database.MIN_PREFIX_LENGTH": null,
+      "scripts.database.PrefixTooShortError": null,
+      "scripts.database.create_memory": null,
       "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api.PACTMemory": null,
       "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
-      "test_working_memory_concurrency_comprehensive": "tests/test_working_memory_concurrency_comprehensive.py"
+      "scripts.working_memory.AmbientSyncRefused": null,
+      "scripts.working_memory.SyncResult": null,
+      "test_working_memory_concurrency_comprehensive": "tests/test_working_memory_concurrency_comprehensive.py",
+      "test_working_memory_concurrency_comprehensive._seed_claude_md": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_memory_ct_fields.py": {
+      "pathlib.Path": null,
       "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database.JSON_FIELDS": null,
+      "scripts.database._migrate_ct_fields": null,
+      "scripts.database.create_memory": null,
+      "scripts.database.delete_memory": null,
+      "scripts.database.ensure_initialized": null,
+      "scripts.database.get_connection": null,
+      "scripts.database.get_memory": null,
+      "scripts.database.init_schema": null,
+      "scripts.database.search_memories_by_text": null,
+      "scripts.database.update_memory": null,
       "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api.CONTENT_FIELDS": null,
       "scripts.models": "tests/../skills/pact-memory/scripts/models.py",
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py"
+      "scripts.models.MemoryObject": null,
+      "scripts.models._parse_string_list": null,
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory._format_memory_entry": null,
+      "scripts.working_memory.sync_to_claude_md": null,
+      "unittest.mock.patch": null
     },
     "tests/test_memory_database.py": {
+      "contextlib.contextmanager": null,
+      "datetime.datetime": null,
+      "datetime.timezone": null,
       "helpers": "tests/helpers.py",
+      "helpers.create_test_schema": null,
+      "pathlib.Path": null,
       "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
       "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database.AMBIGUOUS_MATCH_CAP": null,
+      "scripts.database.AmbiguousPrefixError": null,
+      "scripts.database.MIN_PREFIX_LENGTH": null,
+      "scripts.database.PrefixTooShortError": null,
+      "scripts.database._PREFIX_UPPER_BOUND_CHAR": null,
+      "scripts.database._content_hash": null,
+      "scripts.database._deserialize_json_fields": null,
+      "scripts.database._migrate_ct_fields": null,
+      "scripts.database._serialize_json_fields": null,
+      "scripts.database.check_integrity": null,
+      "scripts.database.create_memory": null,
+      "scripts.database.delete_memory": null,
+      "scripts.database.ensure_initialized": null,
+      "scripts.database.generate_id": null,
+      "scripts.database.get_connection": null,
+      "scripts.database.get_memory": null,
+      "scripts.database.get_memory_count": null,
+      "scripts.database.list_memories": null,
+      "scripts.database.resolve_memory_id_prefix": null,
+      "scripts.database.search_memories_by_text": null,
+      "scripts.database.update_memory": null,
       "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
-      "scripts.models": "tests/../skills/pact-memory/scripts/models.py"
+      "scripts.memory_api.PACTMemory": null,
+      "scripts.models": "tests/../skills/pact-memory/scripts/models.py",
+      "scripts.models.MemoryObject": null,
+      "unittest.mock.patch": null
     },
     "tests/test_memory_end_marker_bounds_the_pin_scan.py": {
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.MANAGED_END_MARKER": null,
+      "shared.claude_md_manager.MANAGED_START_MARKER": null,
+      "shared.claude_md_manager.MEMORY_END_MARKER": null,
+      "shared.claude_md_manager.MEMORY_START_MARKER": null,
       "staleness": "hooks/staleness.py"
     },
     "tests/test_memory_graph.py": {
       "helpers": "tests/helpers.py",
-      "scripts.graph": "tests/../skills/pact-memory/scripts/graph.py"
+      "helpers.create_test_schema": null,
+      "scripts.graph": "tests/../skills/pact-memory/scripts/graph.py",
+      "scripts.graph._normalize_path": null,
+      "scripts.graph.add_file_relation": null,
+      "scripts.graph.get_file_by_id": null,
+      "scripts.graph.get_file_context": null,
+      "scripts.graph.get_file_id": null,
+      "scripts.graph.get_file_relations": null,
+      "scripts.graph.get_files_for_memory": null,
+      "scripts.graph.get_graph_stats": null,
+      "scripts.graph.get_memories_for_file": null,
+      "scripts.graph.get_memories_for_files": null,
+      "scripts.graph.get_related_files": null,
+      "scripts.graph.get_related_files_via_memories": null,
+      "scripts.graph.link_memory_to_file": null,
+      "scripts.graph.link_memory_to_files": null,
+      "scripts.graph.link_memory_to_paths": null,
+      "scripts.graph.list_tracked_files": null,
+      "scripts.graph.track_file": null,
+      "unittest.mock.patch": null
     },
     "tests/test_memory_init.py": {
-      "memory_init": "tests/../skills/pact-memory/scripts/memory_init.py"
+      "concurrent.futures.ThreadPoolExecutor": null,
+      "concurrent.futures.as_completed": null,
+      "contextlib.redirect_stderr": null,
+      "memory_init": "tests/../skills/pact-memory/scripts/memory_init.py",
+      "memory_init._get_embedding_attempted_path": null,
+      "memory_init.check_and_install_dependencies": null,
+      "memory_init.clear_embedding_marker": null,
+      "memory_init.ensure_memory_ready": null,
+      "memory_init.is_initialized": null,
+      "memory_init.maybe_embed_pending": null,
+      "memory_init.maybe_migrate_embeddings": null,
+      "memory_init.reset_initialization": null,
+      "pathlib.Path": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_memory_layer_composition.py": {
+      "__future__.annotations": null,
       "helpers": "tests/helpers.py",
+      "helpers.create_test_schema": null,
+      "model2vec.StaticModel": null,
+      "pathlib.Path": null,
       "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
+      "scripts.cli": "tests/../skills/pact-memory/scripts/cli.py",
       "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
+      "scripts.config._STORE_DB_PATH": null,
+      "scripts.config.resolve_db_path": null,
       "scripts.embeddings": "tests/../skills/pact-memory/scripts/embeddings.py",
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py"
+      "scripts.embeddings.EMBEDDING_DIM": null,
+      "scripts.embeddings.EMBEDDING_MAX_TOKENS": null,
+      "scripts.embeddings.MODEL_NAME": null,
+      "scripts.embeddings.generate_embedding_text": null,
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api.PACTMemory": null,
+      "unittest.mock.patch": null
     },
     "tests/test_memory_models.py": {
-      "scripts.models": "tests/../skills/pact-memory/scripts/models.py"
+      "datetime.datetime": null,
+      "datetime.timezone": null,
+      "scripts.models": "tests/../skills/pact-memory/scripts/models.py",
+      "scripts.models.Decision": null,
+      "scripts.models.Entity": null,
+      "scripts.models.MemoryObject": null,
+      "scripts.models.TaskItem": null,
+      "scripts.models._parse_datetime": null,
+      "scripts.models._parse_string_list": null,
+      "scripts.models.memory_from_db_row": null
     },
-    "tests/test_memory_patterns_docs.py": {},
+    "tests/test_memory_patterns_docs.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null
+    },
     "tests/test_memory_reachability.py": {
-      "memory_reachability": "scripts/memory_reachability.py"
+      "memory_reachability": "scripts/memory_reachability.py",
+      "pathlib.Path": null
     },
     "tests/test_memory_store_isolation.py": {
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.config": "tests/../skills/pact-memory/scripts/config.py"
-    },
-    "tests/test_memory_store_scope.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
       "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
-      "scripts.database": "tests/../skills/pact-memory/scripts/database.py"
+      "scripts.config.MEMORY_DIR_ENV": null,
+      "scripts.config.compute_db_path": null,
+      "scripts.config.get_memory_dir": null,
+      "scripts.memory_init": "tests/../skills/pact-memory/scripts/memory_init.py"
+    },
+    "tests/test_memory_store_scope.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
+      "scripts.cli": "tests/../skills/pact-memory/scripts/cli.py",
+      "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
+      "scripts.config.DB_FILENAME": null,
+      "scripts.config.get_memory_dir": null,
+      "scripts.config.resolve_db_path": null,
+      "scripts.config.store_scope": null,
+      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database.db_connection": null,
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "unittest.mock.patch": null,
+      "uuid.uuid4": null
     },
     "tests/test_merge_guard.py": {
+      "__future__.annotations": null,
       "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_post.TOKEN_TTL": null,
+      "merge_guard_post._cleanup_consumed_tokens": null,
+      "merge_guard_post._mint_context_from_bundle": null,
+      "merge_guard_post._retire_token_for_command": null,
+      "merge_guard_post._target_value": null,
+      "merge_guard_post.extract_command_context": null,
+      "merge_guard_post.is_merge_question": null,
+      "merge_guard_post.main": null,
+      "merge_guard_post.write_token": null,
       "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "merge_guard_pre.TOKEN_PREFIX": null,
+      "merge_guard_pre.TOKEN_TTL": null,
+      "merge_guard_pre._cleanup_consumed_tokens": null,
+      "merge_guard_pre._consume_token": null,
+      "merge_guard_pre._extract_pr_number": null,
+      "merge_guard_pre._has_command_substitution": null,
+      "merge_guard_pre._has_eval_or_source": null,
+      "merge_guard_pre._has_eval_with_heredoc": null,
+      "merge_guard_pre._has_pipe_to_shell": null,
+      "merge_guard_pre._has_process_substitution_to_shell": null,
+      "merge_guard_pre._safe_remove": null,
+      "merge_guard_pre._strip_non_executable_content": null,
+      "merge_guard_pre._token_matches_command": null,
+      "merge_guard_pre._var_is_expanded": null,
+      "merge_guard_pre.check_merge_authorization": null,
+      "merge_guard_pre.find_valid_token": null,
+      "merge_guard_pre.is_compound_destructive_command": null,
+      "merge_guard_pre.is_dangerous_command": null,
+      "merge_guard_pre.main": null,
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "shared.merge_guard_common.LAYER1_SUCCESS_STDOUT_PATTERNS": null,
+      "shared.merge_guard_common.MAX_USES": null,
+      "shared.merge_guard_common.ORPHAN_TOKEN_MAX_AGE_SECONDS": null,
+      "shared.merge_guard_common.TOKEN_TTL": null,
+      "shared.merge_guard_common.USE_MARKER_SUFFIX": null,
+      "shared.merge_guard_common._COMPOUND_OPS_RE": null,
+      "shared.merge_guard_common._FD_REDIRECT_RE": null,
+      "shared.merge_guard_common._has_pipe_to_shell": null,
+      "shared.merge_guard_common._mask_shell_quotes": null,
+      "shared.merge_guard_common._normalize_line_continuations": null,
+      "shared.merge_guard_common._split_into_legs": null,
+      "shared.merge_guard_common._strip_non_executable_content": null,
+      "shared.merge_guard_common.cleanup_consumed_tokens": null,
+      "shared.merge_guard_common.cleanup_orphan_tokens": null,
+      "shared.merge_guard_common.cleanup_unused_tokens": null,
+      "shared.merge_guard_common.detect_command_operation_type": null,
+      "shared.merge_guard_common.extract_command_context": null,
+      "shared.merge_guard_common.is_dangerous_command": null,
+      "unittest.mock.patch": null
     },
     "tests/test_merge_guard_1037_narrow.py": {
-      "merge_guard_pre": "hooks/merge_guard_pre.py"
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "merge_guard_pre._strip_non_executable_content": null,
+      "merge_guard_pre.is_compound_destructive_command": null,
+      "merge_guard_pre.is_dangerous_command": null,
+      "pathlib.Path": null
     },
     "tests/test_merge_guard_1118_output_selector.py": {
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "pathlib.Path": null,
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "shared.merge_guard_common._strip_non_executable_content": null,
+      "shared.merge_guard_common.detect_command_operation_type": null,
+      "shared.merge_guard_common.is_dangerous_command": null
     },
     "tests/test_merge_guard_1118_output_selector_cert.py": {
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "pathlib.Path": null,
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "shared.merge_guard_common._strip_non_executable_content": null,
+      "shared.merge_guard_common.detect_command_operation_type": null,
+      "shared.merge_guard_common.is_dangerous_command": null
     },
     "tests/test_merge_guard_1118_recert.py": {
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "pathlib.Path": null,
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "typing.Any": null
     },
     "tests/test_merge_guard_1129_r1_branch_set.py": {
       "merge_guard_pre": "hooks/merge_guard_pre.py",
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "merge_guard_pre._token_matches_command": null,
+      "pathlib.Path": null,
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "shared.merge_guard_common._canonical_join": null,
+      "shared.merge_guard_common._extract_branch_delete_set": null,
+      "shared.merge_guard_common.detect_command_operation_type": null,
+      "shared.merge_guard_common.extract_command_context": null,
+      "shared.merge_guard_common.is_dangerous_command": null
     },
     "tests/test_merge_guard_1129_r1_cert.py": {
       "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_post.main": null,
       "merge_guard_pre": "hooks/merge_guard_pre.py",
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "merge_guard_pre.main": null,
+      "pathlib.Path": null,
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "unittest.mock.patch": null
     },
     "tests/test_merge_guard_1129_r2_cert.py": {
       "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_post.main": null,
       "merge_guard_pre": "hooks/merge_guard_pre.py",
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "merge_guard_pre.main": null,
+      "pathlib.Path": null,
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "unittest.mock.patch": null
     },
     "tests/test_merge_guard_1129_r3_cert.py": {
+      "pathlib.Path": null,
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
     },
     "tests/test_merge_guard_1134_cert.py": {
       "merge_guard_baseline_loader": "tests/merge_guard_baseline_loader.py",
+      "merge_guard_baseline_loader.load_baseline_172a77dd": null,
       "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_post.main": null,
       "merge_guard_pre": "hooks/merge_guard_pre.py",
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "merge_guard_pre.main": null,
+      "pathlib.Path": null,
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "unittest.mock.patch": null
     },
     "tests/test_merge_guard_1136_canonical_join_ssot.py": {
       "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_post.main": null,
       "merge_guard_pre": "hooks/merge_guard_pre.py",
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "merge_guard_pre.main": null,
+      "pathlib.Path": null,
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "unittest.mock.patch": null
     },
     "tests/test_merge_guard_1140_carrier5_cert.py": {
+      "pathlib.Path": null,
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
     },
     "tests/test_merge_guard_1148_cert.py": {
       "merge_guard_baseline_loader": "tests/merge_guard_baseline_loader.py",
+      "merge_guard_baseline_loader.load_baseline": null,
+      "pathlib.Path": null,
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
     },
     "tests/test_merge_guard_1155_cert.py": {
       "merge_guard_baseline_loader": "tests/merge_guard_baseline_loader.py",
+      "merge_guard_baseline_loader.load_baseline": null,
       "merge_guard_post": "hooks/merge_guard_post.py",
       "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "pathlib.Path": null,
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
     },
     "tests/test_merge_guard_1178_cert.py": {
+      "pathlib.Path": null,
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
     },
     "tests/test_merge_guard_1178_f2_cert.py": {
+      "pathlib.Path": null,
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
     },
     "tests/test_merge_guard_1181_cert.py": {
       "merge_guard_baseline_loader": "tests/merge_guard_baseline_loader.py",
+      "merge_guard_baseline_loader.load_baseline": null,
+      "pathlib.Path": null,
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
     },
     "tests/test_merge_guard_1203_cert.py": {
       "merge_guard_baseline_loader": "tests/merge_guard_baseline_loader.py",
+      "merge_guard_baseline_loader.load_baseline_5017d1f2": null,
       "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_post.main": null,
       "merge_guard_pre": "hooks/merge_guard_pre.py",
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "merge_guard_pre.main": null,
+      "pathlib.Path": null,
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "unittest.mock.patch": null
     },
     "tests/test_merge_guard_auth_symmetry.py": {
+      "__future__.annotations": null,
       "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_post._leg_bounded_flag_scan_surface": null,
+      "merge_guard_post._strip_command_wrapper": null,
+      "merge_guard_post.is_merge_question": null,
+      "merge_guard_post.main": null,
+      "merge_guard_post.write_token": null,
       "merge_guard_pre": "hooks/merge_guard_pre.py",
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "merge_guard_pre.check_merge_authorization": null,
+      "merge_guard_pre.main": null,
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "shared.merge_guard_common.TOKEN_PREFIX": null,
+      "shared.merge_guard_common._single_destructive_leg": null,
+      "shared.merge_guard_common._single_detectable_leg": null,
+      "shared.merge_guard_common.extract_command_context": null,
+      "shared.merge_guard_common.is_dangerous_command": null,
+      "unittest.mock.patch": null
     },
     "tests/test_merge_guard_mint_parity.py": {
       "merge_guard_post": "hooks/merge_guard_post.py",
-      "merge_guard_pre": "hooks/merge_guard_pre.py"
+      "merge_guard_post._mint_context_from_bundle": null,
+      "merge_guard_post._target_value": null,
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "pathlib.Path": null
     },
     "tests/test_merge_guard_obs_cert.py": {
       "merge_guard_baseline_loader": "tests/merge_guard_baseline_loader.py",
+      "merge_guard_baseline_loader.load_baseline": null,
       "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_post._mint_context_from_bundle": null,
+      "merge_guard_post._target_value": null,
+      "merge_guard_post.main": null,
       "merge_guard_pre": "hooks/merge_guard_pre.py",
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "merge_guard_pre.main": null,
+      "pathlib.Path": null,
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "unittest.mock.patch": null
     },
     "tests/test_merge_guard_op_recognition_completeness.py": {
       "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_post._mint_context_from_bundle": null,
+      "merge_guard_post._target_value": null,
+      "merge_guard_post.write_token": null,
       "merge_guard_pre": "hooks/merge_guard_pre.py",
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "merge_guard_pre._token_matches_command": null,
+      "merge_guard_pre.check_merge_authorization": null,
+      "pathlib.Path": null,
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "shared.merge_guard_common.detect_command_operation_type": null,
+      "shared.merge_guard_common.extract_command_context": null,
+      "shared.merge_guard_common.is_dangerous_command": null
     },
     "tests/test_merge_guard_output_side_process_sub.py": {
-      "merge_guard_pre": "hooks/merge_guard_pre.py"
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "merge_guard_pre._has_process_substitution_to_shell": null,
+      "merge_guard_pre.is_dangerous_command": null,
+      "pathlib.Path": null
     },
     "tests/test_merge_guard_over_block_batch.py": {
       "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_post.main": null,
       "merge_guard_pre": "hooks/merge_guard_pre.py",
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "merge_guard_pre.check_merge_authorization": null,
+      "merge_guard_pre.main": null,
+      "pathlib.Path": null,
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "shared.merge_guard_common.detect_command_operation_type": null,
+      "shared.merge_guard_common.extract_privileged_flags": null,
+      "shared.merge_guard_common.is_dangerous_command": null,
+      "unittest.mock.patch": null
     },
     "tests/test_merge_guard_overblock_cluster_monotonicity.py": {
       "merge_guard_baseline_loader": "tests/merge_guard_baseline_loader.py",
+      "merge_guard_baseline_loader.load_baseline": null,
       "merge_guard_post": "hooks/merge_guard_post.py",
       "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "pathlib.Path": null,
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
       "test_merge_guard_1148_cert": "tests/test_merge_guard_1148_cert.py",
+      "test_merge_guard_1148_cert.CLOSURES": null,
+      "test_merge_guard_1148_cert._ESC": null,
+      "test_merge_guard_1148_cert._F3_CLOSE": null,
+      "test_merge_guard_1148_cert._F3_GENUINE": null,
+      "test_merge_guard_1148_cert._GENUINE": null,
+      "test_merge_guard_1148_cert._LC": null,
       "test_merge_guard_1155_cert": "tests/test_merge_guard_1155_cert.py",
+      "test_merge_guard_1155_cert.FIND_CLOSURES": null,
+      "test_merge_guard_1155_cert._R1_DELETE_CLASS": null,
+      "test_merge_guard_1155_cert._R1_FAITHFUL": null,
       "test_merge_guard_1181_cert": "tests/test_merge_guard_1181_cert.py",
-      "test_merge_guard_obs_cert": "tests/test_merge_guard_obs_cert.py"
+      "test_merge_guard_1181_cert.INTENDED_CLOSURES": null,
+      "test_merge_guard_obs_cert": "tests/test_merge_guard_obs_cert.py",
+      "test_merge_guard_obs_cert.A2_CENSUS": null,
+      "test_merge_guard_obs_cert.COMMITTER_CENSUS": null
     },
     "tests/test_merge_guard_overblock_tokenizers.py": {
+      "__future__.annotations": null,
       "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_post._strip_command_wrapper": null,
+      "merge_guard_post.main": null,
+      "merge_guard_post.write_token": null,
       "merge_guard_pre": "hooks/merge_guard_pre.py",
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "merge_guard_pre.check_merge_authorization": null,
+      "merge_guard_pre.main": null,
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "shared.merge_guard_common._executable_prefix": null,
+      "shared.merge_guard_common._extract_branch_name": null,
+      "shared.merge_guard_common._extract_force_push_target_ref": null,
+      "shared.merge_guard_common._single_destructive_leg": null,
+      "shared.merge_guard_common.extract_command_context": null,
+      "shared.merge_guard_common.is_compound_destructive_command": null,
+      "shared.merge_guard_common.is_dangerous_command": null,
+      "unittest.mock.patch": null
     },
     "tests/test_merge_guard_perf.py": {
       "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "merge_guard_pre._GH_PR_NUMBER_RE": null,
+      "merge_guard_pre.is_dangerous_command": null,
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "shared.merge_guard_common._MAX_GLOBAL_FLAG_TOKENS": null,
+      "shared.merge_guard_common._shell_tokenize": null,
+      "shared.merge_guard_common._strip_flag_values": null,
+      "shared.merge_guard_common.detect_command_operation_type": null,
+      "shared.merge_guard_common.extract_privileged_flags": null
     },
     "tests/test_merge_guard_pre.py": {
       "merge_guard_pre": "hooks/merge_guard_pre.py",
-      "shared": "hooks/shared/__init__.py"
+      "merge_guard_pre._GH_PR_NUMBER_RE": null,
+      "pathlib.Path": null,
+      "shared": "hooks/shared/__init__.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
     },
     "tests/test_merge_guard_privileged_flags.py": {
       "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_post._collect_pairs": null,
       "merge_guard_pre": "hooks/merge_guard_pre.py",
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "merge_guard_pre._token_matches_command": null,
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "shared.merge_guard_common.PRIVILEGED_FLAGS": null,
+      "shared.merge_guard_common._extract_mass_delete_target": null,
+      "shared.merge_guard_common.extract_command_context": null,
+      "shared.merge_guard_common.extract_privileged_flags": null
     },
     "tests/test_merge_guard_seam_integration.py": {
+      "__future__.annotations": null,
       "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_post._retire_token_for_command": null,
+      "merge_guard_post.main": null,
+      "merge_guard_post.write_token": null,
       "merge_guard_pre": "hooks/merge_guard_pre.py",
-      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+      "merge_guard_pre.check_merge_authorization": null,
+      "merge_guard_pre.main": null,
+      "pathlib.Path": null,
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "shared.merge_guard_common.extract_command_context": null,
+      "unittest.mock.patch": null
     },
-    "tests/test_merge_guard_why_oracle.py": {},
+    "tests/test_merge_guard_why_oracle.py": {
+      "pathlib.Path": null
+    },
     "tests/test_migration_section_comment.py": {
-      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py"
+      "__future__.annotations": null,
+      "pathlib.Path": null,
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.MANAGED_START_MARKER": null,
+      "shared.claude_md_manager.RETRIEVED_CONTEXT_COMMENT": null,
+      "shared.claude_md_manager.WORKING_MEMORY_COMMENT": null,
+      "shared.claude_md_manager._build_migrated_content": null
     },
     "tests/test_missed_wake_scan.py": {
+      "datetime.datetime": null,
+      "datetime.timedelta": null,
+      "datetime.timezone": null,
       "fixtures.role_frames": "tests/fixtures/role_frames.py",
-      "missed_wake_scan": "hooks/missed_wake_scan.py"
+      "fixtures.role_frames.captured_lead_sessionstart_qualified": null,
+      "fixtures.role_frames.captured_lead_sessionstart_unqualified": null,
+      "fixtures.role_frames.captured_lead_userpromptsubmit_qualified": null,
+      "fixtures.role_frames.captured_plain_sessionstart": null,
+      "fixtures.role_frames.captured_plain_userpromptsubmit": null,
+      "fixtures.role_frames.captured_teammate_sessionstart": null,
+      "missed_wake_scan": "hooks/missed_wake_scan.py",
+      "pathlib.Path": null
     },
     "tests/test_missed_wake_scan_integration.py": {
+      "datetime.datetime": null,
+      "datetime.timedelta": null,
+      "datetime.timezone": null,
       "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "fixtures.role_frames.captured_lead_userpromptsubmit_qualified": null,
+      "fixtures.role_frames.captured_plain_userpromptsubmit": null,
+      "fixtures.role_frames.captured_teammate_sessionstart": null,
       "missed_wake_scan": "hooks/missed_wake_scan.py",
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
       "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_journal.read_events": null,
+      "shared.task_utils": "hooks/shared/task_utils.py",
       "teammate_idle": "hooks/teammate_idle.py"
     },
-    "tests/test_no_broadcast_addressing.py": {},
-    "tests/test_orchestration_retrospective.py": {
-      "shared.teachback_schema": "hooks/shared/teachback_schema.py",
-      "shared.variety_divergence": "hooks/shared/variety_divergence.py"
+    "tests/test_no_broadcast_addressing.py": {
+      "pathlib.Path": null
     },
-    "tests/test_packaging_boundary.py": {},
+    "tests/test_orchestration_retrospective.py": {
+      "pathlib.Path": null,
+      "shared.teachback_schema": "hooks/shared/teachback_schema.py",
+      "shared.teachback_schema.resolve_variety_total": null,
+      "shared.variety_divergence": "hooks/shared/variety_divergence.py",
+      "shared.variety_divergence.extract_dispatch_coverage": null,
+      "shared.variety_divergence.extract_final_dispatch_coverage": null
+    },
+    "tests/test_packaging_boundary.py": {
+      "pathlib.Path": null,
+      "typing.List": null,
+      "typing.Optional": null,
+      "typing.Tuple": null
+    },
     "tests/test_pact_config.py": {
-      "shared.pact_config": "hooks/shared/pact_config.py"
+      "pathlib.Path": null,
+      "shared.pact_config": "hooks/shared/pact_config.py",
+      "shared.pact_config.get_bool": null,
+      "shared.pact_config.get_enum": null,
+      "shared.pact_config.llm_options": null
     },
     "tests/test_pact_config_gate_migration.py": {
+      "pathlib.Path": null,
       "shared.pact_config": "hooks/shared/pact_config.py"
     },
     "tests/test_pact_config_injection.py": {
       "fixtures.role_frames": "tests/fixtures/role_frames.py",
-      "session_init": "hooks/session_init.py"
+      "fixtures.role_frames.plain_frame": null,
+      "fixtures.role_frames.teammate_frame": null,
+      "pathlib.Path": null,
+      "session_init": "hooks/session_init.py",
+      "session_init.format_pact_runtime_config": null,
+      "unittest.mock.patch": null
     },
     "tests/test_pact_context.py": {
+      "datetime.datetime": null,
       "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "fixtures.role_frames.captured_teammate_sessionstart": null,
+      "fixtures.role_frames.lead_frame_qualified": null,
+      "fixtures.role_frames.lead_frame_unqualified": null,
+      "fixtures.role_frames.plain_frame": null,
+      "fixtures.role_frames.teammate_frame": null,
+      "pathlib.Path": null,
       "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
       "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api.PACTMemory": null,
+      "scripts.memory_init": "tests/../skills/pact-memory/scripts/memory_init.py",
       "scripts.pact_session": "tests/../skills/pact-memory/scripts/pact_session.py",
+      "scripts.pact_session._context_file_path": null,
+      "scripts.pact_session._resolve_context_on_disk": null,
+      "scripts.pact_session.get_session_id_from_context_file": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.pact_context._build_session_path": null,
+      "shared.pact_context.get_pact_context": null,
+      "shared.pact_context.get_plugin_root": null,
+      "shared.pact_context.get_project_dir": null,
+      "shared.pact_context.get_session_dir": null,
+      "shared.pact_context.get_session_id": null,
+      "shared.pact_context.get_team_name": null,
+      "shared.pact_context.project_slug": null,
+      "shared.pact_context.reconstruct_session_dir": null,
+      "shared.pact_context.resolve_agent_name": null,
+      "shared.pact_context.resolve_compact_summary_path": null,
       "shared.session_registry": "hooks/shared/session_registry.py",
-      "shared.task_utils": "hooks/shared/task_utils.py"
+      "shared.session_registry.register": null,
+      "shared.task_utils": "hooks/shared/task_utils.py",
+      "shared.task_utils.get_task_list": null
     },
     "tests/test_pact_harvest_cli.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
       "shared.pact_harvest": "hooks/shared/pact_harvest.py",
+      "shared.pact_harvest._resolve_session_dir": null,
       "shared.paths": "hooks/shared/paths.py",
-      "shared.session_journal": "hooks/shared/session_journal.py"
+      "shared.paths.get_claude_config_dir": null,
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_journal._normalize_trailing_z": null,
+      "shared.session_journal._parse_ts": null,
+      "shared.session_journal.append_event": null,
+      "shared.session_journal.make_event": null,
+      "shared.session_journal.resolve_latest_artifacts": null
     },
     "tests/test_pact_orchestrator_agent.py": {
-      "helpers": "tests/helpers.py"
+      "helpers": "tests/helpers.py",
+      "helpers.parse_frontmatter": null,
+      "pathlib.Path": null
     },
     "tests/test_pact_session_config_dir_parity.py": {
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py"
+      "pathlib.Path": null,
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
+      "scripts.pact_session": "tests/../skills/pact-memory/scripts/pact_session.py"
     },
     "tests/test_paths.py": {
+      "pathlib.Path": null,
       "shared.constants": "hooks/shared/constants.py",
+      "shared.constants.get_compact_summary_path": null,
       "shared.failure_log": "hooks/shared/failure_log.py",
+      "shared.failure_log.get_failure_log_path": null,
       "shared.paths": "hooks/shared/paths.py",
-      "track_files": "hooks/track_files.py"
+      "shared.paths.get_claude_config_dir": null,
+      "track_files": "hooks/track_files.py",
+      "track_files.get_tracking_dir": null
     },
     "tests/test_peer_inject.py": {
-      "peer_inject": "hooks/peer_inject.py"
+      "pathlib.Path": null,
+      "peer_inject": "hooks/peer_inject.py",
+      "peer_inject._BOOTSTRAP_PRELUDE_TEMPLATE": null,
+      "peer_inject._COMPLETION_AUTHORITY_NOTE": null,
+      "peer_inject._TEACHBACK_REMINDER": null,
+      "peer_inject._sanitize_agent_name": null,
+      "peer_inject.get_peer_context": null,
+      "peer_inject.main": null,
+      "unittest.mock.patch": null
     },
-    "tests/test_peer_review_greedy_pin.py": {},
-    "tests/test_peer_review_independence_pin.py": {},
+    "tests/test_peer_review_greedy_pin.py": {
+      "pathlib.Path": null
+    },
+    "tests/test_peer_review_independence_pin.py": {
+      "pathlib.Path": null
+    },
     "tests/test_per_dispatch_variety.py": {
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
       "shared.teachback_schema": "hooks/shared/teachback_schema.py",
+      "shared.teachback_schema.TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN": null,
       "shared.variety_divergence": "hooks/shared/variety_divergence.py",
+      "shared.variety_divergence.DEFAULT_THRESHOLD": null,
+      "shared.variety_divergence.compute_variety_divergence": null,
+      "shared.variety_scorer": "hooks/shared/variety_scorer.py",
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_per_write_adversarial_matrix.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.agent_handoff_marker.sanitize_path_component": null,
       "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_journal.read_events": null,
       "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py",
+      "shared.task_metadata_snapshot.PAYLOAD_CAP": null,
+      "shared.task_metadata_snapshot.PER_VALUE_CAP": null,
+      "shared.task_metadata_snapshot._canonical_bytes": null,
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_per_write_mirror_registry.py": {
       "shared.pact_context": "hooks/shared/pact_context.py",
-      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py"
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py",
+      "shared.task_metadata_snapshot.PER_WRITE_MIRROR_KEYS": null,
+      "shared.task_metadata_snapshot.SNAPSHOT_EXCLUDE": null
     },
     "tests/test_per_write_snapshot_seam.py": {
+      "pathlib.Path": null,
       "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py",
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_pin_caps.py": {
-      "pin_caps": "hooks/pin_caps.py"
+      "pathlib.Path": null,
+      "pin_caps": "hooks/pin_caps.py",
+      "pin_caps.DENY_REASON_COUNT": null,
+      "pin_caps.DENY_REASON_EMBEDDED_PIN": null,
+      "pin_caps.DENY_REASON_OVERRIDE_MISSING": null,
+      "pin_caps.DENY_REASON_SIZE": null,
+      "pin_caps.OVERRIDE_RATIONALE_MAX": null,
+      "pin_caps.PIN_COUNT_CAP": null,
+      "pin_caps.PIN_SIZE_CAP": null,
+      "pin_caps.PIN_STALE_BLOCK_THRESHOLD": null,
+      "pin_caps.Pin": null,
+      "pin_caps.apply_edit_and_parse": null,
+      "pin_caps.check_add_allowed": null,
+      "pin_caps.check_stale_block": null,
+      "pin_caps.compute_deny_reason": null,
+      "pin_caps.evaluate_full_state": null,
+      "pin_caps.format_slot_status": null,
+      "pin_caps.has_size_override": null,
+      "pin_caps.parse_pins": null
     },
     "tests/test_pin_caps_adversarial.py": {
+      "pathlib.Path": null,
       "pin_caps": "hooks/pin_caps.py",
+      "pin_caps.Pin": null,
+      "pin_caps.check_add_allowed": null,
+      "pin_caps.parse_pins": null,
       "pin_staleness_gate": "hooks/pin_staleness_gate.py",
+      "pin_staleness_gate.PIN_STALENESS_MARKER_NAME": null,
+      "pin_staleness_gate._check_tool_allowed": null,
       "session_init": "hooks/session_init.py",
+      "session_init.check_pin_slot_status": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
       "staleness": "hooks/staleness.py"
     },
     "tests/test_pin_caps_gate.py": {
       "helpers": "tests/helpers.py",
+      "helpers.make_claude_md_with_pins": null,
+      "helpers.make_pin_entry": null,
+      "pathlib.Path": null,
       "pin_caps_gate": "hooks/pin_caps_gate.py",
+      "pin_caps_gate._check_tool_allowed": null,
       "staleness": "hooks/staleness.py"
     },
     "tests/test_pin_caps_gate_counter_test.py": {
       "helpers": "tests/helpers.py",
+      "helpers.make_claude_md_with_pins": null,
+      "helpers.make_pin_entry": null,
+      "pathlib.Path": null,
       "pin_caps": "hooks/pin_caps.py",
+      "pin_caps.evaluate_full_state": null,
       "pin_caps_gate": "hooks/pin_caps_gate.py",
+      "pin_caps_gate._check_tool_allowed": null,
       "staleness": "hooks/staleness.py"
     },
     "tests/test_pin_caps_gate_low_priority.py": {
       "helpers": "tests/helpers.py",
+      "helpers.make_claude_md_with_pins": null,
+      "helpers.make_pin_entry": null,
+      "pathlib.Path": null,
       "pin_caps_gate": "hooks/pin_caps_gate.py",
+      "pin_caps_gate._check_tool_allowed": null,
       "staleness": "hooks/staleness.py"
     },
     "tests/test_pin_caps_gate_matrix.py": {
       "helpers": "tests/helpers.py",
+      "helpers.make_claude_md_with_pins": null,
+      "helpers.make_pin_entry": null,
+      "pathlib.Path": null,
       "pin_caps": "hooks/pin_caps.py",
+      "pin_caps.parse_pins": null,
       "pin_caps_gate": "hooks/pin_caps_gate.py",
+      "pin_caps_gate._check_tool_allowed": null,
+      "pin_caps_gate._extract_override_rationale": null,
       "staleness": "hooks/staleness.py"
     },
     "tests/test_pin_caps_integration.py": {
       "helpers": "tests/helpers.py",
+      "helpers.make_claude_md_with_pins": null,
+      "helpers.make_pin_entry": null,
+      "helpers.make_pinned_section": null,
+      "pathlib.Path": null,
       "pin_caps": "hooks/pin_caps.py",
+      "pin_caps.parse_pins": null,
       "pin_staleness_gate": "hooks/pin_staleness_gate.py",
+      "pin_staleness_gate.PIN_STALENESS_MARKER_NAME": null,
       "session_init": "hooks/session_init.py",
+      "session_init.check_pin_slot_status": null,
+      "session_init.check_pin_stale_block_directive": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
-      "staleness": "hooks/staleness.py"
+      "staleness": "hooks/staleness.py",
+      "staleness.check_pinned_block_signal": null,
+      "staleness.detect_stale_entries": null
     },
     "tests/test_pin_caps_phantom_green.py": {
       "check_pin_caps": "scripts/check_pin_caps.py",
       "helpers": "tests/helpers.py",
+      "helpers.make_claude_md_with_pins": null,
+      "helpers.make_pin_entry": null,
+      "pathlib.Path": null,
       "pin_caps_gate": "hooks/pin_caps_gate.py",
-      "staleness": "hooks/staleness.py"
+      "pin_caps_gate._check_tool_allowed": null,
+      "staleness": "hooks/staleness.py",
+      "unittest.mock.patch": null
     },
     "tests/test_pin_comment_dominance.py": {
       "helpers": "tests/helpers.py",
+      "helpers.make_claude_md_with_pins": null,
+      "pathlib.Path": null,
       "pin_caps": "hooks/pin_caps.py",
+      "pin_caps.OVERRIDE_COMMENT_RE": null,
+      "pin_caps.PIN_SIZE_CAP": null,
+      "pin_caps._DATE_COMMENT_RE": null,
+      "pin_caps.evaluate_full_state": null,
+      "pin_caps.parse_pins": null,
       "pin_caps_gate": "hooks/pin_caps_gate.py",
+      "pin_caps_gate._check_tool_allowed": null,
       "staleness": "hooks/staleness.py"
     },
     "tests/test_pin_comment_pipeline.py": {
-      "pin_caps": "hooks/pin_caps.py"
+      "pathlib.Path": null,
+      "pin_caps": "hooks/pin_caps.py",
+      "pin_caps.OVERRIDE_COMMENT_RE": null,
+      "pin_caps.PIN_STALE_BLOCK_THRESHOLD": null,
+      "pin_caps._DATE_COMMENT_RE": null,
+      "pin_caps._extract_body_chars": null,
+      "pin_caps.check_stale_block": null,
+      "pin_caps.compute_deny_reason": null,
+      "pin_caps.parse_pins": null
     },
     "tests/test_pin_marker_writer.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "pin_marker_writer": "hooks/pin_marker_writer.py",
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.MANAGED_END_MARKER": null,
+      "shared.claude_md_manager.MANAGED_START_MARKER": null,
+      "shared.claude_md_manager.MEMORY_END_MARKER": null,
+      "shared.claude_md_manager.MEMORY_START_MARKER": null,
+      "shared.claude_md_manager.PACT_BOUNDARY_PREFIXES": null,
+      "shared.claude_md_manager.PINNED_END_MARKER": null,
+      "shared.claude_md_manager.PINNED_START_MARKER": null,
+      "shared.claude_md_manager.ensure_project_memory_md": null,
+      "shared.claude_md_manager.extract_managed_region": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
       "shared.pin_markers": "hooks/shared/pin_markers.py",
+      "shared.pin_markers.END_LINE": null,
+      "shared.pin_markers.Insertion": null,
+      "shared.pin_markers.START_LINE": null,
+      "shared.pin_markers.SkipReason": null,
+      "shared.pin_markers._PINNED_HEADING": null,
+      "shared.pin_markers._PINNED_TERMINATOR": null,
+      "shared.pin_markers._is_already_marked": null,
+      "shared.pin_markers._narrow_to_memory_region": null,
+      "shared.pin_markers.apply_insertion": null,
+      "shared.pin_markers.certify_expel_nothing": null,
+      "shared.pin_markers.marker_line_present": null,
+      "shared.pin_markers.plan_insertion": null,
       "shared.session_journal": "hooks/shared/session_journal.py",
       "staleness": "hooks/staleness.py",
-      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+      "staleness._find_terminator_offset": null,
+      "staleness._parse_pinned_section": null,
+      "staleness._resolve_project_claude_md_with_base": null,
+      "working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "working_memory._PACT_BOUNDARY_ALT": null,
+      "working_memory._SESSION_BOUNDARY_ALT": null
     },
     "tests/test_pin_marker_writer_adversarial.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "pin_caps": "hooks/pin_caps.py",
+      "pin_caps.PIN_COUNT_CAP": null,
+      "pin_caps.PIN_SIZE_CAP": null,
+      "pin_caps.apply_edit_and_parse": null,
+      "pin_caps.compute_deny_reason": null,
       "pin_caps_gate": "hooks/pin_caps_gate.py",
+      "pin_caps_gate._extract_new_body": null,
+      "pin_caps_gate._parse_baseline": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.MEMORY_END_MARKER": null,
+      "shared.claude_md_manager.MEMORY_START_MARKER": null,
+      "shared.claude_md_manager.PINNED_END_MARKER": null,
+      "shared.claude_md_manager.PINNED_START_MARKER": null,
+      "shared.claude_md_manager.extract_managed_region": null,
       "shared.pin_markers": "hooks/shared/pin_markers.py",
+      "shared.pin_markers.Insertion": null,
+      "shared.pin_markers.START_LINE": null,
+      "shared.pin_markers.SkipReason": null,
+      "shared.pin_markers.apply_insertion": null,
+      "shared.pin_markers.certify_expel_nothing": null,
+      "shared.pin_markers.plan_insertion": null,
       "staleness": "hooks/staleness.py",
-      "tests.test_pin_marker_writer": "tests/test_pin_marker_writer.py"
+      "staleness._parse_pinned_section": null,
+      "tests.test_pin_marker_writer": "tests/test_pin_marker_writer.py",
+      "tests.test_pin_marker_writer.production_head_and_tail": null
     },
     "tests/test_pin_staleness_gate.py": {
       "helpers": "tests/helpers.py",
+      "helpers.make_claude_md_with_pins": null,
+      "helpers.make_pin_entry": null,
+      "io.StringIO": null,
+      "pathlib.Path": null,
       "pin_staleness_gate": "hooks/pin_staleness_gate.py",
+      "pin_staleness_gate.PIN_STALENESS_MARKER_NAME": null,
+      "pin_staleness_gate._check_tool_allowed": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.MANAGED_END_MARKER": null,
+      "shared.claude_md_manager.MANAGED_START_MARKER": null,
+      "shared.claude_md_manager.extract_managed_region": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
       "staleness": "hooks/staleness.py"
     },
     "tests/test_pin_staleness_gate_two_rules.py": {
+      "pathlib.Path": null,
       "pin_staleness_gate": "hooks/pin_staleness_gate.py",
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
-      "staleness": "hooks/staleness.py"
+      "shared.claude_md_manager.MANAGED_END_MARKER": null,
+      "shared.claude_md_manager.MANAGED_START_MARKER": null,
+      "shared.claude_md_manager.extract_managed_region": null,
+      "staleness": "hooks/staleness.py",
+      "staleness._parse_pinned_section": null
     },
     "tests/test_pin_staleness_marker_clear.py": {
+      "pathlib.Path": null,
       "pin_staleness_gate": "hooks/pin_staleness_gate.py",
+      "pin_staleness_gate.PIN_STALENESS_MARKER_NAME": null,
       "shared": "hooks/shared/__init__.py",
       "shared.constants": "hooks/shared/constants.py",
+      "shared.constants.PIN_STALENESS_MARKER_NAME": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
       "staleness": "hooks/staleness.py",
       "track_files": "hooks/track_files.py"
     },
-    "tests/test_planning_artifact_scrub.py": {},
-    "tests/test_plugin_json_orchestrator.py": {},
-    "tests/test_plugin_manifest.py": {
-      "shared": "hooks/shared/__init__.py",
-      "shared.plugin_manifest": "hooks/shared/plugin_manifest.py"
+    "tests/test_planning_artifact_scrub.py": {
+      "__future__.annotations": null,
+      "dataclasses.dataclass": null,
+      "pathlib.Path": null
     },
-    "tests/test_plugin_manifest_parity.py": {},
-    "tests/test_plugin_version_bump.py": {},
+    "tests/test_plugin_json_orchestrator.py": {
+      "pathlib.Path": null
+    },
+    "tests/test_plugin_manifest.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
+      "shared": "hooks/shared/__init__.py",
+      "shared.plugin_manifest": "hooks/shared/plugin_manifest.py",
+      "shared.plugin_manifest.format_plugin_banner": null
+    },
+    "tests/test_plugin_manifest_parity.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null
+    },
+    "tests/test_plugin_version_bump.py": {
+      "pathlib.Path": null
+    },
     "tests/test_postcompact_archive.py": {
+      "__future__.annotations": null,
       "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "fixtures.role_frames.postcompact_frame": null,
+      "io.StringIO": null,
+      "pathlib.Path": null,
       "postcompact_archive": "hooks/postcompact_archive.py",
-      "shared.constants": "hooks/shared/constants.py"
+      "postcompact_archive.main": null,
+      "postcompact_archive.write_compact_summary": null,
+      "shared.constants": "hooks/shared/constants.py",
+      "shared.constants.get_compact_summary_path": null,
+      "unittest.mock.patch": null
     },
     "tests/test_pr4_drain_survival_harvest.py": {
-      "shared.session_journal": "hooks/shared/session_journal.py"
+      "__future__.annotations": null,
+      "datetime.datetime": null,
+      "pathlib.Path": null,
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_journal.append_event": null,
+      "shared.session_journal.make_event": null,
+      "shared.session_journal.read_events": null
     },
     "tests/test_pr4_revision_v2_on_journal.py": {
+      "__future__.annotations": null,
       "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
-      "shared.session_journal": "hooks/shared/session_journal.py"
+      "pathlib.Path": null,
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_journal.read_events": null
     },
     "tests/test_precompact_state_reminder.py": {
+      "__future__.annotations": null,
+      "io.StringIO": null,
+      "pathlib.Path": null,
       "precompact_state_reminder": "hooks/precompact_state_reminder.py",
+      "precompact_state_reminder._extract_variety_total": null,
+      "precompact_state_reminder.build_custom_instructions": null,
+      "precompact_state_reminder.build_hook_output": null,
+      "precompact_state_reminder.main": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
-      "shared.session_journal": "hooks/shared/session_journal.py"
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_journal.make_event": null,
+      "unittest.mock.patch": null
     },
-    "tests/test_progress_signals.py": {},
+    "tests/test_progress_signals.py": {
+      "pathlib.Path": null
+    },
     "tests/test_project_dir_resolution.py": {
+      "__future__.annotations": null,
       "fixtures.project_dir": "tests/fixtures/project_dir.py",
+      "fixtures.project_dir.child_env": null,
+      "fixtures.project_dir.enable_record_discovery": null,
+      "fixtures.project_dir.git_flake_shim": null,
+      "fixtures.project_dir.make_umbrella": null,
+      "fixtures.project_dir.source_export_line": null,
+      "fixtures.project_dir.write_session_context": null,
+      "pathlib.Path": null,
       "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
       "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api.PACTMemory": null,
       "scripts.pact_session": "tests/../skills/pact-memory/scripts/pact_session.py",
-      "shared": "hooks/shared/__init__.py"
+      "scripts.pact_session.ProjectScopeDisagreementError": null,
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "shared": "hooks/shared/__init__.py",
+      "shared.backlog": "hooks/shared/backlog.py",
+      "types.SimpleNamespace": null
     },
     "tests/test_project_id.py": {
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py"
+      "pathlib.Path": null,
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api.PACTMemory": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
-    "tests/test_prose_root_gate.py": {},
+    "tests/test_prose_root_gate.py": {
+      "pathlib.Path": null
+    },
     "tests/test_prune_memory_integration.py": {
       "check_pin_caps": "scripts/check_pin_caps.py",
       "helpers": "tests/helpers.py",
+      "helpers.make_claude_md_with_pins": null,
+      "helpers.make_pin_entry": null,
+      "pathlib.Path": null,
       "pin_caps_gate": "hooks/pin_caps_gate.py",
-      "staleness": "hooks/staleness.py"
+      "pin_caps_gate._check_tool_allowed": null,
+      "staleness": "hooks/staleness.py",
+      "unittest.mock.patch": null
     },
-    "tests/test_prune_telemetry_contract.py": {},
-    "tests/test_py39_annotation_compat.py": {},
+    "tests/test_prune_telemetry_contract.py": {
+      "pathlib.Path": null
+    },
+    "tests/test_py39_annotation_compat.py": {
+      "__future__.annotations": null,
+      "dataclasses.dataclass": null,
+      "pathlib.Path": null,
+      "typing.Iterable": null,
+      "typing.Iterator": null,
+      "typing.List": null,
+      "typing.Optional": null,
+      "typing.Tuple": null
+    },
     "tests/test_read_lead_session_id_parity.py": {
+      "pathlib.Path": null,
       "shared.session_registry": "hooks/shared/session_registry.py",
+      "shared.session_registry._read_lead_session_id": null,
       "task_claim_gate": "hooks/task_claim_gate.py"
     },
-    "tests/test_read_trigger_precondition_pinned.py": {},
+    "tests/test_read_trigger_precondition_pinned.py": {
+      "pathlib.Path": null
+    },
     "tests/test_recovery_pointer_fallback.py": {
+      "pathlib.Path": null,
       "working_memory": "skills/pact-memory/scripts/working_memory.py"
     },
     "tests/test_resume_team_realign_1507.py": {
       "dispatch_gate": "hooks/dispatch_gate.py",
+      "dispatch_gate.main": null,
+      "pathlib.Path": null,
       "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py",
-      "shared.pact_context": "hooks/shared/pact_context.py"
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "unittest.mock.patch": null
     },
     "tests/test_resumption_marker_mirror.py": {
-      "shared.session_journal": "hooks/shared/session_journal.py"
+      "__future__.annotations": null,
+      "pathlib.Path": null,
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_journal._REQUIRED_FIELDS_BY_TYPE": null
     },
     "tests/test_resumption_marker_seam.py": {
+      "__future__.annotations": null,
+      "contextlib.ExitStack": null,
+      "pathlib.Path": null,
       "session_init": "hooks/session_init.py",
       "shared.pact_context": "hooks/shared/pact_context.py",
       "tests.test_resumption_marker_mirror": "tests/test_resumption_marker_mirror.py",
-      "tests.test_session_init": "tests/test_session_init.py"
+      "tests.test_resumption_marker_mirror.AGENT_BODY": null,
+      "tests.test_resumption_marker_mirror.HOOK": null,
+      "tests.test_resumption_marker_mirror.marker_event_type": null,
+      "tests.test_session_init": "tests/test_session_init.py",
+      "tests.test_session_init._with_lead_role": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_role_gate_flip_and_postcompact.py": {
       "bootstrap_gate": "hooks/bootstrap_gate.py",
+      "bootstrap_gate._DENY_REASON": null,
+      "bootstrap_gate._check_tool_allowed": null,
       "bootstrap_marker_writer": "hooks/bootstrap_marker_writer.py",
       "bootstrap_prompt_gate": "hooks/bootstrap_prompt_gate.py",
       "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "fixtures.role_frames.captured_postcompact_lead_manual": null,
+      "fixtures.role_frames.lead_frame_qualified": null,
+      "fixtures.role_frames.lead_frame_unqualified": null,
+      "fixtures.role_frames.plain_frame": null,
+      "fixtures.role_frames.postcompact_frame": null,
+      "fixtures.role_frames.teammate_frame": null,
+      "pathlib.Path": null,
       "pin_caps_gate": "hooks/pin_caps_gate.py",
       "pin_staleness_gate": "hooks/pin_staleness_gate.py",
       "postcompact_archive": "hooks/postcompact_archive.py",
-      "shared.pact_context": "hooks/shared/pact_context.py"
+      "postcompact_archive.main": null,
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.pact_context.classify_session_role": null,
+      "shared.pact_context.is_lead": null,
+      "unittest.mock.patch": null
     },
     "tests/test_seam_line_ending_call_sites.py": {
+      "collections.Counter": null,
+      "pathlib.Path": null,
       "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory.sync_retrieved_to_claude_md": null,
+      "scripts.working_memory.sync_to_claude_md": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.migrate_to_managed_structure": null,
       "staleness": "hooks/staleness.py",
-      "test_staleness": "tests/test_staleness.py"
+      "staleness.check_pinned_staleness": null,
+      "test_staleness": "tests/test_staleness.py",
+      "test_staleness.over_budget_body": null
     },
     "tests/test_session_block_substitution.py": {
-      "shared.session_resume": "hooks/shared/session_resume.py"
+      "pathlib.Path": null,
+      "shared.session_resume": "hooks/shared/session_resume.py",
+      "shared.session_resume.update_session_info": null
     },
     "tests/test_session_consolidated_integration.py": {
+      "pathlib.Path": null,
       "session_end": "hooks/session_end.py",
+      "session_end.check_unpaused_pr": null,
       "shared.gh_helpers": "hooks/shared/gh_helpers.py",
-      "shared.session_journal": "hooks/shared/session_journal.py"
+      "shared.gh_helpers.check_pr_state": null,
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_journal.append_event": null,
+      "shared.session_journal.make_event": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_session_discovery_route.py": {
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py"
+      "__future__.annotations": null,
+      "pathlib.Path": null,
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
+      "scripts.pact_session": "tests/../skills/pact-memory/scripts/pact_session.py"
     },
     "tests/test_session_end.py": {
+      "contextlib.ExitStack": null,
+      "pathlib.Path": null,
       "session_end": "hooks/session_end.py",
-      "shared.gh_helpers": "hooks/shared/gh_helpers.py"
+      "session_end._SESSION_MAX_AGE_DAYS": null,
+      "session_end._UUID_PATTERN": null,
+      "session_end._assemble_tasks_skip_set": null,
+      "session_end._dir_max_child_mtime": null,
+      "session_end._is_checkpointed_session": null,
+      "session_end._is_paused_session": null,
+      "session_end._journal_carries_unharvested_handoffs": null,
+      "session_end.check_unpaused_pr": null,
+      "session_end.cleanup_old_sessions": null,
+      "session_end.cleanup_old_tasks": null,
+      "session_end.cleanup_old_teams": null,
+      "session_end.get_project_slug": null,
+      "session_end.main": null,
+      "shared.gh_helpers": "hooks/shared/gh_helpers.py",
+      "shared.gh_helpers.check_pr_state": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_session_end_integration.py": {
+      "pathlib.Path": null,
       "session_end": "hooks/session_end.py"
     },
     "tests/test_session_end_registry_prune.py": {
-      "session_end": "hooks/session_end.py"
+      "pathlib.Path": null,
+      "session_end": "hooks/session_end.py",
+      "session_end._prune_registry_dead_teams": null
     },
     "tests/test_session_end_survives_a_forged_heading.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.MEMORY_END_MARKER": null,
+      "shared.claude_md_manager.MEMORY_START_MARKER": null,
       "tests.test_pin_marker_writer": "tests/test_pin_marker_writer.py",
-      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+      "tests.test_pin_marker_writer.build_claude_md": null,
+      "unittest.mock.patch": null,
+      "working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "working_memory.sync_retrieved_to_claude_md": null,
+      "working_memory.sync_to_claude_md": null
     },
     "tests/test_session_init.py": {
+      "__future__.annotations": null,
+      "contextlib.ExitStack": null,
+      "contextlib.contextmanager": null,
+      "datetime.datetime": null,
+      "datetime.timezone": null,
+      "pathlib.Path": null,
       "session_init": "hooks/session_init.py",
+      "session_init._ROOT_DRAINED_SUMMARY_PREFIX": null,
+      "session_init._UNKNOWN_ROLE_NOTICE": null,
+      "session_init._adopt_old_slug_session_dir": null,
+      "session_init._build_safety_net_context": null,
+      "session_init._clear_bootstrap_marker": null,
+      "session_init._extract_prev_session_dir": null,
+      "session_init._is_unknown_or_missing_session": null,
+      "session_init._resume_own_summary_clause": null,
+      "session_init._validate_under_pact_sessions": null,
+      "session_init.check_additional_directories": null,
+      "session_init.check_resume_state": null,
+      "session_init.generate_team_name": null,
+      "session_init.main": null,
+      "session_init.restore_last_session": null,
       "shared": "hooks/shared/__init__.py",
+      "shared.BOOTSTRAP_MARKER_NAME": null,
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
       "shared.constants": "hooks/shared/constants.py",
+      "shared.constants.COMPACT_SUMMARY_ORPHAN_NAME": null,
+      "shared.constants.get_compact_summary_path": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.pact_context.classify_session_role": null,
       "shared.symlinks": "hooks/shared/symlinks.py",
-      "shared.teammate_mode": "hooks/shared/teammate_mode.py"
+      "shared.symlinks.SYMLINKS_VERIFIED_MESSAGE": null,
+      "shared.teammate_mode": "hooks/shared/teammate_mode.py",
+      "typing.Optional": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_session_init_env_file.py": {
-      "session_init": "hooks/session_init.py"
+      "pathlib.Path": null,
+      "session_init": "hooks/session_init.py",
+      "unittest.mock.patch": null
     },
     "tests/test_session_init_integration.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "session_init": "hooks/session_init.py",
-      "shared": "hooks/shared/__init__.py"
+      "shared": "hooks/shared/__init__.py",
+      "shared.task_utils": "hooks/shared/task_utils.py",
+      "unittest.mock.patch": null
     },
     "tests/test_session_init_primary_frame_keeps_the_ladder.py": {
-      "session_init": "hooks/session_init.py"
+      "pathlib.Path": null,
+      "session_init": "hooks/session_init.py",
+      "session_init._UNKNOWN_ROLE_NOTICE": null,
+      "session_init._build_safety_net_context": null,
+      "unittest.mock.patch": null
     },
     "tests/test_session_init_role_suppression.py": {
       "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "fixtures.role_frames.lead_frame_qualified": null,
+      "fixtures.role_frames.lead_frame_unqualified": null,
+      "fixtures.role_frames.plain_frame": null,
+      "fixtures.role_frames.teammate_frame": null,
+      "pathlib.Path": null,
       "session_init": "hooks/session_init.py",
-      "shared.pact_context": "hooks/shared/pact_context.py"
+      "session_init.main": null,
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "unittest.mock.patch": null
     },
     "tests/test_session_init_routing_contract.py": {
+      "pathlib.Path": null,
       "session_init": "hooks/session_init.py",
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.ensure_project_memory_md": null,
+      "shared.claude_md_manager.migrate_to_managed_structure": null,
+      "shared.claude_md_manager.strip_orphan_kernel_block": null,
       "shared.session_resume": "hooks/shared/session_resume.py",
+      "shared.session_resume.check_resumption_context": null,
       "shared.symlinks": "hooks/shared/symlinks.py",
-      "staleness": "hooks/staleness.py"
+      "shared.symlinks.setup_plugin_symlinks": null,
+      "staleness": "hooks/staleness.py",
+      "staleness.check_pinned_staleness": null,
+      "unittest.mock.patch": null
     },
     "tests/test_session_init_teammate_peer_inject.py": {
       "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "fixtures.role_frames.lead_frame_qualified": null,
+      "fixtures.role_frames.lead_frame_unqualified": null,
+      "fixtures.role_frames.plain_frame": null,
+      "fixtures.role_frames.teammate_frame": null,
+      "pathlib.Path": null,
       "peer_inject": "hooks/peer_inject.py",
-      "session_init": "hooks/session_init.py"
+      "peer_inject.get_peer_context": null,
+      "session_init": "hooks/session_init.py",
+      "session_init.main": null,
+      "unittest.mock.patch": null
     },
-    "tests/test_session_init_teammate_peer_inject_acceptance.py": {},
+    "tests/test_session_init_teammate_peer_inject_acceptance.py": {
+      "pathlib.Path": null
+    },
     "tests/test_session_init_three_way_role_gate.py": {
-      "session_init": "hooks/session_init.py"
+      "pathlib.Path": null,
+      "session_init": "hooks/session_init.py",
+      "session_init._UNKNOWN_ROLE_NOTICE": null,
+      "session_init._build_safety_net_context": null,
+      "unittest.mock.patch": null
     },
     "tests/test_session_journal.py": {
       "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
+      "agent_handoff_emitter.main": null,
+      "datetime.datetime": null,
+      "datetime.timedelta": null,
+      "datetime.timezone": null,
+      "pathlib.Path": null,
       "session_end": "hooks/session_end.py",
+      "session_end.main": null,
       "session_init": "hooks/session_init.py",
+      "session_init._extract_prev_session_dir": null,
+      "session_init.main": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
       "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_journal._OPTIONAL_FIELDS_BY_TYPE": null,
+      "shared.session_journal._REQUIRED_FIELDS_BY_TYPE": null,
+      "shared.session_journal._TAIL_WINDOW_BYTES": null,
+      "shared.session_journal._atomic_write": null,
+      "shared.session_journal._read_last_event_at": null,
+      "shared.session_journal._ts_ge": null,
+      "shared.session_journal._validate_event_schema": null,
+      "shared.session_journal.append_event": null,
+      "shared.session_journal.get_journal_path": null,
+      "shared.session_journal.make_event": null,
+      "shared.session_journal.read_events": null,
+      "shared.session_journal.read_events_from": null,
+      "shared.session_journal.read_last_event": null,
+      "shared.session_journal.read_last_event_from": null,
       "shared.session_resume": "hooks/shared/session_resume.py",
-      "shared.variety_divergence": "hooks/shared/variety_divergence.py"
+      "shared.session_resume._build_journal_resume": null,
+      "shared.session_resume._check_journal_paused_state": null,
+      "shared.session_resume.check_paused_state": null,
+      "shared.session_resume.restore_last_session": null,
+      "shared.variety_divergence": "hooks/shared/variety_divergence.py",
+      "shared.variety_divergence.extract_dispatch_coverage": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_session_registry.py": {
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
       "shared.paths": "hooks/shared/paths.py",
-      "shared.session_registry": "hooks/shared/session_registry.py"
+      "shared.paths.get_claude_config_dir": null,
+      "shared.session_registry": "hooks/shared/session_registry.py",
+      "shared.session_registry.register": null,
+      "shared.session_registry.resolve": null
     },
     "tests/test_session_registry_concurrency.py": {
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
-      "shared.session_registry": "hooks/shared/session_registry.py"
+      "shared.session_registry": "hooks/shared/session_registry.py",
+      "shared.session_registry.resolve": null
     },
     "tests/test_session_registry_integrity.py": {
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
-      "shared.session_registry": "hooks/shared/session_registry.py"
+      "shared.session_registry": "hooks/shared/session_registry.py",
+      "shared.session_registry.register": null,
+      "shared.session_registry.resolve": null
     },
     "tests/test_session_registry_mode_gate.py": {
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
-      "shared.session_registry": "hooks/shared/session_registry.py"
+      "shared.session_registry": "hooks/shared/session_registry.py",
+      "shared.session_registry._read_lead_session_id": null,
+      "shared.session_registry.register": null,
+      "shared.session_registry.resolve": null
     },
     "tests/test_session_registry_trust_partition.py": {
+      "pathlib.Path": null,
       "session_end": "hooks/session_end.py",
+      "session_end._is_safe_team_segment": null,
       "shared": "hooks/shared/__init__.py",
       "shared.peer_context": "hooks/shared/peer_context.py",
-      "shared.session_registry": "hooks/shared/session_registry.py"
+      "shared.peer_context._sanitize_agent_name": null,
+      "shared.session_registry": "hooks/shared/session_registry.py",
+      "shared.session_registry._is_safe_team_segment": null,
+      "shared.session_registry._sanitize_agent_name": null,
+      "shared.session_registry.get_registry_path": null
     },
     "tests/test_session_resume.py": {
+      "__future__.annotations": null,
+      "datetime.datetime": null,
+      "datetime.timedelta": null,
+      "datetime.timezone": null,
+      "pathlib.Path": null,
       "session_init": "hooks/session_init.py",
+      "session_init._extract_prev_session_dir": null,
       "shared": "hooks/shared/__init__.py",
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.MANAGED_END_MARKER": null,
+      "shared.claude_md_manager.MANAGED_START_MARKER": null,
+      "shared.claude_md_manager.MEMORY_END_MARKER": null,
+      "shared.claude_md_manager.MEMORY_START_MARKER": null,
+      "shared.claude_md_manager.file_lock": null,
+      "shared.claude_md_manager.migrate_to_managed_structure": null,
       "shared.failure_cause": "hooks/shared/failure_cause.py",
+      "shared.failure_cause.failure_cause": null,
       "shared.session_journal": "hooks/shared/session_journal.py",
-      "shared.session_resume": "hooks/shared/session_resume.py"
+      "shared.session_journal.append_event": null,
+      "shared.session_journal.make_event": null,
+      "shared.session_resume": "hooks/shared/session_resume.py",
+      "shared.session_resume._REFRESH_FIELD_TRUNCATION_LIMIT": null,
+      "shared.session_resume._REFRESH_PATH_TRUNCATION_LIMIT": null,
+      "shared.session_resume._build_journal_resume": null,
+      "shared.session_resume._check_journal_paused_state": null,
+      "shared.session_resume._check_pr_state": null,
+      "shared.session_resume._compose_halt_line": null,
+      "shared.session_resume._interpret_paused_event": null,
+      "shared.session_resume._interpret_refreshed_event": null,
+      "shared.session_resume._pause_is_spent": null,
+      "shared.session_resume._refresh_is_spent": null,
+      "shared.session_resume.check_paused_state": null,
+      "shared.session_resume.check_resume_state": null,
+      "shared.session_resume.check_resumption_context": null,
+      "shared.session_resume.has_unspent_refresh": null,
+      "shared.session_resume.restore_last_session": null,
+      "shared.session_resume.update_session_info": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_session_state.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
       "shared.session_journal": "hooks/shared/session_journal.py",
-      "shared.session_state": "hooks/shared/session_state.py"
+      "shared.session_journal.make_event": null,
+      "shared.session_state": "hooks/shared/session_state.py",
+      "shared.session_state._default_state": null,
+      "shared.session_state._derive_feature_from_journal": null,
+      "shared.session_state._derive_phase_from_journal": null,
+      "shared.session_state._derive_variety_from_journal": null,
+      "shared.session_state._is_safe_path_component": null,
+      "shared.session_state._read_feature_subject_from_disk": null,
+      "shared.session_state._read_task_counts": null,
+      "shared.session_state._read_team_members": null,
+      "shared.session_state._sanitize_member_name": null,
+      "shared.session_state.is_safe_path_component": null,
+      "shared.session_state.summarize_session_state": null
     },
-    "tests/test_settings_example_json.py": {},
+    "tests/test_settings_example_json.py": {
+      "pathlib.Path": null
+    },
     "tests/test_settings_well_formed.py": {
       "fixtures.role_frames": "tests/fixtures/role_frames.py",
-      "session_init": "hooks/session_init.py"
+      "fixtures.role_frames.lead_frame_qualified": null,
+      "fixtures.role_frames.teammate_frame": null,
+      "pathlib.Path": null,
+      "session_init": "hooks/session_init.py",
+      "session_init.check_settings_well_formed": null,
+      "unittest.mock.patch": null
     },
     "tests/test_setup_memory.py": {
-      "scripts.setup_memory": "tests/../skills/pact-memory/scripts/setup_memory.py"
+      "scripts.setup_memory": "tests/../skills/pact-memory/scripts/setup_memory.py",
+      "scripts.setup_memory._get_recommendations": null,
+      "scripts.setup_memory.check_dependencies": null,
+      "scripts.setup_memory.ensure_directories": null,
+      "scripts.setup_memory.ensure_initialized": null,
+      "scripts.setup_memory.get_setup_status": null,
+      "unittest.mock.patch": null
     },
     "tests/test_shred_detect.py": {
+      "__future__.annotations": null,
       "memory_repair": "scripts/memory_repair/__init__.py",
-      "scripts.database": "tests/../skills/pact-memory/scripts/database.py"
+      "memory_repair.shred_detect": "scripts/memory_repair/shred_detect.py",
+      "pathlib.Path": null,
+      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database.LIST_FIELDS": null
     },
     "tests/test_skills_structure.py": {
-      "helpers": "tests/helpers.py"
+      "helpers": "tests/helpers.py",
+      "helpers.parse_frontmatter": null,
+      "pathlib.Path": null
     },
     "tests/test_snapshot_adversarial_matrix.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.agent_handoff_marker.occupant_hash": null,
       "shared.session_journal": "hooks/shared/session_journal.py",
-      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py"
+      "shared.session_journal.read_events": null,
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py",
+      "shared.task_metadata_snapshot.PAYLOAD_CAP": null,
+      "shared.task_metadata_snapshot.PER_VALUE_CAP": null,
+      "shared.task_metadata_snapshot._canonical_bytes": null,
+      "shared.task_metadata_snapshot.build_snapshot_payload": null,
+      "shared.task_metadata_snapshot.emit_task_metadata_snapshot": null,
+      "shared.task_metadata_snapshot.payload_hash8": null
     },
     "tests/test_snapshot_empty_team_dedup_cert.py": {
+      "pathlib.Path": null,
       "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.agent_handoff_marker.already_emitted": null,
+      "shared.agent_handoff_marker.unclaim": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
       "shared.session_journal": "hooks/shared/session_journal.py",
       "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py",
+      "shared.task_metadata_snapshot.SNAPSHOT_MARKER_NAMESPACE": null,
+      "shared.task_metadata_snapshot.emit_task_metadata_snapshot": null,
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_snapshot_key_count_discriminator.py": {
-      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py"
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py",
+      "shared.task_metadata_snapshot.PAYLOAD_CAP": null,
+      "shared.task_metadata_snapshot.PER_VALUE_CAP": null,
+      "shared.task_metadata_snapshot._canonical_bytes": null,
+      "shared.task_metadata_snapshot.build_snapshot_payload": null
     },
     "tests/test_snapshot_marker_root_fallback.py": {
+      "pathlib.Path": null,
       "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.agent_handoff_marker.already_emitted": null,
+      "shared.agent_handoff_marker.unclaim": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
       "shared.session_journal": "hooks/shared/session_journal.py",
-      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py"
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py",
+      "shared.task_metadata_snapshot.SNAPSHOT_MARKER_NAMESPACE": null,
+      "shared.task_metadata_snapshot.emit_task_metadata_snapshot": null
     },
     "tests/test_snapshot_provenance_semantics.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "shared.session_journal": "hooks/shared/session_journal.py",
-      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py"
+      "shared.session_journal.read_events": null,
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py",
+      "shared.task_metadata_snapshot.PAYLOAD_CAP": null,
+      "shared.task_metadata_snapshot.PER_VALUE_CAP": null,
+      "shared.task_metadata_snapshot._canonical_bytes": null,
+      "shared.task_metadata_snapshot.build_snapshot_payload": null,
+      "shared.task_metadata_snapshot.emit_task_metadata_snapshot": null
     },
     "tests/test_snapshot_roundtrip.py": {
+      "pathlib.Path": null,
       "shared.session_journal": "hooks/shared/session_journal.py",
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_snapshot_seam_emitter.py": {
       "fixtures.emitter": "tests/fixtures/emitter.py",
+      "fixtures.emitter.VALID_HANDOFF": null,
+      "fixtures.emitter._run_main": null,
       "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py"
     },
     "tests/test_snapshot_seams_gate.py": {
       "fixtures.emitter": "tests/fixtures/emitter.py",
+      "fixtures.emitter.VALID_HANDOFF": null,
+      "pathlib.Path": null,
       "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py",
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_snapshot_subprocess_seam.py": {
-      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py"
+      "__future__.annotations": null,
+      "pathlib.Path": null,
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.agent_handoff_marker.occupant_hash": null
     },
     "tests/test_spawn_overhead_benchmark.py": {
-      "peer_inject": "hooks/peer_inject.py"
+      "pathlib.Path": null,
+      "peer_inject": "hooks/peer_inject.py",
+      "peer_inject.get_peer_context": null
     },
     "tests/test_splice_window_memory_region.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.MEMORY_END_MARKER": null,
+      "shared.claude_md_manager.MEMORY_START_MARKER": null,
       "tests.test_pin_marker_writer": "tests/test_pin_marker_writer.py",
-      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+      "tests.test_pin_marker_writer.build_claude_md": null,
+      "unittest.mock.patch": null,
+      "working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "working_memory.sync_retrieved_to_claude_md": null,
+      "working_memory.sync_to_claude_md": null
     },
     "tests/test_stale_session.py": {
-      "shared.stale_session": "hooks/shared/stale_session.py"
+      "pathlib.Path": null,
+      "shared.stale_session": "hooks/shared/stale_session.py",
+      "shared.stale_session._RESUME_LINE_RE": null,
+      "shared.stale_session.detect_stale_session_block": null
     },
     "tests/test_staleness.py": {
+      "datetime.datetime": null,
+      "datetime.timedelta": null,
+      "pathlib.Path": null,
       "pin_caps": "hooks/pin_caps.py",
       "pin_caps_gate": "hooks/pin_caps_gate.py",
       "session_init": "hooks/session_init.py",
+      "session_init.PINNED_STALENESS_DAYS": null,
+      "session_init._estimate_tokens": null,
+      "session_init._get_project_claude_md_path": null,
+      "session_init.check_pinned_staleness": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.ContainmentError": null,
+      "shared.claude_md_manager.MANAGED_END_MARKER": null,
+      "shared.claude_md_manager.MANAGED_START_MARKER": null,
+      "shared.claude_md_manager.PACT_BOUNDARY_PREFIXES": null,
+      "shared.claude_md_manager.PINNED_START_MARKER": null,
+      "shared.claude_md_manager._DOT_CLAUDE_RELATIVE": null,
+      "shared.claude_md_manager._LEGACY_RELATIVE": null,
+      "shared.claude_md_manager._atomic_write_text": null,
+      "shared.claude_md_manager.file_lock": null,
+      "shared.claude_md_manager.resolve_project_claude_md_path": null,
       "shared.session_resume": "hooks/shared/session_resume.py",
+      "shared.session_resume._sanitize_prompt_field": null,
       "staleness": "hooks/staleness.py",
-      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+      "staleness.PINNED_CONTEXT_TOKEN_BUDGET": null,
+      "staleness.PINNED_STALENESS_DAYS": null,
+      "staleness._ANY_BUDGET_WARNING_RE": null,
+      "staleness._BUDGET_WARNING_PREFIX": null,
+      "staleness._BUDGET_WARNING_SHAPE": null,
+      "staleness._LEADING_BUDGET_WARNING_RE": null,
+      "staleness._parse_pinned_section": null,
+      "staleness.check_pinned_staleness": null,
+      "staleness.estimate_tokens": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null,
+      "working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "working_memory.ContainmentError": null,
+      "working_memory._atomic_write_text": null,
+      "working_memory._estimate_tokens": null,
+      "working_memory._project_root_of": null,
+      "working_memory._sanitize_prompt_field": null,
+      "working_memory.file_lock": null
     },
-    "tests/test_store_access_bar_presence.py": {},
+    "tests/test_store_access_bar_presence.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null
+    },
     "tests/test_store_scope_decorator_contract.py": {
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py"
+      "__future__.annotations": null,
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api.PACTMemory": null
     },
-    "tests/test_subagent_start_selects_teammate_frames.py": {},
+    "tests/test_subagent_start_selects_teammate_frames.py": {
+      "pathlib.Path": null
+    },
     "tests/test_symlinks.py": {
-      "shared.symlinks": "hooks/shared/symlinks.py"
+      "fnmatch.fnmatch": null,
+      "pathlib.Path": null,
+      "shared.symlinks": "hooks/shared/symlinks.py",
+      "shared.symlinks._SWAP_SUFFIX": null,
+      "shared.symlinks.setup_plugin_symlinks": null,
+      "unittest.mock.patch": null
     },
     "tests/test_sync_result_contract.py": {
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py"
+      "pathlib.Path": null,
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory.SyncResult": null
     },
     "tests/test_task_claim_gate.py": {
+      "pathlib.Path": null,
       "role_frames": "tests/fixtures/role_frames.py",
-      "task_claim_gate": "hooks/task_claim_gate.py"
+      "task_claim_gate": "hooks/task_claim_gate.py",
+      "unittest.mock.patch": null
     },
     "tests/test_task_id_sanitization_parity.py": {
       "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
+      "agent_handoff_emitter.sanitize_path_component": null,
       "fixtures.emitter": "tests/fixtures/emitter.py",
+      "fixtures.emitter.VALID_HANDOFF": null,
+      "fixtures.emitter._run_main": null,
+      "pathlib.Path": null,
       "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
       "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py",
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_task_integration.py": {
-      "shared.task_utils": "hooks/shared/task_utils.py"
+      "__future__.annotations": null,
+      "pathlib.Path": null,
+      "shared.task_utils": "hooks/shared/task_utils.py",
+      "shared.task_utils.build_post_compaction_checkpoint": null,
+      "shared.task_utils.find_active_agents": null,
+      "shared.task_utils.find_blockers": null,
+      "shared.task_utils.find_current_phase": null,
+      "shared.task_utils.find_feature_task": null,
+      "shared.task_utils.get_task_list": null,
+      "typing.Any": null
     },
     "tests/test_task_lifecycle_gate.py": {
+      "__future__.annotations": null,
+      "datetime.datetime": null,
+      "datetime.timezone": null,
+      "pathlib.Path": null,
       "shared.teachback_schema": "hooks/shared/teachback_schema.py",
-      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+      "shared.teachback_schema.TEACHBACK_SCHEMA_ECHO": null,
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py",
+      "unittest.mock.patch": null
     },
     "tests/test_task_lifecycle_gate_degraded.py": {
-      "tests.test_bootstrap_gate": "tests/test_bootstrap_gate.py"
+      "pathlib.Path": null,
+      "tests.test_bootstrap_gate": "tests/test_bootstrap_gate.py",
+      "tests.test_bootstrap_gate._BREAKAGE_VECTORS": null,
+      "tests.test_bootstrap_gate._find_python39": null
     },
     "tests/test_task_lifecycle_gate_smoke.py": {
-      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+      "__future__.annotations": null,
+      "pathlib.Path": null,
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py",
+      "unittest.mock.patch": null
     },
     "tests/test_task_metadata_snapshot.py": {
-      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py"
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py",
+      "shared.task_metadata_snapshot.HEAD_BYTES": null,
+      "shared.task_metadata_snapshot.PAYLOAD_CAP": null,
+      "shared.task_metadata_snapshot.PER_VALUE_CAP": null,
+      "shared.task_metadata_snapshot.SNAPSHOT_EXCLUDE": null,
+      "shared.task_metadata_snapshot._canonical_bytes": null,
+      "shared.task_metadata_snapshot._is_marker": null,
+      "shared.task_metadata_snapshot._utf8_safe_head": null,
+      "shared.task_metadata_snapshot.build_snapshot_payload": null,
+      "shared.task_metadata_snapshot.payload_hash8": null,
+      "shared.task_metadata_snapshot.snapshot_eligible": null
     },
     "tests/test_task_utils.py": {
-      "task_utils": "hooks/shared/task_utils.py"
+      "pathlib.Path": null,
+      "task_utils": "hooks/shared/task_utils.py",
+      "task_utils.find_active_agents": null,
+      "task_utils.find_blockers": null,
+      "task_utils.find_current_phase": null,
+      "task_utils.find_feature_task": null,
+      "task_utils.get_task_list": null,
+      "task_utils.read_task_json": null,
+      "unittest.mock.patch": null
     },
-    "tests/test_taskb_claim_prose_guard.py": {},
+    "tests/test_taskb_claim_prose_guard.py": {
+      "pathlib.Path": null
+    },
     "tests/test_teachback_reasoning_reconstruction.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "shared.intentional_wait": "hooks/shared/intentional_wait.py",
+      "shared.intentional_wait.TEACHBACK_EXEMPT_AGENT_TYPES": null,
       "shared.teachback_schema": "hooks/shared/teachback_schema.py",
+      "shared.teachback_schema.TEACHBACK_REQUIRED_SUBKEYS": null,
+      "shared.teachback_schema.validate_reasoning_reconstruction": null,
       "shared.variety_scorer": "hooks/shared/variety_scorer.py",
-      "test_skills_structure": "tests/test_skills_structure.py"
+      "shared.variety_scorer.COMPACT_MAX": null,
+      "shared.variety_scorer.ORCHESTRATE_MAX": null,
+      "shared.variety_scorer.PLAN_MODE_MAX": null,
+      "shared.variety_scorer.ROUTE_COMPACT": null,
+      "shared.variety_scorer.ROUTE_ORCHESTRATE": null,
+      "shared.variety_scorer.ROUTE_PLAN_MODE": null,
+      "shared.variety_scorer.ROUTE_RESEARCH_SPIKE": null,
+      "shared.variety_scorer.route_workflow": null,
+      "test_skills_structure": "tests/test_skills_structure.py",
+      "test_skills_structure.TestOrderingInvariantPhraseCount": null
     },
     "tests/test_teachback_schema.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null,
       "shared.teachback_schema": "hooks/shared/teachback_schema.py",
-      "shared.variety_scorer": "hooks/shared/variety_scorer.py"
+      "shared.teachback_schema.TEACHBACK_OBJECT_FIELDS": null,
+      "shared.teachback_schema.TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN": null,
+      "shared.teachback_schema.TEACHBACK_REQUIRED_FIELDS": null,
+      "shared.teachback_schema.TEACHBACK_REQUIRED_SUBKEYS": null,
+      "shared.teachback_schema.TEACHBACK_SCHEMA_ECHO": null,
+      "shared.teachback_schema.TEACHBACK_VARIETY_ACK_VALID_VALUES": null,
+      "shared.teachback_schema.resolve_variety_total": null,
+      "shared.teachback_schema.validate_reasoning_reconstruction": null,
+      "shared.variety_scorer": "hooks/shared/variety_scorer.py",
+      "shared.variety_scorer.MAX_DIMENSION": null,
+      "shared.variety_scorer.MAX_SCORE": null,
+      "shared.variety_scorer.MIN_DIMENSION": null,
+      "shared.variety_scorer.MIN_SCORE": null,
+      "shared.variety_scorer.ORCHESTRATE_MAX": null,
+      "shared.variety_scorer.PLAN_MODE_MAX": null,
+      "shared.variety_scorer.PLAN_MODE_MIN": null
     },
     "tests/test_teachback_subject_hoist_parity.py": {
+      "pathlib.Path": null,
       "shared.task_utils": "hooks/shared/task_utils.py",
+      "shared.task_utils.is_teachback_subject": null,
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_team_name_detect_align.py": {
       "bootstrap_marker_writer": "hooks/bootstrap_marker_writer.py",
       "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "fixtures.role_frames.lead_frame_qualified": null,
+      "pathlib.Path": null,
       "session_end": "hooks/session_end.py",
+      "session_end._assemble_tasks_skip_set": null,
+      "session_end.cleanup_old_tasks": null,
+      "session_end.cleanup_old_teams": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
       "shared.peer_context": "hooks/shared/peer_context.py",
+      "shared.peer_context.get_peer_context": null,
       "shared.session_state": "hooks/shared/session_state.py",
-      "shared.task_utils": "hooks/shared/task_utils.py"
+      "shared.session_state.is_safe_path_component": null,
+      "shared.task_utils": "hooks/shared/task_utils.py",
+      "shared.task_utils.iter_team_task_jsons": null
     },
     "tests/test_team_name_resolution_both_modes.py": {
       "dispatch_gate": "hooks/dispatch_gate.py",
+      "dispatch_gate.main": null,
+      "pathlib.Path": null,
       "session_init": "hooks/session_init.py",
+      "session_init.generate_team_name": null,
       "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py",
-      "shared.pact_context": "hooks/shared/pact_context.py"
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "unittest.mock.patch": null
     },
     "tests/test_team_registration_skill.py": {
-      "shared": "hooks/shared/__init__.py"
+      "pathlib.Path": null,
+      "shared": "hooks/shared/__init__.py",
+      "shared.session_registry": "hooks/shared/session_registry.py"
     },
     "tests/test_teammate_idle.py": {
-      "teammate_idle": "hooks/teammate_idle.py"
+      "pathlib.Path": null,
+      "teammate_idle": "hooks/teammate_idle.py",
+      "teammate_idle.check_idle_cleanup": null,
+      "teammate_idle.find_teammate_task": null,
+      "teammate_idle.main": null,
+      "teammate_idle.read_idle_counts": null,
+      "teammate_idle.reset_idle_count": null,
+      "teammate_idle.write_idle_counts": null,
+      "unittest.mock.patch": null
     },
     "tests/test_teammate_mode.py": {
-      "shared.teammate_mode": "hooks/shared/teammate_mode.py"
+      "pathlib.Path": null,
+      "shared.teammate_mode": "hooks/shared/teammate_mode.py",
+      "shared.teammate_mode.VALID_TEAMMATE_MODES": null,
+      "shared.teammate_mode._managed_settings_path": null,
+      "shared.teammate_mode._read_teammate_mode": null,
+      "shared.teammate_mode._settings_source_paths": null,
+      "shared.teammate_mode.resolve_effective_teammate_mode": null,
+      "shared.teammate_mode.should_emit_inprocess_notice": null
     },
     "tests/test_telegram_client.py": {
-      "telegram.telegram_client": "telegram/telegram_client.py"
+      "pathlib.Path": null,
+      "telegram.telegram_client": "telegram/telegram_client.py",
+      "telegram.telegram_client.TelegramAPIError": null,
+      "telegram.telegram_client.TelegramClient": null,
+      "unittest.mock.AsyncMock": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_telegram_config.py": {
-      "telegram.config": "telegram/config.py"
+      "pathlib.Path": null,
+      "telegram.config": "telegram/config.py",
+      "telegram.config.ConfigError": null,
+      "telegram.config.DEFAULT_MODE": null,
+      "telegram.config.check_file_permissions": null,
+      "telegram.config.check_not_in_git": null,
+      "telegram.config.ensure_config_dir": null,
+      "telegram.config.load_config": null,
+      "telegram.config.load_config_safe": null,
+      "telegram.config.parse_env_file": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_telegram_content_filter.py": {
-      "telegram.content_filter": "telegram/content_filter.py"
+      "pathlib.Path": null,
+      "telegram.content_filter": "telegram/content_filter.py",
+      "telegram.content_filter.MAX_INBOUND_LENGTH": null,
+      "telegram.content_filter.TELEGRAM_MAX_MESSAGE_LENGTH": null,
+      "telegram.content_filter.filter_and_truncate": null,
+      "telegram.content_filter.filter_outbound": null,
+      "telegram.content_filter.sanitize_inbound": null,
+      "telegram.content_filter.truncate_message": null
     },
     "tests/test_telegram_deps.py": {
-      "telegram.deps": "telegram/deps.py"
+      "pathlib.Path": null,
+      "telegram.deps": "telegram/deps.py",
+      "telegram.deps.REQUIRED_PACKAGES": null,
+      "telegram.deps.check_dependencies": null,
+      "telegram.deps.get_dependency_status": null,
+      "telegram.deps.get_optional_dependency_status": null,
+      "telegram.deps.install_dependencies": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_telegram_main.py": {
-      "telegram.__main__": "telegram/__main__.py"
+      "pathlib.Path": null,
+      "telegram.__main__": "telegram/__main__.py",
+      "telegram.__main__.main": null,
+      "types.ModuleType": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_telegram_notify.py": {
-      "telegram.notify": "telegram/notify.py"
+      "pathlib.Path": null,
+      "telegram.notify": "telegram/notify.py",
+      "telegram.notify._build_session_summary": null,
+      "telegram.notify._filter_message": null,
+      "telegram.notify._get_project_name": null,
+      "telegram.notify._parse_env": null,
+      "telegram.notify.main": null,
+      "telegram.notify.send_notification": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_telegram_routing.py": {
+      "pathlib.Path": null,
       "telegram.config": "telegram/config.py",
-      "telegram.routing": "telegram/routing.py"
+      "telegram.config.get_or_create_session_id": null,
+      "telegram.routing": "telegram/routing.py",
+      "telegram.routing.DirectRouter": null,
+      "telegram.routing.FileBasedRouter": null,
+      "telegram.routing.MAX_ROUTING_TABLE_ENTRIES": null,
+      "telegram.routing.READER_POLL_INTERVAL": null,
+      "telegram.routing.STALE_SESSION_TTL": null,
+      "telegram.routing.count_active_sessions": null,
+      "telegram.routing.register_session": null,
+      "telegram.routing.unregister_session": null,
+      "unittest.mock.AsyncMock": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_telegram_server.py": {
+      "pathlib.Path": null,
       "telegram.routing": "telegram/routing.py",
+      "telegram.routing.DirectRouter": null,
       "telegram.server": "telegram/server.py",
+      "telegram.server.ERROR_BACKOFF": null,
+      "telegram.server._extract_message_id": null,
+      "telegram.server._polling_loop": null,
+      "telegram.server._process_update": null,
+      "telegram.server.create_server": null,
+      "telegram.server.lifespan": null,
       "telegram.tools": "telegram/tools.py",
-      "telegram.voice": "telegram/voice.py"
+      "telegram.tools.ToolContext": null,
+      "telegram.voice": "telegram/voice.py",
+      "telegram.voice.VoiceTranscriptionError": null,
+      "types.ModuleType": null,
+      "unittest.mock.AsyncMock": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_telegram_tools.py": {
+      "pathlib.Path": null,
       "telegram.telegram_client": "telegram/telegram_client.py",
-      "telegram.tools": "telegram/tools.py"
+      "telegram.telegram_client.TelegramAPIError": null,
+      "telegram.tools": "telegram/tools.py",
+      "telegram.tools.ASK_REPLY_HINT": null,
+      "telegram.tools.DEFAULT_ASK_TIMEOUT": null,
+      "telegram.tools.MAX_BUTTONS": null,
+      "telegram.tools.MAX_PENDING_REPLIES": null,
+      "telegram.tools.MAX_SENT_NOTIFICATIONS": null,
+      "telegram.tools.NOTIFICATION_SNIPPET_LENGTH": null,
+      "telegram.tools.NOTIFY_RATE_LIMIT": null,
+      "telegram.tools.NOTIFY_RATE_WINDOW": null,
+      "telegram.tools.QueuedReply": null,
+      "telegram.tools.REPLY_QUEUE_MAX_SIZE": null,
+      "telegram.tools.REPLY_QUEUE_TTL": null,
+      "telegram.tools.STALE_FUTURE_BUFFER": null,
+      "telegram.tools.ToolContext": null,
+      "telegram.tools._get_project_name": null,
+      "telegram.tools._prepend_session_prefix": null,
+      "telegram.tools.get_context": null,
+      "telegram.tools.tool_telegram_ask": null,
+      "telegram.tools.tool_telegram_check_replies": null,
+      "telegram.tools.tool_telegram_notify": null,
+      "telegram.tools.tool_telegram_status": null,
+      "unittest.mock.AsyncMock": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_telegram_voice.py": {
-      "telegram.voice": "telegram/voice.py"
+      "pathlib.Path": null,
+      "telegram.voice": "telegram/voice.py",
+      "telegram.voice.MAX_VOICE_FILE_SIZE": null,
+      "telegram.voice.VoiceTranscriber": null,
+      "telegram.voice.VoiceTranscriptionError": null,
+      "unittest.mock.AsyncMock": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
-    "tests/test_testing_craft_pins.py": {},
-    "tests/test_three_surface_split_enforcement.py": {},
+    "tests/test_testing_craft_pins.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null
+    },
+    "tests/test_three_surface_split_enforcement.py": {
+      "pathlib.Path": null
+    },
     "tests/test_token_budget.py": {
-      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+      "pathlib.Path": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null,
+      "working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "working_memory.COMPRESSED_ENTRY_TOKEN_CEILING": null,
+      "working_memory.MAX_WORKING_MEMORIES": null,
+      "working_memory.SyncResult": null,
+      "working_memory.WORKING_MEMORY_TOKEN_BUDGET": null,
+      "working_memory._apply_token_budget": null,
+      "working_memory._compress_memory_entry": null,
+      "working_memory._estimate_tokens": null,
+      "working_memory._find_existing_claude_md": null,
+      "working_memory._format_memory_entry": null,
+      "working_memory._format_retrieved_entry": null,
+      "working_memory._get_claude_md_path": null,
+      "working_memory._parse_retrieved_context_section": null,
+      "working_memory._parse_working_memory_section": null,
+      "working_memory.sync_retrieved_to_claude_md": null,
+      "working_memory.sync_to_claude_md": null
     },
     "tests/test_token_budget_constants_coupling.py": {
-      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+      "pathlib.Path": null,
+      "unittest.mock.patch": null,
+      "working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "working_memory.COMPRESSED_ENTRY_TOKEN_CEILING": null,
+      "working_memory.COMPRESSED_SUMMARY_CHAR_CAP": null,
+      "working_memory.MAX_RETRIEVED_MEMORIES": null,
+      "working_memory.MAX_WORKING_MEMORIES": null,
+      "working_memory.RETRIEVED_CONTEXT_COMMENT": null,
+      "working_memory.RETRIEVED_CONTEXT_TOKEN_BUDGET": null,
+      "working_memory.WORKING_MEMORY_COMMENT": null,
+      "working_memory.WORKING_MEMORY_TOKEN_BUDGET": null,
+      "working_memory._MANAGED_END_MARKER": null,
+      "working_memory._MANAGED_START_MARKER": null,
+      "working_memory._MEMORY_ID_LABEL": null,
+      "working_memory._REFRESH_FIELD_TRUNCATION_LIMIT": null,
+      "working_memory._REFRESH_IDENTIFIER_TRUNCATION_LIMIT": null,
+      "working_memory._SESSION_END_MARKER": null,
+      "working_memory._apply_entry_token_ceiling": null,
+      "working_memory._apply_token_budget": null,
+      "working_memory._compress_memory_entry": null,
+      "working_memory._estimate_tokens": null,
+      "working_memory._format_memory_entry": null,
+      "working_memory._format_retrieved_entry": null,
+      "working_memory._parse_retrieved_context_section": null,
+      "working_memory.sync_retrieved_to_claude_md": null,
+      "working_memory.sync_to_claude_md": null
     },
     "tests/test_tool_response.py": {
-      "shared.tool_response": "hooks/shared/tool_response.py"
+      "pathlib.Path": null,
+      "shared.tool_response": "hooks/shared/tool_response.py",
+      "shared.tool_response.extract_tool_response": null
     },
     "tests/test_track_files.py": {
-      "track_files": "hooks/track_files.py"
+      "datetime.datetime": null,
+      "pathlib.Path": null,
+      "track_files": "hooks/track_files.py",
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_validate_handoff.py": {
-      "validate_handoff": "hooks/validate_handoff.py"
+      "pathlib.Path": null,
+      "unittest.mock.patch": null,
+      "validate_handoff": "hooks/validate_handoff.py",
+      "validate_handoff.check_lossless_fields": null,
+      "validate_handoff.declares_signal_completion": null,
+      "validate_handoff.is_pact_agent": null,
+      "validate_handoff.main": null,
+      "validate_handoff.validate_handoff": null
     },
     "tests/test_validate_handoff_integration.py": {
+      "pathlib.Path": null,
       "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_journal.read_events": null,
+      "unittest.mock.patch": null,
       "validate_handoff": "hooks/validate_handoff.py"
     },
     "tests/test_variety_divergence.py": {
+      "pathlib.Path": null,
       "shared.session_journal": "hooks/shared/session_journal.py",
-      "shared.variety_divergence": "hooks/shared/variety_divergence.py"
+      "shared.session_journal.make_event": null,
+      "shared.variety_divergence": "hooks/shared/variety_divergence.py",
+      "shared.variety_divergence._latest_snapshot_by_task": null,
+      "shared.variety_divergence._parse_ts": null,
+      "shared.variety_divergence.compute_variety_divergence": null,
+      "shared.variety_divergence.extract_dispatch_coverage": null,
+      "shared.variety_divergence.extract_final_dispatch_coverage": null,
+      "shared.variety_divergence.resolve_arc_start": null
     },
-    "tests/test_variety_rationale_contamination.py": {},
+    "tests/test_variety_rationale_contamination.py": {
+      "pathlib.Path": null
+    },
     "tests/test_variety_scorer.py": {
-      "shared.variety_scorer": "hooks/shared/variety_scorer.py"
+      "pathlib.Path": null,
+      "shared.variety_scorer": "hooks/shared/variety_scorer.py",
+      "shared.variety_scorer.COMPACT_MAX": null,
+      "shared.variety_scorer.DIMENSION_COUNT": null,
+      "shared.variety_scorer.LEARNING_II_MAX_BUMP": null,
+      "shared.variety_scorer.LEARNING_II_MIN_MATCHES": null,
+      "shared.variety_scorer.MAX_DIMENSION": null,
+      "shared.variety_scorer.MAX_SCORE": null,
+      "shared.variety_scorer.MIN_DIMENSION": null,
+      "shared.variety_scorer.MIN_SCORE": null,
+      "shared.variety_scorer.ORCHESTRATE_MAX": null,
+      "shared.variety_scorer.PLAN_MODE_MAX": null,
+      "shared.variety_scorer.ROUTE_COMPACT": null,
+      "shared.variety_scorer.ROUTE_ORCHESTRATE": null,
+      "shared.variety_scorer.ROUTE_PLAN_MODE": null,
+      "shared.variety_scorer.ROUTE_RESEARCH_SPIKE": null,
+      "shared.variety_scorer.route_workflow": null,
+      "shared.variety_scorer.score_variety": null,
+      "shared.variety_scorer.validate_dimension": null
     },
     "tests/test_variety_scorer_fuzz.py": {
       "hypothesis": null,
-      "shared.variety_scorer": "hooks/shared/variety_scorer.py"
+      "hypothesis.given": null,
+      "hypothesis.settings": null,
+      "hypothesis.strategies": null,
+      "pathlib.Path": null,
+      "shared.variety_scorer": "hooks/shared/variety_scorer.py",
+      "shared.variety_scorer.COMPACT_MAX": null,
+      "shared.variety_scorer.MAX_DIMENSION": null,
+      "shared.variety_scorer.MAX_SCORE": null,
+      "shared.variety_scorer.MIN_DIMENSION": null,
+      "shared.variety_scorer.MIN_SCORE": null,
+      "shared.variety_scorer.ORCHESTRATE_MAX": null,
+      "shared.variety_scorer.PLAN_MODE_MAX": null,
+      "shared.variety_scorer.ROUTE_COMPACT": null,
+      "shared.variety_scorer.ROUTE_ORCHESTRATE": null,
+      "shared.variety_scorer.ROUTE_PLAN_MODE": null,
+      "shared.variety_scorer.ROUTE_RESEARCH_SPIKE": null,
+      "shared.variety_scorer.route_workflow": null,
+      "shared.variety_scorer.score_variety": null
     },
     "tests/test_vector_dimension_fixes.py": {
+      "pathlib.Path": null,
       "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
       "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
       "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database._check_and_migrate_vector_table": null,
+      "scripts.database.create_memory": null,
+      "scripts.database.ensure_initialized": null,
+      "scripts.database.get_connection": null,
+      "scripts.database.get_memory": null,
+      "scripts.database.init_schema": null,
+      "scripts.database.search_memories_by_text": null,
       "scripts.embeddings": "tests/../skills/pact-memory/scripts/embeddings.py",
+      "scripts.embeddings.EMBEDDING_DIM": null,
+      "scripts.embeddings.check_embedding_availability": null,
+      "scripts.embeddings.generate_embedding_text": null,
       "scripts.memory_init": "tests/../skills/pact-memory/scripts/memory_init.py",
-      "scripts.search": "tests/../skills/pact-memory/scripts/search.py"
+      "scripts.memory_init.maybe_migrate_embeddings": null,
+      "scripts.memory_init.reset_initialization": null,
+      "scripts.search": "tests/../skills/pact-memory/scripts/search.py",
+      "scripts.search.get_search_capabilities": null,
+      "scripts.search.vector_search": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
     "tests/test_vector_write_path.py": {
+      "__future__.annotations": null,
       "helpers": "tests/helpers.py",
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py"
+      "helpers.create_test_schema": null,
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api.PACTMemory": null,
+      "unittest.mock.patch": null
     },
-    "tests/test_verify_gate_tree.py": {},
+    "tests/test_verify_gate_tree.py": {
+      "__future__.annotations": null,
+      "pathlib.Path": null
+    },
     "tests/test_wait_discipline_layers_pinned.py": {
-      "test_wake_ordering_pinned": "tests/test_wake_ordering_pinned.py"
+      "pathlib.Path": null,
+      "test_wake_ordering_pinned": "tests/test_wake_ordering_pinned.py",
+      "test_wake_ordering_pinned._lines_outside_fences": null,
+      "test_wake_ordering_pinned._phrase": null
     },
-    "tests/test_wait_discipline_pins.py": {},
+    "tests/test_wait_discipline_pins.py": {
+      "pathlib.Path": null
+    },
     "tests/test_wait_filler_gate.py": {
+      "pathlib.Path": null,
       "shared.hook_infra_classifier": "hooks/shared/hook_infra_classifier.py",
-      "wait_filler_gate": "hooks/wait_filler_gate.py"
+      "shared.hook_infra_classifier.SEAM_DEPENDENT_HOOKS": null,
+      "unittest.mock.patch": null,
+      "wait_filler_gate": "hooks/wait_filler_gate.py",
+      "wait_filler_gate.main": null
     },
-    "tests/test_wake_ordering_pinned.py": {},
+    "tests/test_wake_ordering_pinned.py": {
+      "pathlib.Path": null
+    },
     "tests/test_window_rule_decline.py": {
+      "pathlib.Path": null,
       "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+      "scripts.cli": "tests/../skills/pact-memory/scripts/cli.py",
+      "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
+      "unittest.mock.patch": null,
+      "working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "working_memory.MEMORY_END_MARKER": null,
+      "working_memory.MEMORY_START_MARKER": null,
+      "working_memory.SyncResult": null,
+      "working_memory._MANAGED_END_MARKER": null,
+      "working_memory._MANAGED_START_MARKER": null,
+      "working_memory._SESSION_END_MARKER": null,
+      "working_memory._resolve_write_window": null,
+      "working_memory.sync_retrieved_to_claude_md": null,
+      "working_memory.sync_to_claude_md": null
     },
     "tests/test_working_memory.py": {
+      "pathlib.Path": null,
       "pin_staleness_gate": "hooks/pin_staleness_gate.py",
+      "pin_staleness_gate._DATE_LED_HEADING_RE": null,
       "working_memory": "skills/pact-memory/scripts/working_memory.py"
     },
     "tests/test_working_memory_concurrency.py": {
+      "contextlib.contextmanager": null,
+      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.file_lock": null,
       "working_memory": "skills/pact-memory/scripts/working_memory.py"
     },
     "tests/test_working_memory_concurrency_comprehensive.py": {
+      "importlib.import_module": null,
+      "pathlib.Path": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.file_lock": null,
       "test_staleness": "tests/test_staleness.py",
-      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+      "test_staleness.TestFileLockTwinCopyDrift": null,
+      "working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "working_memory.file_lock": null
     },
     "tests/test_working_memory_fidelity.py": {
       "helpers": "tests/helpers.py",
+      "helpers.create_test_schema": null,
+      "pathlib.Path": null,
       "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
-      "test_memory_cli": "tests/test_memory_cli.py"
+      "scripts.working_memory.MAX_WORKING_MEMORIES": null,
+      "scripts.working_memory.SyncResult": null,
+      "scripts.working_memory.project_memories_to_claude_md": null,
+      "test_memory_cli": "tests/test_memory_cli.py",
+      "test_memory_cli._backdate": null
     },
     "tests/test_working_memory_parser.py": {
       "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
-      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py"
+      "scripts.working_memory.RETRIEVED_CONTEXT_HEADER": null,
+      "scripts.working_memory.WORKING_MEMORY_HEADER": null,
+      "scripts.working_memory._PACT_BOUNDARY_ALT": null,
+      "scripts.working_memory._SESSION_BOUNDARY_ALT": null,
+      "scripts.working_memory._parse_retrieved_context_section": null,
+      "scripts.working_memory._parse_working_memory_section": null,
+      "scripts.working_memory.extract_managed_region": null,
+      "scripts.working_memory.sync_retrieved_to_claude_md": null,
+      "scripts.working_memory.sync_to_claude_md": null,
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.PACT_BOUNDARY_PREFIXES": null,
+      "shared.claude_md_manager.SESSION_BOUNDARY_PREFIX": null,
+      "shared.claude_md_manager._build_migrated_content": null,
+      "shared.claude_md_manager.extract_managed_region": null,
+      "shared.claude_md_manager.migrate_to_managed_structure": null
     },
     "tests/test_working_memory_projection.py": {
+      "datetime.datetime": null,
+      "datetime.timedelta": null,
+      "datetime.timezone": null,
+      "pathlib.Path": null,
       "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py"
+      "scripts.memory_api.PACTMemory": null,
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory.MAX_WORKING_MEMORIES": null,
+      "scripts.working_memory.SyncResult": null,
+      "scripts.working_memory.WORKING_MEMORY_TOKEN_BUDGET": null,
+      "scripts.working_memory._estimate_tokens": null,
+      "scripts.working_memory._format_memory_entry": null,
+      "scripts.working_memory._record_timestamp": null,
+      "scripts.working_memory.project_memories_to_claude_md": null
     },
     "tests/test_working_memory_redirected_store_refusal.py": {
+      "pathlib.Path": null,
       "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py"
+      "scripts.config.STORE_ORIGIN_ENV": null,
+      "scripts.config.STORE_ORIGIN_HOME": null,
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory.AmbientSyncRefused": null,
+      "scripts.working_memory.SyncResult": null,
+      "scripts.working_memory._refuse_ambient_sync_from_a_redirected_store": null,
+      "scripts.working_memory._target_is_inside_the_declared_project_dir": null
     },
     "tests/test_working_memory_resolver_and_lock_release.py": {
+      "pathlib.Path": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.claude_md_manager.resolve_project_claude_md_path": null,
       "working_memory": "skills/pact-memory/scripts/working_memory.py"
     },
     "tests/test_working_memory_worktree_sync.py": {
+      "pathlib.Path": null,
       "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py"
+      "scripts.memory_api.PACTMemory": null,
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory.SyncResult": null,
+      "scripts.working_memory._project_root_of": null,
+      "scripts.working_memory._resolve_display_claude_md_path": null,
+      "scripts.working_memory.project_memories_to_claude_md": null,
+      "scripts.working_memory.sync_retrieved_to_claude_md": null,
+      "scripts.working_memory.sync_to_claude_md": null,
+      "unittest.mock.MagicMock": null,
+      "unittest.mock.patch": null
     },
-    "tests/test_worktree_cleanup_docs_probe.py": {},
+    "tests/test_worktree_cleanup_docs_probe.py": {
+      "pathlib.Path": null
+    },
     "tests/test_worktree_guard.py": {
-      "worktree_guard": "hooks/worktree_guard.py"
+      "pathlib.Path": null,
+      "unittest.mock.patch": null,
+      "worktree_guard": "hooks/worktree_guard.py",
+      "worktree_guard._suggest_worktree_path": null,
+      "worktree_guard.check_worktree_boundary": null,
+      "worktree_guard.is_allowed_path": null,
+      "worktree_guard.is_application_code": null,
+      "worktree_guard.main": null
     },
-    "tests/test_wrapup_datasafety_contracts.py": {}
+    "tests/test_wrapup_datasafety_contracts.py": {
+      "pathlib.Path": null
+    }
   },
   "path_drift_since_sessionstart": [
-    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory",
-    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory",
-    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks/shared",
-    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/fixtures",
-    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory",
-    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory",
-    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../scripts",
-    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory/scripts",
-    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory",
-    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-handoff-harvest",
-    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-agent-teams"
+    "/private/tmp/baseline-regen/pact-plugin/skills/pact-memory",
+    "/private/tmp/baseline-regen/pact-plugin/skills/pact-memory",
+    "/private/tmp/baseline-regen/pact-plugin/hooks/shared",
+    "/private/tmp/baseline-regen/pact-plugin/tests/fixtures",
+    "/private/tmp/baseline-regen/pact-plugin/skills/pact-memory",
+    "/private/tmp/baseline-regen/pact-plugin/skills/pact-memory",
+    "/private/tmp/baseline-regen/pact-plugin/tests/../scripts",
+    "/private/tmp/baseline-regen/pact-plugin/tests/../skills/pact-memory/scripts",
+    "/private/tmp/baseline-regen/pact-plugin/skills/pact-memory",
+    "/private/tmp/baseline-regen/pact-plugin/skills/pact-handoff-harvest",
+    "/private/tmp/baseline-regen/pact-plugin/skills/pact-agent-teams"
   ]
 }

--- a/pact-plugin/tests/import_identity_baseline.json
+++ b/pact-plugin/tests/import_identity_baseline.json
@@ -59,7 +59,7 @@
       "helpers.make_pin_entry": null,
       "pathlib.Path": null,
       "pin_caps": "hooks/pin_caps.py",
-      "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
+      "scripts.config": "skills/pact-memory/scripts/config.py",
       "scripts.config.MEMORY_DIR_ENV": null,
       "scripts.config.STORE_ORIGIN_HOME": null,
       "scripts.config.resolve_db_path": null,
@@ -190,16 +190,16 @@
       "__future__.annotations": null,
       "helpers": "tests/helpers.py",
       "helpers.create_test_schema": null,
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api": "skills/pact-memory/scripts/memory_api.py",
       "scripts.memory_api.PACTMemory": null,
       "unittest.mock.patch": null
     },
     "tests/test_caller_path_is_not_created.py": {
       "__future__.annotations": null,
       "pathlib.Path": null,
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.cli": "tests/../skills/pact-memory/scripts/cli.py",
-      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.cli": "skills/pact-memory/scripts/cli.py",
+      "scripts.database": "skills/pact-memory/scripts/database.py",
       "scripts.database.get_connection": null
     },
     "tests/test_canary_checklist_count.py": {
@@ -220,8 +220,8 @@
     },
     "tests/test_catchup_reason_is_read.py": {
       "__future__.annotations": null,
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.embedding_catchup": "tests/../skills/pact-memory/scripts/embedding_catchup.py",
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.embedding_catchup": "skills/pact-memory/scripts/embedding_catchup.py",
       "unittest.mock.patch": null
     },
     "tests/test_check_pin_caps.py": {
@@ -244,9 +244,9 @@
       "pathlib.Path": null
     },
     "tests/test_ci_env_truthiness.py": {
-      "memory_init": "tests/../skills/pact-memory/scripts/memory_init.py",
-      "memory_init._ci_is_declared": null,
-      "memory_init.check_and_install_dependencies": null,
+      "scripts.memory_init": "skills/pact-memory/scripts/memory_init.py",
+      "scripts.memory_init._ci_is_declared": null,
+      "scripts.memory_init.check_and_install_dependencies": null,
       "unittest.mock.MagicMock": null,
       "unittest.mock.patch": null
     },
@@ -274,16 +274,16 @@
     },
     "tests/test_claude_md_resolver_parity.py": {
       "pathlib.Path": null,
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api": "skills/pact-memory/scripts/memory_api.py",
       "scripts.memory_api.PACTMemory": null,
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory._get_claude_md_path": null,
+      "scripts.working_memory._resolve_display_claude_md_path": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
       "shared.claude_md_manager.resolve_project_claude_md_path": null,
       "staleness": "hooks/staleness.py",
       "staleness.get_project_claude_md_path": null,
-      "typing.Optional": null,
-      "working_memory": "skills/pact-memory/scripts/working_memory.py",
-      "working_memory._get_claude_md_path": null,
-      "working_memory._resolve_display_claude_md_path": null
+      "typing.Optional": null
     },
     "tests/test_claudemd_write_prohibition_guard.py": {
       "pathlib.Path": null
@@ -306,7 +306,6 @@
       "pathlib.Path": null
     },
     "tests/test_compact_summary_session_scope.py": {
-      "pathlib.Path": null,
       "postcompact_archive": "hooks/postcompact_archive.py",
       "postcompact_archive.main": null,
       "session_init": "hooks/session_init.py",
@@ -368,25 +367,26 @@
     },
     "tests/test_connection_transaction_mode.py": {
       "__future__.annotations": null,
-      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database": "skills/pact-memory/scripts/database.py",
       "scripts.database.get_connection": null,
       "scripts.database.sqlite3": null
     },
     "tests/test_containment_certification.py": {
       "__future__.annotations": null,
       "pathlib.Path": null,
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
       "session_init": "hooks/session_init.py",
       "session_init.check_pinned_staleness": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
       "shared.claude_md_manager.migrate_to_managed_structure": null,
       "shared.session_resume": "hooks/shared/session_resume.py",
       "shared.session_resume.update_session_info": null,
-      "unittest.mock.patch": null,
-      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+      "unittest.mock.patch": null
     },
     "tests/test_containment_guard.py": {
       "pathlib.Path": null,
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
       "session_init": "hooks/session_init.py",
       "session_init.check_pinned_staleness": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
@@ -412,8 +412,7 @@
       "helpers.create_test_schema": null,
       "memory_repair": "scripts/memory_repair/__init__.py",
       "memory_repair.shred_detect": "scripts/memory_repair/shred_detect.py",
-      "pathlib.Path": null,
-      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database": "skills/pact-memory/scripts/database.py",
       "scripts.database.DICT_LIST_FIELDS": null,
       "scripts.database.LIST_FIELDS": null,
       "scripts.database.create_memory": null,
@@ -431,9 +430,9 @@
     },
     "tests/test_declared_anchor_contract.py": {
       "pathlib.Path": null,
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.cli": "tests/../skills/pact-memory/scripts/cli.py",
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.cli": "skills/pact-memory/scripts/cli.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
       "scripts.working_memory.ContainmentError": null,
       "scripts.working_memory.SyncResult": null,
       "scripts.working_memory._atomic_write_text": null,
@@ -497,7 +496,6 @@
     "tests/test_dispatch_gate_stale_diagnosis.py": {
       "dispatch_gate": "hooks/dispatch_gate.py",
       "dispatch_gate._STALE_REALIGN_HINT": null,
-      "pathlib.Path": null,
       "shared.pact_context": "hooks/shared/pact_context.py",
       "test_dispatch_gate": "tests/test_dispatch_gate.py",
       "test_dispatch_gate._TEAM": null,
@@ -507,7 +505,6 @@
       "test_dispatch_gate._seed_team": null
     },
     "tests/test_dispatch_helpers.py": {
-      "pathlib.Path": null,
       "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py",
       "shared.dispatch_helpers.is_owner_bearing_write": null,
       "shared.dispatch_helpers.is_owner_wiring_shape": null,
@@ -526,7 +523,6 @@
       "pathlib.Path": null
     },
     "tests/test_dispatch_variety_teachback_ack_emit.py": {
-      "pathlib.Path": null,
       "shared.session_journal": "hooks/shared/session_journal.py",
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
@@ -542,12 +538,12 @@
       "pathlib.Path": null
     },
     "tests/test_embedding_catchup.py": {
-      "embeddings": "skills/pact-memory/scripts/embeddings.py",
-      "embeddings.MIN_CATCHUP_RAM_MB": null,
-      "embeddings.generate_embedding": null,
-      "embeddings.generate_embedding_text": null,
       "io.StringIO": null,
       "pathlib.Path": null,
+      "scripts.embeddings": "skills/pact-memory/scripts/embeddings.py",
+      "scripts.embeddings.MIN_CATCHUP_RAM_MB": null,
+      "scripts.embeddings.generate_embedding": null,
+      "scripts.embeddings.generate_embedding_text": null,
       "types.ModuleType": null,
       "unittest.mock.MagicMock": null,
       "unittest.mock.patch": null
@@ -555,9 +551,9 @@
     "tests/test_embedding_status_contract.py": {
       "__future__.annotations": null,
       "pathlib.Path": null,
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.cli": "tests/../skills/pact-memory/scripts/cli.py",
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.cli": "skills/pact-memory/scripts/cli.py",
+      "scripts.memory_api": "skills/pact-memory/scripts/memory_api.py",
       "scripts.memory_api.PACTMemory": null,
       "types.SimpleNamespace": null,
       "unittest.mock.MagicMock": null,
@@ -567,21 +563,20 @@
     "tests/test_embedding_status_wiring.py": {
       "__future__.annotations": null,
       "pathlib.Path": null,
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.memory_api": "skills/pact-memory/scripts/memory_api.py",
       "scripts.memory_api.PACTMemory": null,
       "unittest.mock.patch": null
     },
     "tests/test_embedding_window.py": {
       "__future__.annotations": null,
       "pathlib.Path": null,
-      "scripts.embeddings": "tests/../skills/pact-memory/scripts/embeddings.py",
+      "scripts.embeddings": "skills/pact-memory/scripts/embeddings.py",
       "scripts.embeddings.EMBEDDING_MAX_TOKENS": null,
       "scripts.embeddings.EmbeddingService": null,
       "scripts.embeddings.MEASURED_MEDIAN_TOKENS": null
     },
     "tests/test_emit_skip_accounting.py": {
-      "pathlib.Path": null,
       "shared.session_journal": "hooks/shared/session_journal.py",
       "shared.session_journal.SKIP_CAUSE_RAISED": null,
       "shared.session_journal.SKIP_CAUSE_RETURNED_FALSE": null,
@@ -657,8 +652,7 @@
     },
     "tests/test_environment_drift.py": {
       "file_tracker": "hooks/file_tracker.py",
-      "file_tracker.get_environment_delta": null,
-      "pathlib.Path": null
+      "file_tracker.get_environment_delta": null
     },
     "tests/test_environment_drift_convention.py": {
       "pathlib.Path": null
@@ -672,7 +666,6 @@
       "git_commit_check.main": null,
       "merge_guard_post": "hooks/merge_guard_post.py",
       "merge_guard_post.main": null,
-      "pathlib.Path": null,
       "peer_inject": "hooks/peer_inject.py",
       "peer_inject.main": null,
       "postcompact_archive": "hooks/postcompact_archive.py",
@@ -731,10 +724,10 @@
     },
     "tests/test_file_permissions.py": {
       "pathlib.Path": null,
-      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database": "skills/pact-memory/scripts/database.py",
       "scripts.database.get_connection": null,
       "scripts.database.get_db_path": null,
-      "scripts.setup_memory": "tests/../skills/pact-memory/scripts/setup_memory.py",
+      "scripts.setup_memory": "skills/pact-memory/scripts/setup_memory.py",
       "scripts.setup_memory.ensure_directories": null,
       "unittest.mock.patch": null
     },
@@ -744,7 +737,6 @@
       "file_tracker.check_conflict": null,
       "file_tracker.main": null,
       "file_tracker.track_edit": null,
-      "pathlib.Path": null,
       "unittest.mock.patch": null
     },
     "tests/test_file_tracker_composite_key_edges.py": {
@@ -758,18 +750,14 @@
     },
     "tests/test_gate_crashpath_hardening.py": {
       "bootstrap_gate": "hooks/bootstrap_gate.py",
-      "pathlib.Path": null,
       "shared.session_journal": "hooks/shared/session_journal.py",
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py",
       "tests.test_bootstrap_gate": "tests/test_bootstrap_gate.py",
       "tests.test_bootstrap_gate._make_input": null,
       "tests.test_bootstrap_gate._setup_pact_session": null
     },
-    "tests/test_gate_invalid_mode_resolution.py": {
-      "pathlib.Path": null
-    },
+    "tests/test_gate_invalid_mode_resolution.py": {},
     "tests/test_gh_helpers.py": {
-      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
       "shared.gh_helpers": "hooks/shared/gh_helpers.py",
       "shared.gh_helpers.check_pr_state": null,
@@ -788,7 +776,6 @@
       "git_commit_check.get_staged_file_content": null,
       "git_commit_check.get_staged_files": null,
       "git_commit_check.main": null,
-      "pathlib.Path": null,
       "unittest.mock.MagicMock": null,
       "unittest.mock.patch": null
     },
@@ -867,7 +854,6 @@
       "__future__.annotations": null,
       "fixtures.emitter": "tests/fixtures/emitter.py",
       "fixtures.emitter.VALID_HANDOFF": null,
-      "pathlib.Path": null,
       "shared.handoff_schema": "hooks/shared/handoff_schema.py",
       "shared.handoff_schema.HANDOFF_CANONICAL_FIELDS": null,
       "shared.handoff_schema.HANDOFF_LEGACY_ALIASES": null,
@@ -971,7 +957,7 @@
       "helpers": "tests/helpers.py",
       "helpers.create_test_schema": null,
       "pathlib.Path": null,
-      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database": "skills/pact-memory/scripts/database.py",
       "scripts.database.create_memory": null,
       "unittest.mock.patch": null
     },
@@ -1034,18 +1020,20 @@
     "tests/test_lock_identity_certification.py": {
       "__future__.annotations": null,
       "pathlib.Path": null,
-      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
-      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py"
     },
     "tests/test_managed_comment_emitted.py": {
       "__future__.annotations": null,
       "pathlib.Path": null,
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
       "shared.claude_md_manager._build_migrated_content": null,
       "shared.claude_md_manager.ensure_project_memory_md": null,
       "shared.session_resume": "hooks/shared/session_resume.py",
-      "shared.session_resume.update_session_info": null,
-      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+      "shared.session_resume.update_session_info": null
     },
     "tests/test_managed_comment_mirror.py": {
       "__future__.annotations": null,
@@ -1053,11 +1041,11 @@
     },
     "tests/test_marker_helper_twin_drift.py": {
       "__future__.annotations": null,
-      "pathlib.Path": null,
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
       "shared.pin_markers": "hooks/shared/pin_markers.py",
       "tests": "tests/__init__.py",
-      "tests.test_staleness": "tests/test_staleness.py",
-      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+      "tests.test_staleness": "tests/test_staleness.py"
     },
     "tests/test_marker_namespace.py": {
       "pathlib.Path": null,
@@ -1074,7 +1062,6 @@
     "tests/test_marker_schema.py": {
       "bootstrap_gate": "hooks/bootstrap_gate.py",
       "bootstrap_gate._BLOCKED_TOOLS": null,
-      "pathlib.Path": null,
       "shared.marker_schema": "hooks/shared/marker_schema.py",
       "shared.marker_schema.MARKER_MAX_BYTES": null,
       "shared.marker_schema.MARKER_SCHEMA_VERSION": null,
@@ -1090,7 +1077,7 @@
       "helpers.make_cli_memory_dict": null,
       "io.StringIO": null,
       "pathlib.Path": null,
-      "scripts.cli": "tests/../skills/pact-memory/scripts/cli.py",
+      "scripts.cli": "skills/pact-memory/scripts/cli.py",
       "scripts.cli._COMMANDS": null,
       "scripts.cli._best_effort_report": null,
       "scripts.cli._error": null,
@@ -1107,15 +1094,15 @@
       "scripts.cli.cmd_status": null,
       "scripts.cli.cmd_update": null,
       "scripts.cli.main": null,
-      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database": "skills/pact-memory/scripts/database.py",
       "scripts.database.AmbiguousPrefixError": null,
       "scripts.database.MEMORY_ID_LENGTH": null,
       "scripts.database.MIN_PREFIX_LENGTH": null,
       "scripts.database.PrefixTooShortError": null,
       "scripts.database.create_memory": null,
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api": "skills/pact-memory/scripts/memory_api.py",
       "scripts.memory_api.PACTMemory": null,
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
       "scripts.working_memory.AmbientSyncRefused": null,
       "scripts.working_memory.SyncResult": null,
       "test_working_memory_concurrency_comprehensive": "tests/test_working_memory_concurrency_comprehensive.py",
@@ -1125,7 +1112,7 @@
     },
     "tests/test_memory_ct_fields.py": {
       "pathlib.Path": null,
-      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database": "skills/pact-memory/scripts/database.py",
       "scripts.database.JSON_FIELDS": null,
       "scripts.database._migrate_ct_fields": null,
       "scripts.database.create_memory": null,
@@ -1136,12 +1123,12 @@
       "scripts.database.init_schema": null,
       "scripts.database.search_memories_by_text": null,
       "scripts.database.update_memory": null,
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api": "skills/pact-memory/scripts/memory_api.py",
       "scripts.memory_api.CONTENT_FIELDS": null,
-      "scripts.models": "tests/../skills/pact-memory/scripts/models.py",
+      "scripts.models": "skills/pact-memory/scripts/models.py",
       "scripts.models.MemoryObject": null,
       "scripts.models._parse_string_list": null,
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
       "scripts.working_memory._format_memory_entry": null,
       "scripts.working_memory.sync_to_claude_md": null,
       "unittest.mock.patch": null
@@ -1153,8 +1140,8 @@
       "helpers": "tests/helpers.py",
       "helpers.create_test_schema": null,
       "pathlib.Path": null,
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.database": "skills/pact-memory/scripts/database.py",
       "scripts.database.AMBIGUOUS_MATCH_CAP": null,
       "scripts.database.AmbiguousPrefixError": null,
       "scripts.database.MIN_PREFIX_LENGTH": null,
@@ -1176,9 +1163,9 @@
       "scripts.database.resolve_memory_id_prefix": null,
       "scripts.database.search_memories_by_text": null,
       "scripts.database.update_memory": null,
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api": "skills/pact-memory/scripts/memory_api.py",
       "scripts.memory_api.PACTMemory": null,
-      "scripts.models": "tests/../skills/pact-memory/scripts/models.py",
+      "scripts.models": "skills/pact-memory/scripts/models.py",
       "scripts.models.MemoryObject": null,
       "unittest.mock.patch": null
     },
@@ -1193,7 +1180,7 @@
     "tests/test_memory_graph.py": {
       "helpers": "tests/helpers.py",
       "helpers.create_test_schema": null,
-      "scripts.graph": "tests/../skills/pact-memory/scripts/graph.py",
+      "scripts.graph": "skills/pact-memory/scripts/graph.py",
       "scripts.graph._normalize_path": null,
       "scripts.graph.add_file_relation": null,
       "scripts.graph.get_file_by_id": null,
@@ -1217,16 +1204,17 @@
       "concurrent.futures.ThreadPoolExecutor": null,
       "concurrent.futures.as_completed": null,
       "contextlib.redirect_stderr": null,
-      "memory_init": "tests/../skills/pact-memory/scripts/memory_init.py",
-      "memory_init._get_embedding_attempted_path": null,
-      "memory_init.check_and_install_dependencies": null,
-      "memory_init.clear_embedding_marker": null,
-      "memory_init.ensure_memory_ready": null,
-      "memory_init.is_initialized": null,
-      "memory_init.maybe_embed_pending": null,
-      "memory_init.maybe_migrate_embeddings": null,
-      "memory_init.reset_initialization": null,
       "pathlib.Path": null,
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.memory_init": "skills/pact-memory/scripts/memory_init.py",
+      "scripts.memory_init._get_embedding_attempted_path": null,
+      "scripts.memory_init.check_and_install_dependencies": null,
+      "scripts.memory_init.clear_embedding_marker": null,
+      "scripts.memory_init.ensure_memory_ready": null,
+      "scripts.memory_init.is_initialized": null,
+      "scripts.memory_init.maybe_embed_pending": null,
+      "scripts.memory_init.maybe_migrate_embeddings": null,
+      "scripts.memory_init.reset_initialization": null,
       "unittest.mock.MagicMock": null,
       "unittest.mock.patch": null
     },
@@ -1236,24 +1224,24 @@
       "helpers.create_test_schema": null,
       "model2vec.StaticModel": null,
       "pathlib.Path": null,
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.cli": "tests/../skills/pact-memory/scripts/cli.py",
-      "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.cli": "skills/pact-memory/scripts/cli.py",
+      "scripts.config": "skills/pact-memory/scripts/config.py",
       "scripts.config._STORE_DB_PATH": null,
       "scripts.config.resolve_db_path": null,
-      "scripts.embeddings": "tests/../skills/pact-memory/scripts/embeddings.py",
+      "scripts.embeddings": "skills/pact-memory/scripts/embeddings.py",
       "scripts.embeddings.EMBEDDING_DIM": null,
       "scripts.embeddings.EMBEDDING_MAX_TOKENS": null,
       "scripts.embeddings.MODEL_NAME": null,
       "scripts.embeddings.generate_embedding_text": null,
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api": "skills/pact-memory/scripts/memory_api.py",
       "scripts.memory_api.PACTMemory": null,
       "unittest.mock.patch": null
     },
     "tests/test_memory_models.py": {
       "datetime.datetime": null,
       "datetime.timezone": null,
-      "scripts.models": "tests/../skills/pact-memory/scripts/models.py",
+      "scripts.models": "skills/pact-memory/scripts/models.py",
       "scripts.models.Decision": null,
       "scripts.models.Entity": null,
       "scripts.models.MemoryObject": null,
@@ -1273,26 +1261,26 @@
     "tests/test_memory_store_isolation.py": {
       "__future__.annotations": null,
       "pathlib.Path": null,
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.config": "skills/pact-memory/scripts/config.py",
       "scripts.config.MEMORY_DIR_ENV": null,
       "scripts.config.compute_db_path": null,
       "scripts.config.get_memory_dir": null,
-      "scripts.memory_init": "tests/../skills/pact-memory/scripts/memory_init.py"
+      "scripts.memory_init": "skills/pact-memory/scripts/memory_init.py"
     },
     "tests/test_memory_store_scope.py": {
       "__future__.annotations": null,
       "pathlib.Path": null,
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.cli": "tests/../skills/pact-memory/scripts/cli.py",
-      "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.cli": "skills/pact-memory/scripts/cli.py",
+      "scripts.config": "skills/pact-memory/scripts/config.py",
       "scripts.config.DB_FILENAME": null,
       "scripts.config.get_memory_dir": null,
       "scripts.config.resolve_db_path": null,
       "scripts.config.store_scope": null,
-      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database": "skills/pact-memory/scripts/database.py",
       "scripts.database.db_connection": null,
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api": "skills/pact-memory/scripts/memory_api.py",
       "unittest.mock.patch": null,
       "uuid.uuid4": null
     },
@@ -1355,18 +1343,15 @@
       "merge_guard_pre": "hooks/merge_guard_pre.py",
       "merge_guard_pre._strip_non_executable_content": null,
       "merge_guard_pre.is_compound_destructive_command": null,
-      "merge_guard_pre.is_dangerous_command": null,
-      "pathlib.Path": null
+      "merge_guard_pre.is_dangerous_command": null
     },
     "tests/test_merge_guard_1118_output_selector.py": {
-      "pathlib.Path": null,
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
       "shared.merge_guard_common._strip_non_executable_content": null,
       "shared.merge_guard_common.detect_command_operation_type": null,
       "shared.merge_guard_common.is_dangerous_command": null
     },
     "tests/test_merge_guard_1118_output_selector_cert.py": {
-      "pathlib.Path": null,
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
       "shared.merge_guard_common._strip_non_executable_content": null,
       "shared.merge_guard_common.detect_command_operation_type": null,
@@ -1380,7 +1365,6 @@
     "tests/test_merge_guard_1129_r1_branch_set.py": {
       "merge_guard_pre": "hooks/merge_guard_pre.py",
       "merge_guard_pre._token_matches_command": null,
-      "pathlib.Path": null,
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
       "shared.merge_guard_common._canonical_join": null,
       "shared.merge_guard_common._extract_branch_delete_set": null,
@@ -1437,7 +1421,6 @@
     "tests/test_merge_guard_1148_cert.py": {
       "merge_guard_baseline_loader": "tests/merge_guard_baseline_loader.py",
       "merge_guard_baseline_loader.load_baseline": null,
-      "pathlib.Path": null,
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
     },
     "tests/test_merge_guard_1155_cert.py": {
@@ -1445,7 +1428,6 @@
       "merge_guard_baseline_loader.load_baseline": null,
       "merge_guard_post": "hooks/merge_guard_post.py",
       "merge_guard_pre": "hooks/merge_guard_pre.py",
-      "pathlib.Path": null,
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
     },
     "tests/test_merge_guard_1178_cert.py": {
@@ -1459,7 +1441,6 @@
     "tests/test_merge_guard_1181_cert.py": {
       "merge_guard_baseline_loader": "tests/merge_guard_baseline_loader.py",
       "merge_guard_baseline_loader.load_baseline": null,
-      "pathlib.Path": null,
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
     },
     "tests/test_merge_guard_1203_cert.py": {
@@ -1496,8 +1477,7 @@
       "merge_guard_post": "hooks/merge_guard_post.py",
       "merge_guard_post._mint_context_from_bundle": null,
       "merge_guard_post._target_value": null,
-      "merge_guard_pre": "hooks/merge_guard_pre.py",
-      "pathlib.Path": null
+      "merge_guard_pre": "hooks/merge_guard_pre.py"
     },
     "tests/test_merge_guard_obs_cert.py": {
       "merge_guard_baseline_loader": "tests/merge_guard_baseline_loader.py",
@@ -1520,7 +1500,6 @@
       "merge_guard_pre": "hooks/merge_guard_pre.py",
       "merge_guard_pre._token_matches_command": null,
       "merge_guard_pre.check_merge_authorization": null,
-      "pathlib.Path": null,
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
       "shared.merge_guard_common.detect_command_operation_type": null,
       "shared.merge_guard_common.extract_command_context": null,
@@ -1529,8 +1508,7 @@
     "tests/test_merge_guard_output_side_process_sub.py": {
       "merge_guard_pre": "hooks/merge_guard_pre.py",
       "merge_guard_pre._has_process_substitution_to_shell": null,
-      "merge_guard_pre.is_dangerous_command": null,
-      "pathlib.Path": null
+      "merge_guard_pre.is_dangerous_command": null
     },
     "tests/test_merge_guard_over_block_batch.py": {
       "merge_guard_post": "hooks/merge_guard_post.py",
@@ -1538,7 +1516,6 @@
       "merge_guard_pre": "hooks/merge_guard_pre.py",
       "merge_guard_pre.check_merge_authorization": null,
       "merge_guard_pre.main": null,
-      "pathlib.Path": null,
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
       "shared.merge_guard_common.detect_command_operation_type": null,
       "shared.merge_guard_common.extract_privileged_flags": null,
@@ -1550,7 +1527,6 @@
       "merge_guard_baseline_loader.load_baseline": null,
       "merge_guard_post": "hooks/merge_guard_post.py",
       "merge_guard_pre": "hooks/merge_guard_pre.py",
-      "pathlib.Path": null,
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
       "test_merge_guard_1148_cert": "tests/test_merge_guard_1148_cert.py",
       "test_merge_guard_1148_cert.CLOSURES": null,
@@ -1604,7 +1580,6 @@
     "tests/test_merge_guard_pre.py": {
       "merge_guard_pre": "hooks/merge_guard_pre.py",
       "merge_guard_pre._GH_PR_NUMBER_RE": null,
-      "pathlib.Path": null,
       "shared": "hooks/shared/__init__.py",
       "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
     },
@@ -1656,8 +1631,7 @@
       "fixtures.role_frames.captured_plain_sessionstart": null,
       "fixtures.role_frames.captured_plain_userpromptsubmit": null,
       "fixtures.role_frames.captured_teammate_sessionstart": null,
-      "missed_wake_scan": "hooks/missed_wake_scan.py",
-      "pathlib.Path": null
+      "missed_wake_scan": "hooks/missed_wake_scan.py"
     },
     "tests/test_missed_wake_scan_integration.py": {
       "datetime.datetime": null,
@@ -1693,14 +1667,12 @@
       "typing.Tuple": null
     },
     "tests/test_pact_config.py": {
-      "pathlib.Path": null,
       "shared.pact_config": "hooks/shared/pact_config.py",
       "shared.pact_config.get_bool": null,
       "shared.pact_config.get_enum": null,
       "shared.pact_config.llm_options": null
     },
     "tests/test_pact_config_gate_migration.py": {
-      "pathlib.Path": null,
       "shared.pact_config": "hooks/shared/pact_config.py"
     },
     "tests/test_pact_config_injection.py": {
@@ -1721,11 +1693,11 @@
       "fixtures.role_frames.plain_frame": null,
       "fixtures.role_frames.teammate_frame": null,
       "pathlib.Path": null,
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.memory_api": "skills/pact-memory/scripts/memory_api.py",
       "scripts.memory_api.PACTMemory": null,
-      "scripts.memory_init": "tests/../skills/pact-memory/scripts/memory_init.py",
-      "scripts.pact_session": "tests/../skills/pact-memory/scripts/pact_session.py",
+      "scripts.memory_init": "skills/pact-memory/scripts/memory_init.py",
+      "scripts.pact_session": "skills/pact-memory/scripts/pact_session.py",
       "scripts.pact_session._context_file_path": null,
       "scripts.pact_session._resolve_context_on_disk": null,
       "scripts.pact_session.get_session_id_from_context_file": null,
@@ -1768,8 +1740,11 @@
     },
     "tests/test_pact_session_config_dir_parity.py": {
       "pathlib.Path": null,
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.pact_session": "tests/../skills/pact-memory/scripts/pact_session.py"
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.pact_session": "skills/pact-memory/scripts/pact_session.py"
+    },
+    "tests/test_path_setup_pin.py": {
+      "pathlib.Path": null
     },
     "tests/test_paths.py": {
       "pathlib.Path": null,
@@ -1835,7 +1810,6 @@
       "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
     },
     "tests/test_pin_caps.py": {
-      "pathlib.Path": null,
       "pin_caps": "hooks/pin_caps.py",
       "pin_caps.DENY_REASON_COUNT": null,
       "pin_caps.DENY_REASON_EMBEDDED_PIN": null,
@@ -1856,7 +1830,6 @@
       "pin_caps.parse_pins": null
     },
     "tests/test_pin_caps_adversarial.py": {
-      "pathlib.Path": null,
       "pin_caps": "hooks/pin_caps.py",
       "pin_caps.Pin": null,
       "pin_caps.check_add_allowed": null,
@@ -1873,7 +1846,6 @@
       "helpers": "tests/helpers.py",
       "helpers.make_claude_md_with_pins": null,
       "helpers.make_pin_entry": null,
-      "pathlib.Path": null,
       "pin_caps_gate": "hooks/pin_caps_gate.py",
       "pin_caps_gate._check_tool_allowed": null,
       "staleness": "hooks/staleness.py"
@@ -1882,7 +1854,6 @@
       "helpers": "tests/helpers.py",
       "helpers.make_claude_md_with_pins": null,
       "helpers.make_pin_entry": null,
-      "pathlib.Path": null,
       "pin_caps": "hooks/pin_caps.py",
       "pin_caps.evaluate_full_state": null,
       "pin_caps_gate": "hooks/pin_caps_gate.py",
@@ -1893,7 +1864,6 @@
       "helpers": "tests/helpers.py",
       "helpers.make_claude_md_with_pins": null,
       "helpers.make_pin_entry": null,
-      "pathlib.Path": null,
       "pin_caps_gate": "hooks/pin_caps_gate.py",
       "pin_caps_gate._check_tool_allowed": null,
       "staleness": "hooks/staleness.py"
@@ -1902,7 +1872,6 @@
       "helpers": "tests/helpers.py",
       "helpers.make_claude_md_with_pins": null,
       "helpers.make_pin_entry": null,
-      "pathlib.Path": null,
       "pin_caps": "hooks/pin_caps.py",
       "pin_caps.parse_pins": null,
       "pin_caps_gate": "hooks/pin_caps_gate.py",
@@ -1933,7 +1902,6 @@
       "helpers": "tests/helpers.py",
       "helpers.make_claude_md_with_pins": null,
       "helpers.make_pin_entry": null,
-      "pathlib.Path": null,
       "pin_caps_gate": "hooks/pin_caps_gate.py",
       "pin_caps_gate._check_tool_allowed": null,
       "staleness": "hooks/staleness.py",
@@ -1942,7 +1910,6 @@
     "tests/test_pin_comment_dominance.py": {
       "helpers": "tests/helpers.py",
       "helpers.make_claude_md_with_pins": null,
-      "pathlib.Path": null,
       "pin_caps": "hooks/pin_caps.py",
       "pin_caps.OVERRIDE_COMMENT_RE": null,
       "pin_caps.PIN_SIZE_CAP": null,
@@ -1954,7 +1921,6 @@
       "staleness": "hooks/staleness.py"
     },
     "tests/test_pin_comment_pipeline.py": {
-      "pathlib.Path": null,
       "pin_caps": "hooks/pin_caps.py",
       "pin_caps.OVERRIDE_COMMENT_RE": null,
       "pin_caps.PIN_STALE_BLOCK_THRESHOLD": null,
@@ -1968,6 +1934,10 @@
       "__future__.annotations": null,
       "pathlib.Path": null,
       "pin_marker_writer": "hooks/pin_marker_writer.py",
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory._PACT_BOUNDARY_ALT": null,
+      "scripts.working_memory._SESSION_BOUNDARY_ALT": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
       "shared.claude_md_manager.MANAGED_END_MARKER": null,
       "shared.claude_md_manager.MANAGED_START_MARKER": null,
@@ -1996,10 +1966,7 @@
       "staleness": "hooks/staleness.py",
       "staleness._find_terminator_offset": null,
       "staleness._parse_pinned_section": null,
-      "staleness._resolve_project_claude_md_with_base": null,
-      "working_memory": "skills/pact-memory/scripts/working_memory.py",
-      "working_memory._PACT_BOUNDARY_ALT": null,
-      "working_memory._SESSION_BOUNDARY_ALT": null
+      "staleness._resolve_project_claude_md_with_base": null
     },
     "tests/test_pin_marker_writer_adversarial.py": {
       "__future__.annotations": null,
@@ -2057,7 +2024,6 @@
       "staleness._parse_pinned_section": null
     },
     "tests/test_pin_staleness_marker_clear.py": {
-      "pathlib.Path": null,
       "pin_staleness_gate": "hooks/pin_staleness_gate.py",
       "pin_staleness_gate.PIN_STALENESS_MARKER_NAME": null,
       "shared": "hooks/shared/__init__.py",
@@ -2145,19 +2111,19 @@
       "fixtures.project_dir.source_export_line": null,
       "fixtures.project_dir.write_session_context": null,
       "pathlib.Path": null,
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.memory_api": "skills/pact-memory/scripts/memory_api.py",
       "scripts.memory_api.PACTMemory": null,
-      "scripts.pact_session": "tests/../skills/pact-memory/scripts/pact_session.py",
+      "scripts.pact_session": "skills/pact-memory/scripts/pact_session.py",
       "scripts.pact_session.ProjectScopeDisagreementError": null,
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
       "shared": "hooks/shared/__init__.py",
       "shared.backlog": "hooks/shared/backlog.py",
       "types.SimpleNamespace": null
     },
     "tests/test_project_id.py": {
       "pathlib.Path": null,
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api": "skills/pact-memory/scripts/memory_api.py",
       "scripts.memory_api.PACTMemory": null,
       "unittest.mock.MagicMock": null,
       "unittest.mock.patch": null
@@ -2200,7 +2166,8 @@
     },
     "tests/test_recovery_pointer_fallback.py": {
       "pathlib.Path": null,
-      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py"
     },
     "tests/test_resume_team_realign_1507.py": {
       "dispatch_gate": "hooks/dispatch_gate.py",
@@ -2257,7 +2224,7 @@
     "tests/test_seam_line_ending_call_sites.py": {
       "collections.Counter": null,
       "pathlib.Path": null,
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
       "scripts.working_memory.sync_retrieved_to_claude_md": null,
       "scripts.working_memory.sync_to_claude_md": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
@@ -2268,7 +2235,6 @@
       "test_staleness.over_budget_body": null
     },
     "tests/test_session_block_substitution.py": {
-      "pathlib.Path": null,
       "shared.session_resume": "hooks/shared/session_resume.py",
       "shared.session_resume.update_session_info": null
     },
@@ -2287,8 +2253,8 @@
     "tests/test_session_discovery_route.py": {
       "__future__.annotations": null,
       "pathlib.Path": null,
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.pact_session": "tests/../skills/pact-memory/scripts/pact_session.py"
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.pact_session": "skills/pact-memory/scripts/pact_session.py"
     },
     "tests/test_session_end.py": {
       "contextlib.ExitStack": null,
@@ -2323,16 +2289,15 @@
     },
     "tests/test_session_end_survives_a_forged_heading.py": {
       "__future__.annotations": null,
-      "pathlib.Path": null,
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory.sync_retrieved_to_claude_md": null,
+      "scripts.working_memory.sync_to_claude_md": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
       "shared.claude_md_manager.MEMORY_END_MARKER": null,
       "shared.claude_md_manager.MEMORY_START_MARKER": null,
       "tests.test_pin_marker_writer": "tests/test_pin_marker_writer.py",
       "tests.test_pin_marker_writer.build_claude_md": null,
-      "unittest.mock.patch": null,
-      "working_memory": "skills/pact-memory/scripts/working_memory.py",
-      "working_memory.sync_retrieved_to_claude_md": null,
-      "working_memory.sync_to_claude_md": null
+      "unittest.mock.patch": null
     },
     "tests/test_session_init.py": {
       "__future__.annotations": null,
@@ -2594,7 +2559,7 @@
       "unittest.mock.patch": null
     },
     "tests/test_setup_memory.py": {
-      "scripts.setup_memory": "tests/../skills/pact-memory/scripts/setup_memory.py",
+      "scripts.setup_memory": "skills/pact-memory/scripts/setup_memory.py",
       "scripts.setup_memory._get_recommendations": null,
       "scripts.setup_memory.check_dependencies": null,
       "scripts.setup_memory.ensure_directories": null,
@@ -2607,7 +2572,7 @@
       "memory_repair": "scripts/memory_repair/__init__.py",
       "memory_repair.shred_detect": "scripts/memory_repair/shred_detect.py",
       "pathlib.Path": null,
-      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.database": "skills/pact-memory/scripts/database.py",
       "scripts.database.LIST_FIELDS": null
     },
     "tests/test_skills_structure.py": {
@@ -2703,16 +2668,15 @@
     },
     "tests/test_splice_window_memory_region.py": {
       "__future__.annotations": null,
-      "pathlib.Path": null,
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory.sync_retrieved_to_claude_md": null,
+      "scripts.working_memory.sync_to_claude_md": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
       "shared.claude_md_manager.MEMORY_END_MARKER": null,
       "shared.claude_md_manager.MEMORY_START_MARKER": null,
       "tests.test_pin_marker_writer": "tests/test_pin_marker_writer.py",
       "tests.test_pin_marker_writer.build_claude_md": null,
-      "unittest.mock.patch": null,
-      "working_memory": "skills/pact-memory/scripts/working_memory.py",
-      "working_memory.sync_retrieved_to_claude_md": null,
-      "working_memory.sync_to_claude_md": null
+      "unittest.mock.patch": null
     },
     "tests/test_stale_session.py": {
       "pathlib.Path": null,
@@ -2726,6 +2690,14 @@
       "pathlib.Path": null,
       "pin_caps": "hooks/pin_caps.py",
       "pin_caps_gate": "hooks/pin_caps_gate.py",
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory.ContainmentError": null,
+      "scripts.working_memory._atomic_write_text": null,
+      "scripts.working_memory._estimate_tokens": null,
+      "scripts.working_memory._project_root_of": null,
+      "scripts.working_memory._sanitize_prompt_field": null,
+      "scripts.working_memory.file_lock": null,
       "session_init": "hooks/session_init.py",
       "session_init.PINNED_STALENESS_DAYS": null,
       "session_init._estimate_tokens": null,
@@ -2755,14 +2727,7 @@
       "staleness.check_pinned_staleness": null,
       "staleness.estimate_tokens": null,
       "unittest.mock.MagicMock": null,
-      "unittest.mock.patch": null,
-      "working_memory": "skills/pact-memory/scripts/working_memory.py",
-      "working_memory.ContainmentError": null,
-      "working_memory._atomic_write_text": null,
-      "working_memory._estimate_tokens": null,
-      "working_memory._project_root_of": null,
-      "working_memory._sanitize_prompt_field": null,
-      "working_memory.file_lock": null
+      "unittest.mock.patch": null
     },
     "tests/test_store_access_bar_presence.py": {
       "__future__.annotations": null,
@@ -2770,7 +2735,7 @@
     },
     "tests/test_store_scope_decorator_contract.py": {
       "__future__.annotations": null,
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api": "skills/pact-memory/scripts/memory_api.py",
       "scripts.memory_api.PACTMemory": null
     },
     "tests/test_subagent_start_selects_teammate_frames.py": {
@@ -2786,7 +2751,7 @@
     },
     "tests/test_sync_result_contract.py": {
       "pathlib.Path": null,
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
       "scripts.working_memory.SyncResult": null
     },
     "tests/test_task_claim_gate.py": {
@@ -2968,7 +2933,6 @@
       "shared.teammate_mode.should_emit_inprocess_notice": null
     },
     "tests/test_telegram_client.py": {
-      "pathlib.Path": null,
       "telegram.telegram_client": "telegram/telegram_client.py",
       "telegram.telegram_client.TelegramAPIError": null,
       "telegram.telegram_client.TelegramClient": null,
@@ -2977,7 +2941,6 @@
       "unittest.mock.patch": null
     },
     "tests/test_telegram_config.py": {
-      "pathlib.Path": null,
       "telegram.config": "telegram/config.py",
       "telegram.config.ConfigError": null,
       "telegram.config.DEFAULT_MODE": null,
@@ -2991,7 +2954,6 @@
       "unittest.mock.patch": null
     },
     "tests/test_telegram_content_filter.py": {
-      "pathlib.Path": null,
       "telegram.content_filter": "telegram/content_filter.py",
       "telegram.content_filter.MAX_INBOUND_LENGTH": null,
       "telegram.content_filter.TELEGRAM_MAX_MESSAGE_LENGTH": null,
@@ -3001,7 +2963,6 @@
       "telegram.content_filter.truncate_message": null
     },
     "tests/test_telegram_deps.py": {
-      "pathlib.Path": null,
       "telegram.deps": "telegram/deps.py",
       "telegram.deps.REQUIRED_PACKAGES": null,
       "telegram.deps.check_dependencies": null,
@@ -3012,7 +2973,6 @@
       "unittest.mock.patch": null
     },
     "tests/test_telegram_main.py": {
-      "pathlib.Path": null,
       "telegram.__main__": "telegram/__main__.py",
       "telegram.__main__.main": null,
       "types.ModuleType": null,
@@ -3020,7 +2980,6 @@
       "unittest.mock.patch": null
     },
     "tests/test_telegram_notify.py": {
-      "pathlib.Path": null,
       "telegram.notify": "telegram/notify.py",
       "telegram.notify._build_session_summary": null,
       "telegram.notify._filter_message": null,
@@ -3049,7 +3008,6 @@
       "unittest.mock.patch": null
     },
     "tests/test_telegram_server.py": {
-      "pathlib.Path": null,
       "telegram.routing": "telegram/routing.py",
       "telegram.routing.DirectRouter": null,
       "telegram.server": "telegram/server.py",
@@ -3069,7 +3027,6 @@
       "unittest.mock.patch": null
     },
     "tests/test_telegram_tools.py": {
-      "pathlib.Path": null,
       "telegram.telegram_client": "telegram/telegram_client.py",
       "telegram.telegram_client.TelegramAPIError": null,
       "telegram.tools": "telegram/tools.py",
@@ -3115,68 +3072,64 @@
       "pathlib.Path": null
     },
     "tests/test_token_budget.py": {
-      "pathlib.Path": null,
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory.COMPRESSED_ENTRY_TOKEN_CEILING": null,
+      "scripts.working_memory.MAX_WORKING_MEMORIES": null,
+      "scripts.working_memory.SyncResult": null,
+      "scripts.working_memory.WORKING_MEMORY_TOKEN_BUDGET": null,
+      "scripts.working_memory._apply_token_budget": null,
+      "scripts.working_memory._compress_memory_entry": null,
+      "scripts.working_memory._estimate_tokens": null,
+      "scripts.working_memory._find_existing_claude_md": null,
+      "scripts.working_memory._format_memory_entry": null,
+      "scripts.working_memory._format_retrieved_entry": null,
+      "scripts.working_memory._get_claude_md_path": null,
+      "scripts.working_memory._parse_retrieved_context_section": null,
+      "scripts.working_memory._parse_working_memory_section": null,
+      "scripts.working_memory.sync_retrieved_to_claude_md": null,
+      "scripts.working_memory.sync_to_claude_md": null,
       "unittest.mock.MagicMock": null,
-      "unittest.mock.patch": null,
-      "working_memory": "skills/pact-memory/scripts/working_memory.py",
-      "working_memory.COMPRESSED_ENTRY_TOKEN_CEILING": null,
-      "working_memory.MAX_WORKING_MEMORIES": null,
-      "working_memory.SyncResult": null,
-      "working_memory.WORKING_MEMORY_TOKEN_BUDGET": null,
-      "working_memory._apply_token_budget": null,
-      "working_memory._compress_memory_entry": null,
-      "working_memory._estimate_tokens": null,
-      "working_memory._find_existing_claude_md": null,
-      "working_memory._format_memory_entry": null,
-      "working_memory._format_retrieved_entry": null,
-      "working_memory._get_claude_md_path": null,
-      "working_memory._parse_retrieved_context_section": null,
-      "working_memory._parse_working_memory_section": null,
-      "working_memory.sync_retrieved_to_claude_md": null,
-      "working_memory.sync_to_claude_md": null
+      "unittest.mock.patch": null
     },
     "tests/test_token_budget_constants_coupling.py": {
       "pathlib.Path": null,
-      "unittest.mock.patch": null,
-      "working_memory": "skills/pact-memory/scripts/working_memory.py",
-      "working_memory.COMPRESSED_ENTRY_TOKEN_CEILING": null,
-      "working_memory.COMPRESSED_SUMMARY_CHAR_CAP": null,
-      "working_memory.MAX_RETRIEVED_MEMORIES": null,
-      "working_memory.MAX_WORKING_MEMORIES": null,
-      "working_memory.RETRIEVED_CONTEXT_COMMENT": null,
-      "working_memory.RETRIEVED_CONTEXT_TOKEN_BUDGET": null,
-      "working_memory.WORKING_MEMORY_COMMENT": null,
-      "working_memory.WORKING_MEMORY_TOKEN_BUDGET": null,
-      "working_memory._MANAGED_END_MARKER": null,
-      "working_memory._MANAGED_START_MARKER": null,
-      "working_memory._MEMORY_ID_LABEL": null,
-      "working_memory._REFRESH_FIELD_TRUNCATION_LIMIT": null,
-      "working_memory._REFRESH_IDENTIFIER_TRUNCATION_LIMIT": null,
-      "working_memory._SESSION_END_MARKER": null,
-      "working_memory._apply_entry_token_ceiling": null,
-      "working_memory._apply_token_budget": null,
-      "working_memory._compress_memory_entry": null,
-      "working_memory._estimate_tokens": null,
-      "working_memory._format_memory_entry": null,
-      "working_memory._format_retrieved_entry": null,
-      "working_memory._parse_retrieved_context_section": null,
-      "working_memory.sync_retrieved_to_claude_md": null,
-      "working_memory.sync_to_claude_md": null
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory.COMPRESSED_ENTRY_TOKEN_CEILING": null,
+      "scripts.working_memory.COMPRESSED_SUMMARY_CHAR_CAP": null,
+      "scripts.working_memory.MAX_RETRIEVED_MEMORIES": null,
+      "scripts.working_memory.MAX_WORKING_MEMORIES": null,
+      "scripts.working_memory.RETRIEVED_CONTEXT_COMMENT": null,
+      "scripts.working_memory.RETRIEVED_CONTEXT_TOKEN_BUDGET": null,
+      "scripts.working_memory.WORKING_MEMORY_COMMENT": null,
+      "scripts.working_memory.WORKING_MEMORY_TOKEN_BUDGET": null,
+      "scripts.working_memory._MANAGED_END_MARKER": null,
+      "scripts.working_memory._MANAGED_START_MARKER": null,
+      "scripts.working_memory._MEMORY_ID_LABEL": null,
+      "scripts.working_memory._REFRESH_FIELD_TRUNCATION_LIMIT": null,
+      "scripts.working_memory._REFRESH_IDENTIFIER_TRUNCATION_LIMIT": null,
+      "scripts.working_memory._SESSION_END_MARKER": null,
+      "scripts.working_memory._apply_entry_token_ceiling": null,
+      "scripts.working_memory._apply_token_budget": null,
+      "scripts.working_memory._compress_memory_entry": null,
+      "scripts.working_memory._estimate_tokens": null,
+      "scripts.working_memory._format_memory_entry": null,
+      "scripts.working_memory._format_retrieved_entry": null,
+      "scripts.working_memory._parse_retrieved_context_section": null,
+      "scripts.working_memory.sync_retrieved_to_claude_md": null,
+      "scripts.working_memory.sync_to_claude_md": null,
+      "unittest.mock.patch": null
     },
     "tests/test_tool_response.py": {
-      "pathlib.Path": null,
       "shared.tool_response": "hooks/shared/tool_response.py",
       "shared.tool_response.extract_tool_response": null
     },
     "tests/test_track_files.py": {
       "datetime.datetime": null,
-      "pathlib.Path": null,
       "track_files": "hooks/track_files.py",
       "unittest.mock.MagicMock": null,
       "unittest.mock.patch": null
     },
     "tests/test_validate_handoff.py": {
-      "pathlib.Path": null,
       "unittest.mock.patch": null,
       "validate_handoff": "hooks/validate_handoff.py",
       "validate_handoff.check_lossless_fields": null,
@@ -3193,7 +3146,6 @@
       "validate_handoff": "hooks/validate_handoff.py"
     },
     "tests/test_variety_divergence.py": {
-      "pathlib.Path": null,
       "shared.session_journal": "hooks/shared/session_journal.py",
       "shared.session_journal.make_event": null,
       "shared.variety_divergence": "hooks/shared/variety_divergence.py",
@@ -3208,7 +3160,6 @@
       "pathlib.Path": null
     },
     "tests/test_variety_scorer.py": {
-      "pathlib.Path": null,
       "shared.variety_scorer": "hooks/shared/variety_scorer.py",
       "shared.variety_scorer.COMPACT_MAX": null,
       "shared.variety_scorer.DIMENSION_COUNT": null,
@@ -3233,7 +3184,6 @@
       "hypothesis.given": null,
       "hypothesis.settings": null,
       "hypothesis.strategies": null,
-      "pathlib.Path": null,
       "shared.variety_scorer": "hooks/shared/variety_scorer.py",
       "shared.variety_scorer.COMPACT_MAX": null,
       "shared.variety_scorer.MAX_DIMENSION": null,
@@ -3251,9 +3201,9 @@
     },
     "tests/test_vector_dimension_fixes.py": {
       "pathlib.Path": null,
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
-      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.config": "skills/pact-memory/scripts/config.py",
+      "scripts.database": "skills/pact-memory/scripts/database.py",
       "scripts.database._check_and_migrate_vector_table": null,
       "scripts.database.create_memory": null,
       "scripts.database.ensure_initialized": null,
@@ -3261,14 +3211,14 @@
       "scripts.database.get_memory": null,
       "scripts.database.init_schema": null,
       "scripts.database.search_memories_by_text": null,
-      "scripts.embeddings": "tests/../skills/pact-memory/scripts/embeddings.py",
+      "scripts.embeddings": "skills/pact-memory/scripts/embeddings.py",
       "scripts.embeddings.EMBEDDING_DIM": null,
       "scripts.embeddings.check_embedding_availability": null,
       "scripts.embeddings.generate_embedding_text": null,
-      "scripts.memory_init": "tests/../skills/pact-memory/scripts/memory_init.py",
+      "scripts.memory_init": "skills/pact-memory/scripts/memory_init.py",
       "scripts.memory_init.maybe_migrate_embeddings": null,
       "scripts.memory_init.reset_initialization": null,
-      "scripts.search": "tests/../skills/pact-memory/scripts/search.py",
+      "scripts.search": "skills/pact-memory/scripts/search.py",
       "scripts.search.get_search_capabilities": null,
       "scripts.search.vector_search": null,
       "unittest.mock.MagicMock": null,
@@ -3278,7 +3228,7 @@
       "__future__.annotations": null,
       "helpers": "tests/helpers.py",
       "helpers.create_test_schema": null,
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api": "skills/pact-memory/scripts/memory_api.py",
       "scripts.memory_api.PACTMemory": null,
       "unittest.mock.patch": null
     },
@@ -3308,50 +3258,52 @@
     },
     "tests/test_window_rule_decline.py": {
       "pathlib.Path": null,
-      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
-      "scripts.cli": "tests/../skills/pact-memory/scripts/cli.py",
-      "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
-      "unittest.mock.patch": null,
-      "working_memory": "skills/pact-memory/scripts/working_memory.py",
-      "working_memory.MEMORY_END_MARKER": null,
-      "working_memory.MEMORY_START_MARKER": null,
-      "working_memory.SyncResult": null,
-      "working_memory._MANAGED_END_MARKER": null,
-      "working_memory._MANAGED_START_MARKER": null,
-      "working_memory._SESSION_END_MARKER": null,
-      "working_memory._resolve_write_window": null,
-      "working_memory.sync_retrieved_to_claude_md": null,
-      "working_memory.sync_to_claude_md": null
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.cli": "skills/pact-memory/scripts/cli.py",
+      "scripts.config": "skills/pact-memory/scripts/config.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory.MEMORY_END_MARKER": null,
+      "scripts.working_memory.MEMORY_START_MARKER": null,
+      "scripts.working_memory.SyncResult": null,
+      "scripts.working_memory._MANAGED_END_MARKER": null,
+      "scripts.working_memory._MANAGED_START_MARKER": null,
+      "scripts.working_memory._SESSION_END_MARKER": null,
+      "scripts.working_memory._resolve_write_window": null,
+      "scripts.working_memory.sync_retrieved_to_claude_md": null,
+      "scripts.working_memory.sync_to_claude_md": null,
+      "unittest.mock.patch": null
     },
     "tests/test_working_memory.py": {
-      "pathlib.Path": null,
       "pin_staleness_gate": "hooks/pin_staleness_gate.py",
       "pin_staleness_gate._DATE_LED_HEADING_RE": null,
-      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py"
     },
     "tests/test_working_memory_concurrency.py": {
       "contextlib.contextmanager": null,
       "pathlib.Path": null,
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
       "shared": "hooks/shared/__init__.py",
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
-      "shared.claude_md_manager.file_lock": null,
-      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+      "shared.claude_md_manager.file_lock": null
     },
     "tests/test_working_memory_concurrency_comprehensive.py": {
       "importlib.import_module": null,
       "pathlib.Path": null,
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory.file_lock": null,
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
       "shared.claude_md_manager.file_lock": null,
       "test_staleness": "tests/test_staleness.py",
-      "test_staleness.TestFileLockTwinCopyDrift": null,
-      "working_memory": "skills/pact-memory/scripts/working_memory.py",
-      "working_memory.file_lock": null
+      "test_staleness.TestFileLockTwinCopyDrift": null
     },
     "tests/test_working_memory_fidelity.py": {
       "helpers": "tests/helpers.py",
       "helpers.create_test_schema": null,
       "pathlib.Path": null,
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
       "scripts.working_memory.MAX_WORKING_MEMORIES": null,
       "scripts.working_memory.SyncResult": null,
       "scripts.working_memory.project_memories_to_claude_md": null,
@@ -3359,7 +3311,7 @@
       "test_memory_cli._backdate": null
     },
     "tests/test_working_memory_parser.py": {
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
       "scripts.working_memory.RETRIEVED_CONTEXT_HEADER": null,
       "scripts.working_memory.WORKING_MEMORY_HEADER": null,
       "scripts.working_memory._PACT_BOUNDARY_ALT": null,
@@ -3381,9 +3333,9 @@
       "datetime.timedelta": null,
       "datetime.timezone": null,
       "pathlib.Path": null,
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api": "skills/pact-memory/scripts/memory_api.py",
       "scripts.memory_api.PACTMemory": null,
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
       "scripts.working_memory.MAX_WORKING_MEMORIES": null,
       "scripts.working_memory.SyncResult": null,
       "scripts.working_memory.WORKING_MEMORY_TOKEN_BUDGET": null,
@@ -3394,10 +3346,10 @@
     },
     "tests/test_working_memory_redirected_store_refusal.py": {
       "pathlib.Path": null,
-      "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
+      "scripts.config": "skills/pact-memory/scripts/config.py",
       "scripts.config.STORE_ORIGIN_ENV": null,
       "scripts.config.STORE_ORIGIN_HOME": null,
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
       "scripts.working_memory.AmbientSyncRefused": null,
       "scripts.working_memory.SyncResult": null,
       "scripts.working_memory._refuse_ambient_sync_from_a_redirected_store": null,
@@ -3405,15 +3357,16 @@
     },
     "tests/test_working_memory_resolver_and_lock_release.py": {
       "pathlib.Path": null,
+      "scripts": "skills/pact-memory/scripts/__init__.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
       "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
-      "shared.claude_md_manager.resolve_project_claude_md_path": null,
-      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+      "shared.claude_md_manager.resolve_project_claude_md_path": null
     },
     "tests/test_working_memory_worktree_sync.py": {
       "pathlib.Path": null,
-      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.memory_api": "skills/pact-memory/scripts/memory_api.py",
       "scripts.memory_api.PACTMemory": null,
-      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "scripts.working_memory": "skills/pact-memory/scripts/working_memory.py",
       "scripts.working_memory.SyncResult": null,
       "scripts.working_memory._project_root_of": null,
       "scripts.working_memory._resolve_display_claude_md_path": null,
@@ -3427,7 +3380,6 @@
       "pathlib.Path": null
     },
     "tests/test_worktree_guard.py": {
-      "pathlib.Path": null,
       "unittest.mock.patch": null,
       "worktree_guard": "hooks/worktree_guard.py",
       "worktree_guard._suggest_worktree_path": null,
@@ -3441,16 +3393,9 @@
     }
   },
   "path_drift_since_sessionstart": [
-    "/private/tmp/baseline-regen/pact-plugin/skills/pact-memory",
-    "/private/tmp/baseline-regen/pact-plugin/skills/pact-memory",
-    "/private/tmp/baseline-regen/pact-plugin/hooks/shared",
-    "/private/tmp/baseline-regen/pact-plugin/tests/fixtures",
-    "/private/tmp/baseline-regen/pact-plugin/skills/pact-memory",
-    "/private/tmp/baseline-regen/pact-plugin/skills/pact-memory",
-    "/private/tmp/baseline-regen/pact-plugin/tests/../scripts",
-    "/private/tmp/baseline-regen/pact-plugin/tests/../skills/pact-memory/scripts",
-    "/private/tmp/baseline-regen/pact-plugin/skills/pact-memory",
-    "/private/tmp/baseline-regen/pact-plugin/skills/pact-handoff-harvest",
-    "/private/tmp/baseline-regen/pact-plugin/skills/pact-agent-teams"
+    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks/shared",
+    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/fixtures",
+    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-handoff-harvest",
+    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-agent-teams"
   ]
 }

--- a/pact-plugin/tests/import_identity_baseline.json
+++ b/pact-plugin/tests/import_identity_baseline.json
@@ -1,0 +1,1345 @@
+{
+  "map": {
+    "skills/pact-agent-teams/test_skill_loading_agent_teams.py": {},
+    "skills/pact-handoff-harvest/test_skill_loading_harvest.py": {},
+    "tests/test_628_coverage.py": {
+      "peer_inject": "hooks/peer_inject.py",
+      "shared": "hooks/shared/__init__.py"
+    },
+    "tests/test_agent_handoff_emitter_integration.py": {
+      "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
+      "shared.session_journal": "hooks/shared/session_journal.py"
+    },
+    "tests/test_agent_handoff_marker.py": {
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py"
+    },
+    "tests/test_agent_handoff_ts_caller_property.py": {
+      "shared.session_journal": "hooks/shared/session_journal.py"
+    },
+    "tests/test_agent_memory_cap_single_source.py": {},
+    "tests/test_agent_memory_leaf_construction.py": {},
+    "tests/test_agent_state_model.py": {},
+    "tests/test_agents_structure.py": {
+      "helpers": "tests/helpers.py"
+    },
+    "tests/test_archive_pin.py": {
+      "archive_pin": "scripts/archive_pin.py",
+      "helpers": "tests/helpers.py",
+      "pin_caps": "hooks/pin_caps.py",
+      "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
+      "staleness": "hooks/staleness.py"
+    },
+    "tests/test_archive_pin_emit.py": {
+      "archive_pin": "scripts/archive_pin.py",
+      "helpers": "tests/helpers.py",
+      "staleness": "hooks/staleness.py"
+    },
+    "tests/test_archive_pin_raise_census.py": {},
+    "tests/test_archive_pin_resolver.py": {
+      "archive_pin": "scripts/archive_pin.py"
+    },
+    "tests/test_artifact_paths_durability.py": {
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.paths": "hooks/shared/paths.py",
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_audit_protocol.py": {},
+    "tests/test_audit_summary_overwrite_906.py": {
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_backlog.py": {
+      "session_init": "hooks/session_init.py",
+      "shared": "hooks/shared/__init__.py"
+    },
+    "tests/test_bin_pact_launcher.py": {},
+    "tests/test_bootstrap_gate.py": {
+      "bootstrap_gate": "hooks/bootstrap_gate.py",
+      "shared": "hooks/shared/__init__.py",
+      "shared.marker_schema": "hooks/shared/marker_schema.py",
+      "shared.pact_context": "hooks/shared/pact_context.py"
+    },
+    "tests/test_bootstrap_marker_writer.py": {
+      "bootstrap_gate": "hooks/bootstrap_gate.py",
+      "bootstrap_marker_writer": "hooks/bootstrap_marker_writer.py",
+      "shared": "hooks/shared/__init__.py",
+      "shared.marker_schema": "hooks/shared/marker_schema.py",
+      "shared.pact_context": "hooks/shared/pact_context.py"
+    },
+    "tests/test_bootstrap_prompt_gate.py": {
+      "bootstrap_prompt_gate": "hooks/bootstrap_prompt_gate.py",
+      "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "shared": "hooks/shared/__init__.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.pact_context": "hooks/shared/pact_context.py"
+    },
+    "tests/test_calibration_schema.py": {
+      "shared.variety_scorer": "hooks/shared/variety_scorer.py"
+    },
+    "tests/test_caller_commits_before_embedding.py": {
+      "helpers": "tests/helpers.py",
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py"
+    },
+    "tests/test_caller_path_is_not_created.py": {
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
+      "scripts.database": "tests/../skills/pact-memory/scripts/database.py"
+    },
+    "tests/test_canary_checklist_count.py": {},
+    "tests/test_canonical_journal_frame_gate.py": {
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_canonical_json_contract.py": {
+      "shared.canonical_json": "hooks/shared/canonical_json.py"
+    },
+    "tests/test_canonical_json_identity_certification.py": {
+      "shared.canonical_json": "hooks/shared/canonical_json.py"
+    },
+    "tests/test_catchup_reason_is_read.py": {
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py"
+    },
+    "tests/test_check_pin_caps.py": {
+      "check_pin_caps": "scripts/check_pin_caps.py",
+      "helpers": "tests/helpers.py",
+      "pin_caps": "hooks/pin_caps.py",
+      "staleness": "hooks/staleness.py"
+    },
+    "tests/test_check_unused_imports.py": {},
+    "tests/test_ci_collection_scope.py": {},
+    "tests/test_ci_env_truthiness.py": {
+      "memory_init": "tests/../skills/pact-memory/scripts/memory_init.py"
+    },
+    "tests/test_claude_md_manager.py": {
+      "shared": "hooks/shared/__init__.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py"
+    },
+    "tests/test_claude_md_resolver_parity.py": {
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "staleness": "hooks/staleness.py",
+      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_claudemd_write_prohibition_guard.py": {},
+    "tests/test_cli_output_purity.py": {},
+    "tests/test_commands_structure.py": {
+      "dispatch_gate": "hooks/dispatch_gate.py",
+      "helpers": "tests/helpers.py",
+      "shared": "hooks/shared/__init__.py",
+      "shared.intentional_wait": "hooks/shared/intentional_wait.py"
+    },
+    "tests/test_compact_summary_archive_contract.py": {},
+    "tests/test_compact_summary_session_scope.py": {
+      "postcompact_archive": "hooks/postcompact_archive.py",
+      "session_init": "hooks/session_init.py",
+      "shared.constants": "hooks/shared/constants.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.session_journal": "hooks/shared/session_journal.py"
+    },
+    "tests/test_concurrent_auditor_wake.py": {},
+    "tests/test_config_dir_comprehensive.py": {
+      "session_init": "hooks/session_init.py",
+      "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py",
+      "shared.plugin_manifest": "hooks/shared/plugin_manifest.py",
+      "shared.session_registry": "hooks/shared/session_registry.py"
+    },
+    "tests/test_config_dir_dispatch_integration.py": {
+      "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py"
+    },
+    "tests/test_config_dir_migration_completeness.py": {},
+    "tests/test_config_injection_both_modes.py": {
+      "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "session_init": "hooks/session_init.py"
+    },
+    "tests/test_conftest_config_root_isolation.py": {
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.paths": "hooks/shared/paths.py"
+    },
+    "tests/test_connection_transaction_mode.py": {
+      "scripts.database": "tests/../skills/pact-memory/scripts/database.py"
+    },
+    "tests/test_containment_certification.py": {
+      "session_init": "hooks/session_init.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.session_resume": "hooks/shared/session_resume.py",
+      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_containment_guard.py": {
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "session_init": "hooks/session_init.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.paths": "hooks/shared/paths.py",
+      "shared.session_resume": "hooks/shared/session_resume.py"
+    },
+    "tests/test_count_word_guard.py": {
+      "hooks.shared.variety_divergence": "hooks/shared/variety_divergence.py"
+    },
+    "tests/test_create_ingress_guard.py": {
+      "helpers": "tests/helpers.py",
+      "memory_repair": "scripts/memory_repair/__init__.py",
+      "scripts.database": "tests/../skills/pact-memory/scripts/database.py"
+    },
+    "tests/test_cross_references.py": {},
+    "tests/test_cybernetic_cross_references.py": {
+      "shared.variety_scorer": "hooks/shared/variety_scorer.py"
+    },
+    "tests/test_declared_anchor_contract.py": {
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_dispatch_emission_prose.py": {
+      "shared": "hooks/shared/__init__.py",
+      "shared.constants": "hooks/shared/constants.py"
+    },
+    "tests/test_dispatch_gate.py": {
+      "dispatch_gate": "hooks/dispatch_gate.py",
+      "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py",
+      "shared.intentional_wait": "hooks/shared/intentional_wait.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.task_utils": "hooks/shared/task_utils.py"
+    },
+    "tests/test_dispatch_gate_cause_enumeration.py": {
+      "dispatch_gate": "hooks/dispatch_gate.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "test_dispatch_gate": "tests/test_dispatch_gate.py"
+    },
+    "tests/test_dispatch_gate_integration.py": {
+      "dispatch_gate": "hooks/dispatch_gate.py"
+    },
+    "tests/test_dispatch_gate_smoke.py": {
+      "dispatch_gate": "hooks/dispatch_gate.py",
+      "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.session_journal": "hooks/shared/session_journal.py"
+    },
+    "tests/test_dispatch_gate_stale_diagnosis.py": {
+      "dispatch_gate": "hooks/dispatch_gate.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "test_dispatch_gate": "tests/test_dispatch_gate.py"
+    },
+    "tests/test_dispatch_helpers.py": {
+      "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py"
+    },
+    "tests/test_dispatch_site_emit.py": {
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_dispatch_variety_deny_honor_probe.py": {},
+    "tests/test_dispatch_variety_teachback_ack_emit.py": {
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_dogfood_livelock_invariant.py": {
+      "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
+      "fixtures.emitter": "tests/fixtures/emitter.py"
+    },
+    "tests/test_dual_channel_acceptance_pinned.py": {},
+    "tests/test_embedding_catchup.py": {
+      "embeddings": "skills/pact-memory/scripts/embeddings.py"
+    },
+    "tests/test_embedding_status_contract.py": {
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py"
+    },
+    "tests/test_embedding_status_wiring.py": {
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py"
+    },
+    "tests/test_embedding_window.py": {
+      "scripts.embeddings": "tests/../skills/pact-memory/scripts/embeddings.py"
+    },
+    "tests/test_emit_skip_accounting.py": {
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.variety_divergence": "hooks/shared/variety_divergence.py"
+    },
+    "tests/test_emitter_happy_and_gates.py": {
+      "fixtures.emitter": "tests/fixtures/emitter.py"
+    },
+    "tests/test_emitter_idempotency.py": {
+      "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py"
+    },
+    "tests/test_emitter_path_sanitization.py": {
+      "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.pact_context": "hooks/shared/pact_context.py"
+    },
+    "tests/test_emitter_race_regression.py": {
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py"
+    },
+    "tests/test_emitter_real_disk.py": {
+      "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "shared": "hooks/shared/__init__.py"
+    },
+    "tests/test_emitter_resolution.py": {
+      "fixtures.emitter": "tests/fixtures/emitter.py"
+    },
+    "tests/test_emitter_robustness.py": {
+      "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
+      "fixtures.emitter": "tests/fixtures/emitter.py"
+    },
+    "tests/test_environment_drift.py": {
+      "file_tracker": "hooks/file_tracker.py"
+    },
+    "tests/test_environment_drift_convention.py": {},
+    "tests/test_error_output.py": {
+      "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
+      "file_tracker": "hooks/file_tracker.py",
+      "git_commit_check": "hooks/git_commit_check.py",
+      "merge_guard_post": "hooks/merge_guard_post.py",
+      "peer_inject": "hooks/peer_inject.py",
+      "postcompact_archive": "hooks/postcompact_archive.py",
+      "precompact_state_reminder": "hooks/precompact_state_reminder.py",
+      "session_end": "hooks/session_end.py",
+      "session_init": "hooks/session_init.py",
+      "shared": "hooks/shared/__init__.py",
+      "shared.error_output": "hooks/shared/error_output.py",
+      "teammate_idle": "hooks/teammate_idle.py",
+      "track_files": "hooks/track_files.py",
+      "validate_handoff": "hooks/validate_handoff.py"
+    },
+    "tests/test_exemption_policy_tripwires.py": {
+      "shared": "hooks/shared/__init__.py",
+      "shared.intentional_wait": "hooks/shared/intentional_wait.py",
+      "test_harvest_trigger_coherence": "tests/test_harvest_trigger_coherence.py"
+    },
+    "tests/test_failure_cause_convention.py": {
+      "shared": "hooks/shared/__init__.py",
+      "shared.failure_cause": "hooks/shared/failure_cause.py",
+      "shared.session_resume": "hooks/shared/session_resume.py"
+    },
+    "tests/test_failure_log.py": {
+      "shared": "hooks/shared/__init__.py",
+      "shared.failure_log": "hooks/shared/failure_log.py"
+    },
+    "tests/test_file_permissions.py": {
+      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.setup_memory": "tests/../skills/pact-memory/scripts/setup_memory.py"
+    },
+    "tests/test_file_tracker.py": {
+      "file_tracker": "hooks/file_tracker.py"
+    },
+    "tests/test_file_tracker_composite_key_edges.py": {
+      "file_tracker": "hooks/file_tracker.py"
+    },
+    "tests/test_first_observable_write_misfire_invariant.py": {},
+    "tests/test_gate_crashpath_hardening.py": {
+      "bootstrap_gate": "hooks/bootstrap_gate.py",
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py",
+      "tests.test_bootstrap_gate": "tests/test_bootstrap_gate.py"
+    },
+    "tests/test_gate_invalid_mode_resolution.py": {},
+    "tests/test_gh_helpers.py": {
+      "shared": "hooks/shared/__init__.py",
+      "shared.gh_helpers": "hooks/shared/gh_helpers.py"
+    },
+    "tests/test_git_commit_check.py": {
+      "git_commit_check": "hooks/git_commit_check.py"
+    },
+    "tests/test_git_helpers.py": {
+      "shared.git_helpers": "hooks/shared/git_helpers.py"
+    },
+    "tests/test_handoff_917_captured_regression.py": {
+      "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_handoff_advisories.py": {
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_handoff_b1_b2_dedup.py": {
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_handoff_census.py": {
+      "handoff_census": "scripts/handoff_census.py"
+    },
+    "tests/test_handoff_content_discrimination.py": {
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "shared.canonical_json": "hooks/shared/canonical_json.py"
+    },
+    "tests/test_handoff_eligibility_parity.py": {
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_handoff_key_annotation_pinned.py": {
+      "shared.handoff_schema": "hooks/shared/handoff_schema.py"
+    },
+    "tests/test_handoff_ordering_gate.py": {
+      "handoff_ordering_gate": "hooks/handoff_ordering_gate.py",
+      "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py",
+      "shared.pact_context": "hooks/shared/pact_context.py"
+    },
+    "tests/test_handoff_schema.py": {
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "shared.handoff_schema": "hooks/shared/handoff_schema.py"
+    },
+    "tests/test_handoff_unclaim_twin_917.py": {
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_handoff_writability_parity.py": {
+      "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_handoff_write_after_completion_backstop.py": {
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_harness_aware_bootstrap.py": {
+      "bootstrap_marker_writer": "hooks/bootstrap_marker_writer.py",
+      "shared": "hooks/shared/__init__.py",
+      "shared.pact_context": "hooks/shared/pact_context.py"
+    },
+    "tests/test_harvest_ledger_read_contract.py": {},
+    "tests/test_harvest_prune_foreign_root.py": {},
+    "tests/test_harvest_trigger_coherence.py": {},
+    "tests/test_hook_emitted_config_root.py": {
+      "bootstrap_gate": "hooks/bootstrap_gate.py",
+      "session_init": "hooks/session_init.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py"
+    },
+    "tests/test_hook_infra_classifier.py": {
+      "shared.hook_infra_classifier": "hooks/shared/hook_infra_classifier.py"
+    },
+    "tests/test_hook_schema_compliance.py": {},
+    "tests/test_hooks_json.py": {},
+    "tests/test_idle_preamble.py": {
+      "teammate_idle": "hooks/teammate_idle.py"
+    },
+    "tests/test_import_bar_cause_presence.py": {},
+    "tests/test_import_hygiene.py": {},
+    "tests/test_import_identity_map.py": {
+      "import_identity_map": "tests/import_identity_map.py"
+    },
+    "tests/test_index_append_method_pinned.py": {},
+    "tests/test_ingress_guard_mechanisms.py": {
+      "helpers": "tests/helpers.py",
+      "scripts.database": "tests/../skills/pact-memory/scripts/database.py"
+    },
+    "tests/test_intentional_wait.py": {
+      "shared": "hooks/shared/__init__.py",
+      "shared.intentional_wait": "hooks/shared/intentional_wait.py"
+    },
+    "tests/test_is_lead.py": {
+      "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "shared.pact_context": "hooks/shared/pact_context.py"
+    },
+    "tests/test_lazy_load_cross_references.py": {},
+    "tests/test_lead_discriminator_invariant.py": {},
+    "tests/test_lead_side_handoff_emit.py": {
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_learning_ii.py": {},
+    "tests/test_lint_check_argument_accounting.py": {},
+    "tests/test_lint_check_files_mode.py": {},
+    "tests/test_lint_check_help.py": {},
+    "tests/test_lock_identity_certification.py": {
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_managed_comment_emitted.py": {
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.session_resume": "hooks/shared/session_resume.py",
+      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_managed_comment_mirror.py": {},
+    "tests/test_marker_helper_twin_drift.py": {
+      "shared.pin_markers": "hooks/shared/pin_markers.py",
+      "tests": "tests/__init__.py",
+      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_marker_namespace.py": {
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py"
+    },
+    "tests/test_marker_schema.py": {
+      "bootstrap_gate": "hooks/bootstrap_gate.py",
+      "shared.marker_schema": "hooks/shared/marker_schema.py"
+    },
+    "tests/test_memory_api_import_time_reach.py": {},
+    "tests/test_memory_cli.py": {
+      "helpers": "tests/helpers.py",
+      "scripts.cli": "tests/../skills/pact-memory/scripts/cli.py",
+      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "test_working_memory_concurrency_comprehensive": "tests/test_working_memory_concurrency_comprehensive.py"
+    },
+    "tests/test_memory_ct_fields.py": {
+      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.models": "tests/../skills/pact-memory/scripts/models.py",
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_memory_database.py": {
+      "helpers": "tests/helpers.py",
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
+      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.models": "tests/../skills/pact-memory/scripts/models.py"
+    },
+    "tests/test_memory_end_marker_bounds_the_pin_scan.py": {
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "staleness": "hooks/staleness.py"
+    },
+    "tests/test_memory_graph.py": {
+      "helpers": "tests/helpers.py",
+      "scripts.graph": "tests/../skills/pact-memory/scripts/graph.py"
+    },
+    "tests/test_memory_init.py": {
+      "memory_init": "tests/../skills/pact-memory/scripts/memory_init.py"
+    },
+    "tests/test_memory_layer_composition.py": {
+      "helpers": "tests/helpers.py",
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
+      "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
+      "scripts.embeddings": "tests/../skills/pact-memory/scripts/embeddings.py",
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py"
+    },
+    "tests/test_memory_models.py": {
+      "scripts.models": "tests/../skills/pact-memory/scripts/models.py"
+    },
+    "tests/test_memory_patterns_docs.py": {},
+    "tests/test_memory_reachability.py": {
+      "memory_reachability": "scripts/memory_reachability.py"
+    },
+    "tests/test_memory_store_isolation.py": {
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
+      "scripts.config": "tests/../skills/pact-memory/scripts/config.py"
+    },
+    "tests/test_memory_store_scope.py": {
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
+      "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
+      "scripts.database": "tests/../skills/pact-memory/scripts/database.py"
+    },
+    "tests/test_merge_guard.py": {
+      "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared": "hooks/shared/__init__.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_1037_narrow.py": {
+      "merge_guard_pre": "hooks/merge_guard_pre.py"
+    },
+    "tests/test_merge_guard_1118_output_selector.py": {
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_1118_output_selector_cert.py": {
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_1118_recert.py": {
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_1129_r1_branch_set.py": {
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_1129_r1_cert.py": {
+      "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_1129_r2_cert.py": {
+      "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_1129_r3_cert.py": {
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_1134_cert.py": {
+      "merge_guard_baseline_loader": "tests/merge_guard_baseline_loader.py",
+      "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_1136_canonical_join_ssot.py": {
+      "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_1140_carrier5_cert.py": {
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_1148_cert.py": {
+      "merge_guard_baseline_loader": "tests/merge_guard_baseline_loader.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_1155_cert.py": {
+      "merge_guard_baseline_loader": "tests/merge_guard_baseline_loader.py",
+      "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_1178_cert.py": {
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_1178_f2_cert.py": {
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_1181_cert.py": {
+      "merge_guard_baseline_loader": "tests/merge_guard_baseline_loader.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_1203_cert.py": {
+      "merge_guard_baseline_loader": "tests/merge_guard_baseline_loader.py",
+      "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_auth_symmetry.py": {
+      "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_mint_parity.py": {
+      "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_pre": "hooks/merge_guard_pre.py"
+    },
+    "tests/test_merge_guard_obs_cert.py": {
+      "merge_guard_baseline_loader": "tests/merge_guard_baseline_loader.py",
+      "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_op_recognition_completeness.py": {
+      "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_output_side_process_sub.py": {
+      "merge_guard_pre": "hooks/merge_guard_pre.py"
+    },
+    "tests/test_merge_guard_over_block_batch.py": {
+      "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_overblock_cluster_monotonicity.py": {
+      "merge_guard_baseline_loader": "tests/merge_guard_baseline_loader.py",
+      "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py",
+      "test_merge_guard_1148_cert": "tests/test_merge_guard_1148_cert.py",
+      "test_merge_guard_1155_cert": "tests/test_merge_guard_1155_cert.py",
+      "test_merge_guard_1181_cert": "tests/test_merge_guard_1181_cert.py",
+      "test_merge_guard_obs_cert": "tests/test_merge_guard_obs_cert.py"
+    },
+    "tests/test_merge_guard_overblock_tokenizers.py": {
+      "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_perf.py": {
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared": "hooks/shared/__init__.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_pre.py": {
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared": "hooks/shared/__init__.py"
+    },
+    "tests/test_merge_guard_privileged_flags.py": {
+      "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_seam_integration.py": {
+      "merge_guard_post": "hooks/merge_guard_post.py",
+      "merge_guard_pre": "hooks/merge_guard_pre.py",
+      "shared.merge_guard_common": "hooks/shared/merge_guard_common.py"
+    },
+    "tests/test_merge_guard_why_oracle.py": {},
+    "tests/test_migration_section_comment.py": {
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py"
+    },
+    "tests/test_missed_wake_scan.py": {
+      "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "missed_wake_scan": "hooks/missed_wake_scan.py"
+    },
+    "tests/test_missed_wake_scan_integration.py": {
+      "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "missed_wake_scan": "hooks/missed_wake_scan.py",
+      "shared": "hooks/shared/__init__.py",
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "teammate_idle": "hooks/teammate_idle.py"
+    },
+    "tests/test_no_broadcast_addressing.py": {},
+    "tests/test_orchestration_retrospective.py": {
+      "shared.teachback_schema": "hooks/shared/teachback_schema.py",
+      "shared.variety_divergence": "hooks/shared/variety_divergence.py"
+    },
+    "tests/test_packaging_boundary.py": {},
+    "tests/test_pact_config.py": {
+      "shared.pact_config": "hooks/shared/pact_config.py"
+    },
+    "tests/test_pact_config_gate_migration.py": {
+      "shared.pact_config": "hooks/shared/pact_config.py"
+    },
+    "tests/test_pact_config_injection.py": {
+      "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "session_init": "hooks/session_init.py"
+    },
+    "tests/test_pact_context.py": {
+      "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.pact_session": "tests/../skills/pact-memory/scripts/pact_session.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.session_registry": "hooks/shared/session_registry.py",
+      "shared.task_utils": "hooks/shared/task_utils.py"
+    },
+    "tests/test_pact_harvest_cli.py": {
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.pact_harvest": "hooks/shared/pact_harvest.py",
+      "shared.paths": "hooks/shared/paths.py",
+      "shared.session_journal": "hooks/shared/session_journal.py"
+    },
+    "tests/test_pact_orchestrator_agent.py": {
+      "helpers": "tests/helpers.py"
+    },
+    "tests/test_pact_session_config_dir_parity.py": {
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py"
+    },
+    "tests/test_paths.py": {
+      "shared.constants": "hooks/shared/constants.py",
+      "shared.failure_log": "hooks/shared/failure_log.py",
+      "shared.paths": "hooks/shared/paths.py",
+      "track_files": "hooks/track_files.py"
+    },
+    "tests/test_peer_inject.py": {
+      "peer_inject": "hooks/peer_inject.py"
+    },
+    "tests/test_peer_review_greedy_pin.py": {},
+    "tests/test_peer_review_independence_pin.py": {},
+    "tests/test_per_dispatch_variety.py": {
+      "shared": "hooks/shared/__init__.py",
+      "shared.teachback_schema": "hooks/shared/teachback_schema.py",
+      "shared.variety_divergence": "hooks/shared/variety_divergence.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_per_write_adversarial_matrix.py": {
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_per_write_mirror_registry.py": {
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py"
+    },
+    "tests/test_per_write_snapshot_seam.py": {
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_pin_caps.py": {
+      "pin_caps": "hooks/pin_caps.py"
+    },
+    "tests/test_pin_caps_adversarial.py": {
+      "pin_caps": "hooks/pin_caps.py",
+      "pin_staleness_gate": "hooks/pin_staleness_gate.py",
+      "session_init": "hooks/session_init.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "staleness": "hooks/staleness.py"
+    },
+    "tests/test_pin_caps_gate.py": {
+      "helpers": "tests/helpers.py",
+      "pin_caps_gate": "hooks/pin_caps_gate.py",
+      "staleness": "hooks/staleness.py"
+    },
+    "tests/test_pin_caps_gate_counter_test.py": {
+      "helpers": "tests/helpers.py",
+      "pin_caps": "hooks/pin_caps.py",
+      "pin_caps_gate": "hooks/pin_caps_gate.py",
+      "staleness": "hooks/staleness.py"
+    },
+    "tests/test_pin_caps_gate_low_priority.py": {
+      "helpers": "tests/helpers.py",
+      "pin_caps_gate": "hooks/pin_caps_gate.py",
+      "staleness": "hooks/staleness.py"
+    },
+    "tests/test_pin_caps_gate_matrix.py": {
+      "helpers": "tests/helpers.py",
+      "pin_caps": "hooks/pin_caps.py",
+      "pin_caps_gate": "hooks/pin_caps_gate.py",
+      "staleness": "hooks/staleness.py"
+    },
+    "tests/test_pin_caps_integration.py": {
+      "helpers": "tests/helpers.py",
+      "pin_caps": "hooks/pin_caps.py",
+      "pin_staleness_gate": "hooks/pin_staleness_gate.py",
+      "session_init": "hooks/session_init.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "staleness": "hooks/staleness.py"
+    },
+    "tests/test_pin_caps_phantom_green.py": {
+      "check_pin_caps": "scripts/check_pin_caps.py",
+      "helpers": "tests/helpers.py",
+      "pin_caps_gate": "hooks/pin_caps_gate.py",
+      "staleness": "hooks/staleness.py"
+    },
+    "tests/test_pin_comment_dominance.py": {
+      "helpers": "tests/helpers.py",
+      "pin_caps": "hooks/pin_caps.py",
+      "pin_caps_gate": "hooks/pin_caps_gate.py",
+      "staleness": "hooks/staleness.py"
+    },
+    "tests/test_pin_comment_pipeline.py": {
+      "pin_caps": "hooks/pin_caps.py"
+    },
+    "tests/test_pin_marker_writer.py": {
+      "pin_marker_writer": "hooks/pin_marker_writer.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.pin_markers": "hooks/shared/pin_markers.py",
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "staleness": "hooks/staleness.py",
+      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_pin_marker_writer_adversarial.py": {
+      "pin_caps": "hooks/pin_caps.py",
+      "pin_caps_gate": "hooks/pin_caps_gate.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.pin_markers": "hooks/shared/pin_markers.py",
+      "staleness": "hooks/staleness.py",
+      "tests.test_pin_marker_writer": "tests/test_pin_marker_writer.py"
+    },
+    "tests/test_pin_staleness_gate.py": {
+      "helpers": "tests/helpers.py",
+      "pin_staleness_gate": "hooks/pin_staleness_gate.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "staleness": "hooks/staleness.py"
+    },
+    "tests/test_pin_staleness_gate_two_rules.py": {
+      "pin_staleness_gate": "hooks/pin_staleness_gate.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "staleness": "hooks/staleness.py"
+    },
+    "tests/test_pin_staleness_marker_clear.py": {
+      "pin_staleness_gate": "hooks/pin_staleness_gate.py",
+      "shared": "hooks/shared/__init__.py",
+      "shared.constants": "hooks/shared/constants.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "staleness": "hooks/staleness.py",
+      "track_files": "hooks/track_files.py"
+    },
+    "tests/test_planning_artifact_scrub.py": {},
+    "tests/test_plugin_json_orchestrator.py": {},
+    "tests/test_plugin_manifest.py": {
+      "shared": "hooks/shared/__init__.py",
+      "shared.plugin_manifest": "hooks/shared/plugin_manifest.py"
+    },
+    "tests/test_plugin_manifest_parity.py": {},
+    "tests/test_plugin_version_bump.py": {},
+    "tests/test_postcompact_archive.py": {
+      "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "postcompact_archive": "hooks/postcompact_archive.py",
+      "shared.constants": "hooks/shared/constants.py"
+    },
+    "tests/test_pr4_drain_survival_harvest.py": {
+      "shared.session_journal": "hooks/shared/session_journal.py"
+    },
+    "tests/test_pr4_revision_v2_on_journal.py": {
+      "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
+      "shared.session_journal": "hooks/shared/session_journal.py"
+    },
+    "tests/test_precompact_state_reminder.py": {
+      "precompact_state_reminder": "hooks/precompact_state_reminder.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.session_journal": "hooks/shared/session_journal.py"
+    },
+    "tests/test_progress_signals.py": {},
+    "tests/test_project_dir_resolution.py": {
+      "fixtures.project_dir": "tests/fixtures/project_dir.py",
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.pact_session": "tests/../skills/pact-memory/scripts/pact_session.py",
+      "shared": "hooks/shared/__init__.py"
+    },
+    "tests/test_project_id.py": {
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py"
+    },
+    "tests/test_prose_root_gate.py": {},
+    "tests/test_prune_memory_integration.py": {
+      "check_pin_caps": "scripts/check_pin_caps.py",
+      "helpers": "tests/helpers.py",
+      "pin_caps_gate": "hooks/pin_caps_gate.py",
+      "staleness": "hooks/staleness.py"
+    },
+    "tests/test_prune_telemetry_contract.py": {},
+    "tests/test_py39_annotation_compat.py": {},
+    "tests/test_read_lead_session_id_parity.py": {
+      "shared.session_registry": "hooks/shared/session_registry.py",
+      "task_claim_gate": "hooks/task_claim_gate.py"
+    },
+    "tests/test_read_trigger_precondition_pinned.py": {},
+    "tests/test_recovery_pointer_fallback.py": {
+      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_resume_team_realign_1507.py": {
+      "dispatch_gate": "hooks/dispatch_gate.py",
+      "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py",
+      "shared.pact_context": "hooks/shared/pact_context.py"
+    },
+    "tests/test_resumption_marker_mirror.py": {
+      "shared.session_journal": "hooks/shared/session_journal.py"
+    },
+    "tests/test_resumption_marker_seam.py": {
+      "session_init": "hooks/session_init.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "tests.test_resumption_marker_mirror": "tests/test_resumption_marker_mirror.py",
+      "tests.test_session_init": "tests/test_session_init.py"
+    },
+    "tests/test_role_gate_flip_and_postcompact.py": {
+      "bootstrap_gate": "hooks/bootstrap_gate.py",
+      "bootstrap_marker_writer": "hooks/bootstrap_marker_writer.py",
+      "bootstrap_prompt_gate": "hooks/bootstrap_prompt_gate.py",
+      "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "pin_caps_gate": "hooks/pin_caps_gate.py",
+      "pin_staleness_gate": "hooks/pin_staleness_gate.py",
+      "postcompact_archive": "hooks/postcompact_archive.py",
+      "shared.pact_context": "hooks/shared/pact_context.py"
+    },
+    "tests/test_seam_line_ending_call_sites.py": {
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "staleness": "hooks/staleness.py",
+      "test_staleness": "tests/test_staleness.py"
+    },
+    "tests/test_session_block_substitution.py": {
+      "shared.session_resume": "hooks/shared/session_resume.py"
+    },
+    "tests/test_session_consolidated_integration.py": {
+      "session_end": "hooks/session_end.py",
+      "shared.gh_helpers": "hooks/shared/gh_helpers.py",
+      "shared.session_journal": "hooks/shared/session_journal.py"
+    },
+    "tests/test_session_discovery_route.py": {
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py"
+    },
+    "tests/test_session_end.py": {
+      "session_end": "hooks/session_end.py",
+      "shared.gh_helpers": "hooks/shared/gh_helpers.py"
+    },
+    "tests/test_session_end_integration.py": {
+      "session_end": "hooks/session_end.py"
+    },
+    "tests/test_session_end_registry_prune.py": {
+      "session_end": "hooks/session_end.py"
+    },
+    "tests/test_session_end_survives_a_forged_heading.py": {
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "tests.test_pin_marker_writer": "tests/test_pin_marker_writer.py",
+      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_session_init.py": {
+      "session_init": "hooks/session_init.py",
+      "shared": "hooks/shared/__init__.py",
+      "shared.constants": "hooks/shared/constants.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.symlinks": "hooks/shared/symlinks.py",
+      "shared.teammate_mode": "hooks/shared/teammate_mode.py"
+    },
+    "tests/test_session_init_env_file.py": {
+      "session_init": "hooks/session_init.py"
+    },
+    "tests/test_session_init_integration.py": {
+      "session_init": "hooks/session_init.py",
+      "shared": "hooks/shared/__init__.py"
+    },
+    "tests/test_session_init_primary_frame_keeps_the_ladder.py": {
+      "session_init": "hooks/session_init.py"
+    },
+    "tests/test_session_init_role_suppression.py": {
+      "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "session_init": "hooks/session_init.py",
+      "shared.pact_context": "hooks/shared/pact_context.py"
+    },
+    "tests/test_session_init_routing_contract.py": {
+      "session_init": "hooks/session_init.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.session_resume": "hooks/shared/session_resume.py",
+      "shared.symlinks": "hooks/shared/symlinks.py",
+      "staleness": "hooks/staleness.py"
+    },
+    "tests/test_session_init_teammate_peer_inject.py": {
+      "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "peer_inject": "hooks/peer_inject.py",
+      "session_init": "hooks/session_init.py"
+    },
+    "tests/test_session_init_teammate_peer_inject_acceptance.py": {},
+    "tests/test_session_init_three_way_role_gate.py": {
+      "session_init": "hooks/session_init.py"
+    },
+    "tests/test_session_journal.py": {
+      "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
+      "session_end": "hooks/session_end.py",
+      "session_init": "hooks/session_init.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_resume": "hooks/shared/session_resume.py",
+      "shared.variety_divergence": "hooks/shared/variety_divergence.py"
+    },
+    "tests/test_session_registry.py": {
+      "shared": "hooks/shared/__init__.py",
+      "shared.paths": "hooks/shared/paths.py",
+      "shared.session_registry": "hooks/shared/session_registry.py"
+    },
+    "tests/test_session_registry_concurrency.py": {
+      "shared": "hooks/shared/__init__.py",
+      "shared.session_registry": "hooks/shared/session_registry.py"
+    },
+    "tests/test_session_registry_integrity.py": {
+      "shared": "hooks/shared/__init__.py",
+      "shared.session_registry": "hooks/shared/session_registry.py"
+    },
+    "tests/test_session_registry_mode_gate.py": {
+      "shared": "hooks/shared/__init__.py",
+      "shared.session_registry": "hooks/shared/session_registry.py"
+    },
+    "tests/test_session_registry_trust_partition.py": {
+      "session_end": "hooks/session_end.py",
+      "shared": "hooks/shared/__init__.py",
+      "shared.peer_context": "hooks/shared/peer_context.py",
+      "shared.session_registry": "hooks/shared/session_registry.py"
+    },
+    "tests/test_session_resume.py": {
+      "session_init": "hooks/session_init.py",
+      "shared": "hooks/shared/__init__.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.failure_cause": "hooks/shared/failure_cause.py",
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_resume": "hooks/shared/session_resume.py"
+    },
+    "tests/test_session_state.py": {
+      "shared": "hooks/shared/__init__.py",
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.session_state": "hooks/shared/session_state.py"
+    },
+    "tests/test_settings_example_json.py": {},
+    "tests/test_settings_well_formed.py": {
+      "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "session_init": "hooks/session_init.py"
+    },
+    "tests/test_setup_memory.py": {
+      "scripts.setup_memory": "tests/../skills/pact-memory/scripts/setup_memory.py"
+    },
+    "tests/test_shred_detect.py": {
+      "memory_repair": "scripts/memory_repair/__init__.py",
+      "scripts.database": "tests/../skills/pact-memory/scripts/database.py"
+    },
+    "tests/test_skills_structure.py": {
+      "helpers": "tests/helpers.py"
+    },
+    "tests/test_snapshot_adversarial_matrix.py": {
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py"
+    },
+    "tests/test_snapshot_empty_team_dedup_cert.py": {
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_snapshot_key_count_discriminator.py": {
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py"
+    },
+    "tests/test_snapshot_marker_root_fallback.py": {
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py"
+    },
+    "tests/test_snapshot_provenance_semantics.py": {
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py"
+    },
+    "tests/test_snapshot_roundtrip.py": {
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_snapshot_seam_emitter.py": {
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py"
+    },
+    "tests/test_snapshot_seams_gate.py": {
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_snapshot_subprocess_seam.py": {
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py"
+    },
+    "tests/test_spawn_overhead_benchmark.py": {
+      "peer_inject": "hooks/peer_inject.py"
+    },
+    "tests/test_splice_window_memory_region.py": {
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "tests.test_pin_marker_writer": "tests/test_pin_marker_writer.py",
+      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_stale_session.py": {
+      "shared.stale_session": "hooks/shared/stale_session.py"
+    },
+    "tests/test_staleness.py": {
+      "pin_caps": "hooks/pin_caps.py",
+      "pin_caps_gate": "hooks/pin_caps_gate.py",
+      "session_init": "hooks/session_init.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "shared.session_resume": "hooks/shared/session_resume.py",
+      "staleness": "hooks/staleness.py",
+      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_store_access_bar_presence.py": {},
+    "tests/test_store_scope_decorator_contract.py": {
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py"
+    },
+    "tests/test_subagent_start_selects_teammate_frames.py": {},
+    "tests/test_symlinks.py": {
+      "shared.symlinks": "hooks/shared/symlinks.py"
+    },
+    "tests/test_sync_result_contract.py": {
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_task_claim_gate.py": {
+      "role_frames": "tests/fixtures/role_frames.py",
+      "task_claim_gate": "hooks/task_claim_gate.py"
+    },
+    "tests/test_task_id_sanitization_parity.py": {
+      "agent_handoff_emitter": "hooks/agent_handoff_emitter.py",
+      "fixtures.emitter": "tests/fixtures/emitter.py",
+      "shared.agent_handoff_marker": "hooks/shared/agent_handoff_marker.py",
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_task_integration.py": {
+      "shared.task_utils": "hooks/shared/task_utils.py"
+    },
+    "tests/test_task_lifecycle_gate.py": {
+      "shared.teachback_schema": "hooks/shared/teachback_schema.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_task_lifecycle_gate_degraded.py": {
+      "tests.test_bootstrap_gate": "tests/test_bootstrap_gate.py"
+    },
+    "tests/test_task_lifecycle_gate_smoke.py": {
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_task_metadata_snapshot.py": {
+      "shared.task_metadata_snapshot": "hooks/shared/task_metadata_snapshot.py"
+    },
+    "tests/test_task_utils.py": {
+      "task_utils": "hooks/shared/task_utils.py"
+    },
+    "tests/test_taskb_claim_prose_guard.py": {},
+    "tests/test_teachback_reasoning_reconstruction.py": {
+      "shared.intentional_wait": "hooks/shared/intentional_wait.py",
+      "shared.teachback_schema": "hooks/shared/teachback_schema.py",
+      "shared.variety_scorer": "hooks/shared/variety_scorer.py",
+      "test_skills_structure": "tests/test_skills_structure.py"
+    },
+    "tests/test_teachback_schema.py": {
+      "shared.teachback_schema": "hooks/shared/teachback_schema.py",
+      "shared.variety_scorer": "hooks/shared/variety_scorer.py"
+    },
+    "tests/test_teachback_subject_hoist_parity.py": {
+      "shared.task_utils": "hooks/shared/task_utils.py",
+      "task_lifecycle_gate": "hooks/task_lifecycle_gate.py"
+    },
+    "tests/test_team_name_detect_align.py": {
+      "bootstrap_marker_writer": "hooks/bootstrap_marker_writer.py",
+      "fixtures.role_frames": "tests/fixtures/role_frames.py",
+      "session_end": "hooks/session_end.py",
+      "shared.pact_context": "hooks/shared/pact_context.py",
+      "shared.peer_context": "hooks/shared/peer_context.py",
+      "shared.session_state": "hooks/shared/session_state.py",
+      "shared.task_utils": "hooks/shared/task_utils.py"
+    },
+    "tests/test_team_name_resolution_both_modes.py": {
+      "dispatch_gate": "hooks/dispatch_gate.py",
+      "session_init": "hooks/session_init.py",
+      "shared.dispatch_helpers": "hooks/shared/dispatch_helpers.py",
+      "shared.pact_context": "hooks/shared/pact_context.py"
+    },
+    "tests/test_team_registration_skill.py": {
+      "shared": "hooks/shared/__init__.py"
+    },
+    "tests/test_teammate_idle.py": {
+      "teammate_idle": "hooks/teammate_idle.py"
+    },
+    "tests/test_teammate_mode.py": {
+      "shared.teammate_mode": "hooks/shared/teammate_mode.py"
+    },
+    "tests/test_telegram_client.py": {
+      "telegram.telegram_client": "telegram/telegram_client.py"
+    },
+    "tests/test_telegram_config.py": {
+      "telegram.config": "telegram/config.py"
+    },
+    "tests/test_telegram_content_filter.py": {
+      "telegram.content_filter": "telegram/content_filter.py"
+    },
+    "tests/test_telegram_deps.py": {
+      "telegram.deps": "telegram/deps.py"
+    },
+    "tests/test_telegram_main.py": {
+      "telegram.__main__": "telegram/__main__.py"
+    },
+    "tests/test_telegram_notify.py": {
+      "telegram.notify": "telegram/notify.py"
+    },
+    "tests/test_telegram_routing.py": {
+      "telegram.config": "telegram/config.py",
+      "telegram.routing": "telegram/routing.py"
+    },
+    "tests/test_telegram_server.py": {
+      "telegram.routing": "telegram/routing.py",
+      "telegram.server": "telegram/server.py",
+      "telegram.tools": "telegram/tools.py",
+      "telegram.voice": "telegram/voice.py"
+    },
+    "tests/test_telegram_tools.py": {
+      "telegram.telegram_client": "telegram/telegram_client.py",
+      "telegram.tools": "telegram/tools.py"
+    },
+    "tests/test_telegram_voice.py": {
+      "telegram.voice": "telegram/voice.py"
+    },
+    "tests/test_testing_craft_pins.py": {},
+    "tests/test_three_surface_split_enforcement.py": {},
+    "tests/test_token_budget.py": {
+      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_token_budget_constants_coupling.py": {
+      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_tool_response.py": {
+      "shared.tool_response": "hooks/shared/tool_response.py"
+    },
+    "tests/test_track_files.py": {
+      "track_files": "hooks/track_files.py"
+    },
+    "tests/test_validate_handoff.py": {
+      "validate_handoff": "hooks/validate_handoff.py"
+    },
+    "tests/test_validate_handoff_integration.py": {
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "validate_handoff": "hooks/validate_handoff.py"
+    },
+    "tests/test_variety_divergence.py": {
+      "shared.session_journal": "hooks/shared/session_journal.py",
+      "shared.variety_divergence": "hooks/shared/variety_divergence.py"
+    },
+    "tests/test_variety_rationale_contamination.py": {},
+    "tests/test_variety_scorer.py": {
+      "shared.variety_scorer": "hooks/shared/variety_scorer.py"
+    },
+    "tests/test_variety_scorer_fuzz.py": {
+      "hypothesis": null,
+      "shared.variety_scorer": "hooks/shared/variety_scorer.py"
+    },
+    "tests/test_vector_dimension_fixes.py": {
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
+      "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
+      "scripts.database": "tests/../skills/pact-memory/scripts/database.py",
+      "scripts.embeddings": "tests/../skills/pact-memory/scripts/embeddings.py",
+      "scripts.memory_init": "tests/../skills/pact-memory/scripts/memory_init.py",
+      "scripts.search": "tests/../skills/pact-memory/scripts/search.py"
+    },
+    "tests/test_vector_write_path.py": {
+      "helpers": "tests/helpers.py",
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py"
+    },
+    "tests/test_verify_gate_tree.py": {},
+    "tests/test_wait_discipline_layers_pinned.py": {
+      "test_wake_ordering_pinned": "tests/test_wake_ordering_pinned.py"
+    },
+    "tests/test_wait_discipline_pins.py": {},
+    "tests/test_wait_filler_gate.py": {
+      "shared.hook_infra_classifier": "hooks/shared/hook_infra_classifier.py",
+      "wait_filler_gate": "hooks/wait_filler_gate.py"
+    },
+    "tests/test_wake_ordering_pinned.py": {},
+    "tests/test_window_rule_decline.py": {
+      "scripts": "tests/../skills/pact-memory/scripts/__init__.py",
+      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_working_memory.py": {
+      "pin_staleness_gate": "hooks/pin_staleness_gate.py",
+      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_working_memory_concurrency.py": {
+      "shared": "hooks/shared/__init__.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_working_memory_concurrency_comprehensive.py": {
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "test_staleness": "tests/test_staleness.py",
+      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_working_memory_fidelity.py": {
+      "helpers": "tests/helpers.py",
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "test_memory_cli": "tests/test_memory_cli.py"
+    },
+    "tests/test_working_memory_parser.py": {
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py",
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py"
+    },
+    "tests/test_working_memory_projection.py": {
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_working_memory_redirected_store_refusal.py": {
+      "scripts.config": "tests/../skills/pact-memory/scripts/config.py",
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_working_memory_resolver_and_lock_release.py": {
+      "shared.claude_md_manager": "hooks/shared/claude_md_manager.py",
+      "working_memory": "skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_working_memory_worktree_sync.py": {
+      "scripts.memory_api": "tests/../skills/pact-memory/scripts/memory_api.py",
+      "scripts.working_memory": "tests/../skills/pact-memory/scripts/working_memory.py"
+    },
+    "tests/test_worktree_cleanup_docs_probe.py": {},
+    "tests/test_worktree_guard.py": {
+      "worktree_guard": "hooks/worktree_guard.py"
+    },
+    "tests/test_wrapup_datasafety_contracts.py": {}
+  },
+  "path_drift_since_sessionstart": [
+    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory",
+    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory",
+    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks/shared",
+    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/fixtures",
+    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory",
+    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory",
+    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../scripts",
+    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory/scripts",
+    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory",
+    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-handoff-harvest",
+    "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-agent-teams"
+  ]
+}

--- a/pact-plugin/tests/import_identity_map.py
+++ b/pact-plugin/tests/import_identity_map.py
@@ -72,8 +72,9 @@ def imported_names(test_file):
 
 
 def resolve_origins(names):
-    """find_spec each dotted name -> origin, repo-relative when under the
-    plugin root, None when unresolvable. Externals omitted entirely.
+    """find_spec each dotted name -> origin, repo-relative and
+    resolve-normalized when under the plugin root (no 'tests/../' spellings),
+    None when unresolvable. Externals omitted entirely.
 
     find_spec on a dotted name imports its parent packages — acceptable
     here (scripts/__init__.py is trivial); flagged so a future heavyweight
@@ -90,7 +91,17 @@ def resolve_origins(names):
         if not origin:
             out[name] = None
             continue
+        # resolve() before relative_to: sys.path entries carrying '..' (e.g.
+        # a tests/../skills insert) otherwise leak 'tests/../'-spelled origins
+        # into the map — pure spelling noise that a baseline diff then has to
+        # normalize away. PLUGIN_ROOT is resolved, so the pair stays consistent.
+        # Non-path sentinel origins ('frozen', 'built-in') are relative, so the
+        # is_absolute gate must precede resolve(): resolving first would anchor
+        # them under cwd and leak them into the map as externals.
         p = Path(origin)
+        if not p.is_absolute():
+            continue  # sentinel origin or relative external — not our concern
+        p = p.resolve()
         try:
             out[name] = str(p.relative_to(PLUGIN_ROOT))
         except ValueError:

--- a/pact-plugin/tests/import_identity_map.py
+++ b/pact-plugin/tests/import_identity_map.py
@@ -57,6 +57,11 @@ def imported_names(test_file):
             names.update(a.name for a in node.names)
         elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
             names.add(node.module)
+            # `from scripts import working_memory` — the submodule rides the
+            # package's name, so record the full dotted path too, or the
+            # bare->package rename set can't match it. Non-module aliases
+            # (functions/classes) capture as None on both sides: no diff.
+            names.update(f"{node.module}.{a.name}" for a in node.names)
     return names
 
 

--- a/pact-plugin/tests/import_identity_map.py
+++ b/pact-plugin/tests/import_identity_map.py
@@ -5,18 +5,24 @@ Per test module, record which FILE each imported plugin module resolves to
 a precedence flip (same module name resolving from a different directory
 still imports); this map is the only proof layer that catches one.
 
-Prototype registration (no conftest edit — the owner integrates later):
+Production registration: the plugin-root conftest re-exports the three hook
+functions below (name-based hook discovery picks up imported callables), so
+every run rooted at or below pact-plugin/ carries the capture. Emission is
+gated on PACT_IDENTITY_MAP_OUT; normal gate runs write nothing.
+
+Regenerate the baseline (pre/post-restructure diff halves alike):
 
     cd pact-plugin
+    PACT_IDENTITY_MAP_OUT=tests/import_identity_baseline.json \\
+        python3 -m pytest -q        # full suite, no path argument
+
+Compare with diff_maps(baseline, current, renames=<codemod's bare->package
+list>). An empty diff after rename normalization = no precedence flip.
+
+Prototype-era fallback, if conftest registration is ever bypassed:
+
     PYTHONPATH=tests PACT_IDENTITY_MAP_OUT=/tmp/map.json \\
         python3 -m pytest -p import_identity_map <files> -q
-
-Baseline-generation procedure (the pre-restructure half of the diff):
-the harness must land BEFORE any deletion batch. Baseline = run the command
-above (full suite, no path argument) at the first commit carrying this file;
-store the emitted JSON. Post-restructure runs emit the same shape; compare
-with diff_maps(baseline, current, renames=<codemod's bare->package list>).
-An empty diff after rename normalization = no precedence flip.
 
 Capture timing (measured on the 5-strata demo): pytest_sessionstart fires
 BEFORE tests/conftest.py loads — conftest's own inserts appear in the

--- a/pact-plugin/tests/import_identity_map.py
+++ b/pact-plugin/tests/import_identity_map.py
@@ -146,10 +146,23 @@ def _unrename(renames, key):
 
 _state = {"sessionstart_path": None, "collected_files": set()}
 
+# Nested-pytest guard: several suite tests spawn subprocess pytest runs, and
+# env propagates to children — without this, a nested session inherits
+# PACT_IDENTITY_MAP_OUT and overwrites the map at ITS sessionfinish while the
+# outer gate is still running (measured: a nested write landed ~90s into an
+# 18-minute gate). The outermost process marks the env at sessionstart;
+# nested sessions see the mark and skip emission. Process-local: the shell's
+# env is never mutated, so sequential runs are unaffected.
+_GUARD_ENV = "PACT_IDENTITY_MAP_ACTIVE"
+
 
 def pytest_sessionstart(session):
     # Fires BEFORE tests/conftest.py loads (measured) — this snapshot is the
     # pre-conftest baseline the drift canary compares against, nothing more.
+    if os.environ.get(_GUARD_ENV):
+        _state["nested"] = True
+    else:
+        os.environ[_GUARD_ENV] = "1"
     _state["sessionstart_path"] = list(sys.path)
 
 
@@ -163,7 +176,7 @@ def pytest_collection_modifyitems(session, config, items):
 
 def pytest_sessionfinish(session, exitstatus):
     out = os.environ.get("PACT_IDENTITY_MAP_OUT")
-    if not out:
+    if not out or _state.get("nested"):
         return
     drift = [p for p in sys.path if p not in (_state["sessionstart_path"] or [])]
     payload = {

--- a/pact-plugin/tests/import_identity_map.py
+++ b/pact-plugin/tests/import_identity_map.py
@@ -1,0 +1,162 @@
+"""Import-identity map capture — layer 4 of the test-import-restructure proof.
+
+Per test module, record which FILE each imported plugin module resolves to
+(importlib.util.find_spec origin), as diffable JSON. A green gate cannot see
+a precedence flip (same module name resolving from a different directory
+still imports); this map is the only proof layer that catches one.
+
+Prototype registration (no conftest edit — the owner integrates later):
+
+    cd pact-plugin
+    PYTHONPATH=tests PACT_IDENTITY_MAP_OUT=/tmp/map.json \\
+        python3 -m pytest -p import_identity_map <files> -q
+
+Baseline-generation procedure (the pre-restructure half of the diff):
+the harness must land BEFORE any deletion batch. Baseline = run the command
+above (full suite, no path argument) at the first commit carrying this file;
+store the emitted JSON. Post-restructure runs emit the same shape; compare
+with diff_maps(baseline, current, renames=<codemod's bare->package list>).
+An empty diff after rename normalization = no precedence flip.
+
+Capture timing (measured on the 5-strata demo): pytest_sessionstart fires
+BEFORE tests/conftest.py loads — conftest's own inserts appear in the
+sessionstart->sessionfinish drift list alongside pytest prepend-mode basedir
+inserts. So sessionstart is too early for the post-conftest state; the
+capture point is pytest_collection_modifyitems, which fires after ALL
+collection, when conftest, carrier inserts, and prepend-mode basedirs have
+all landed — matching the runtime state function-level imports actually
+resolve under (collection-phase masking is order-independent). The
+sessionstart snapshot remains as the drift canary: an EXPECTED drift list
+contains conftest's targets and test-file basedirs; anything else is the
+signal that would force per-module collection-time capture instead.
+"""
+
+import ast
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+
+# Modules whose resolution the restructure contract cares about. Anything
+# resolving outside the plugin tree (stdlib, site-packages) is noise for
+# precedence purposes and is omitted from the map; resolution FAILURES are
+# recorded as None so a silently-missing import stays visible.
+def imported_names(test_file):
+    """All absolute-import dotted names in a test file, module- AND
+    function-level (ast.walk descends into function bodies). Full dotted
+    path kept: `from scripts.working_memory import x` records
+    'scripts.working_memory', so the bare->package codemod renames are
+    visible as key changes rather than collapsing onto 'scripts'."""
+    tree = ast.parse(Path(test_file).read_text(encoding="utf-8"))
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(a.name for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            names.add(node.module)
+    return names
+
+
+def resolve_origins(names):
+    """find_spec each dotted name -> origin, repo-relative when under the
+    plugin root, None when unresolvable. Externals omitted entirely.
+
+    find_spec on a dotted name imports its parent packages — acceptable
+    here (scripts/__init__.py is trivial); flagged so a future heavyweight
+    __init__ doesn't surprise.
+    """
+    out = {}
+    for name in sorted(names):
+        try:
+            spec = importlib.util.find_spec(name)
+        except (ImportError, ValueError, AttributeError):
+            out[name] = None
+            continue
+        origin = getattr(spec, "origin", None) if spec else None
+        if not origin:
+            out[name] = None
+            continue
+        p = Path(origin)
+        try:
+            out[name] = str(p.relative_to(PLUGIN_ROOT))
+        except ValueError:
+            continue  # external — not the precedence contract's concern
+    return out
+
+
+def capture_map(test_paths):
+    """{test_file_relpath: {module_name: origin_relpath|None}}."""
+    result = {}
+    for tp in test_paths:
+        p = Path(tp)
+        try:
+            key = str(p.resolve().relative_to(PLUGIN_ROOT))
+        except ValueError:
+            key = str(p)
+        result[key] = resolve_origins(imported_names(p))
+    return result
+
+
+def diff_maps(baseline, current, renames=None):
+    """Compare origin FILES per (test_file, module). renames maps baseline
+    keys to current keys (the codemod's bare->package conversions): a rename
+    is expected and NOT a diff when the origin file is unchanged. Returns a
+    list of human-readable differences; empty = no precedence flip."""
+    renames = renames or {}
+    diffs = []
+    for tf in sorted(set(baseline) | set(current)):
+        b, c = baseline.get(tf, {}), current.get(tf, {})
+        if tf not in baseline:
+            diffs.append(f"{tf}: NEW FILE (no baseline)")
+            continue
+        if tf not in current:
+            diffs.append(f"{tf}: MISSING (collected pre-restructure only)")
+            continue
+        b_keys = {renames.get(k, k) for k in b}
+        for k in sorted(set(b_keys) | set(c)):
+            b_origin = b.get(k) if k in b else b.get(_unrename(renames, k))
+            c_origin = c.get(k)
+            if b_origin != c_origin:
+                diffs.append(f"{tf}: {k} was {b_origin} now {c_origin}")
+    return diffs
+
+
+def _unrename(renames, key):
+    for old, new in renames.items():
+        if new == key:
+            return old
+    return key
+
+
+# --- pytest hook integration (prototype: -p registration; production: conftest) ---
+
+_state = {"sessionstart_path": None, "collected_files": set()}
+
+
+def pytest_sessionstart(session):
+    # Fires BEFORE tests/conftest.py loads (measured) — this snapshot is the
+    # pre-conftest baseline the drift canary compares against, nothing more.
+    _state["sessionstart_path"] = list(sys.path)
+
+
+def pytest_collection_modifyitems(session, config, items):
+    for item in items:
+        try:
+            _state["collected_files"].add(str(item.path))
+        except AttributeError:  # very old pytest: fspath
+            _state["collected_files"].add(str(item.fspath))
+
+
+def pytest_sessionfinish(session, exitstatus):
+    out = os.environ.get("PACT_IDENTITY_MAP_OUT")
+    if not out:
+        return
+    drift = [p for p in sys.path if p not in (_state["sessionstart_path"] or [])]
+    payload = {
+        "map": capture_map(sorted(_state["collected_files"])),
+        "path_drift_since_sessionstart": drift,
+    }
+    Path(out).write_text(json.dumps(payload, indent=2, sort_keys=True))

--- a/pact-plugin/tests/test_628_coverage.py
+++ b/pact-plugin/tests/test_628_coverage.py
@@ -25,12 +25,9 @@ Y2 (auditor YELLOW-2): TestMarkerNameConsistency parametrized variant —
 """
 
 import re
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared import BOOTSTRAP_MARKER_NAME
 

--- a/pact-plugin/tests/test_agent_handoff_emitter_integration.py
+++ b/pact-plugin/tests/test_agent_handoff_emitter_integration.py
@@ -43,8 +43,6 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-
 import agent_handoff_emitter as ahe  # noqa: E402
 from shared.session_journal import read_events  # noqa: E402
 

--- a/pact-plugin/tests/test_agent_handoff_ts_caller_property.py
+++ b/pact-plugin/tests/test_agent_handoff_ts_caller_property.py
@@ -41,13 +41,11 @@ spellings and each broken by the next probe.
 """
 
 import ast
-import sys
 from pathlib import Path
 
 import pytest
 
 _HOOKS_DIR = Path(__file__).resolve().parents[1] / "hooks"
-sys.path.insert(0, str(_HOOKS_DIR))
 
 # The two agent_handoff emit paths. Named rather than derived: this is a
 # claim ABOUT these two files, so discovering them from the property this file

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -56,10 +56,6 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
-
 from helpers import make_claude_md_with_pins, make_pin_entry  # noqa: E402
 
 import archive_pin  # noqa: E402

--- a/pact-plugin/tests/test_archive_pin_emit.py
+++ b/pact-plugin/tests/test_archive_pin_emit.py
@@ -41,10 +41,6 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
-
 from helpers import make_claude_md_with_pins, make_pin_entry  # noqa: E402
 
 import archive_pin  # noqa: E402

--- a/pact-plugin/tests/test_archive_pin_resolver.py
+++ b/pact-plugin/tests/test_archive_pin_resolver.py
@@ -43,13 +43,9 @@ claim silently becomes false.
 import json
 import os
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import archive_pin  # noqa: E402
 

--- a/pact-plugin/tests/test_artifact_paths_durability.py
+++ b/pact-plugin/tests/test_artifact_paths_durability.py
@@ -46,12 +46,9 @@ Run with the 3.13.7 interpreter (default python3 has no pytest):
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import task_lifecycle_gate as tlg  # noqa: E402
 from shared.session_journal import (  # noqa: E402

--- a/pact-plugin/tests/test_audit_protocol.py
+++ b/pact-plugin/tests/test_audit_protocol.py
@@ -8,12 +8,9 @@ Tests cover:
 4. Auditor agent definition structure
 5. Completion lifecycle: signal-type with audit_summary
 """
-import sys
 from pathlib import Path, PurePosixPath
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 PROTOCOLS_DIR = Path(__file__).parent.parent / "protocols"
 COMMANDS_DIR = Path(__file__).parent.parent / "commands"

--- a/pact-plugin/tests/test_audit_summary_overwrite_906.py
+++ b/pact-plugin/tests/test_audit_summary_overwrite_906.py
@@ -21,12 +21,9 @@ Preservation is UNCONDITIONAL (any direction); a destructive downgrade
 (severity lowered, e.g. RED->GREEN) escalates the advisory WORDING only.
 """
 import json
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import task_lifecycle_gate as tlg  # noqa: E402
 

--- a/pact-plugin/tests/test_bootstrap_gate.py
+++ b/pact-plugin/tests/test_bootstrap_gate.py
@@ -75,8 +75,6 @@ from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-
 from shared import BOOTSTRAP_MARKER_NAME
 
 _SUPPRESS_EXPECTED = {

--- a/pact-plugin/tests/test_bootstrap_marker_writer.py
+++ b/pact-plugin/tests/test_bootstrap_marker_writer.py
@@ -60,8 +60,6 @@ from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-
 from shared import BOOTSTRAP_MARKER_NAME
 from shared.marker_schema import MARKER_SCHEMA_VERSION
 

--- a/pact-plugin/tests/test_bootstrap_prompt_gate.py
+++ b/pact-plugin/tests/test_bootstrap_prompt_gate.py
@@ -24,8 +24,6 @@ from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-
 from shared import BOOTSTRAP_MARKER_NAME
 
 _SUPPRESS_EXPECTED = {

--- a/pact-plugin/tests/test_calibration_schema.py
+++ b/pact-plugin/tests/test_calibration_schema.py
@@ -5,12 +5,9 @@ Tests cover:
 1. CalibrationRecord schema: required fields, types
 2. Schema consistency between architecture doc and pact-variety.md protocol
 """
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.variety_scorer import (
     MAX_SCORE,

--- a/pact-plugin/tests/test_caller_commits_before_embedding.py
+++ b/pact-plugin/tests/test_caller_commits_before_embedding.py
@@ -45,15 +45,11 @@ than papered over with an arm that would test its own fixture.
 from __future__ import annotations
 
 import json
-import os
-import sys
 from unittest.mock import patch
 
 import pytest
 
 from helpers import create_test_schema
-
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 try:
     import pysqlite3 as sqlite3

--- a/pact-plugin/tests/test_caller_commits_before_embedding.py
+++ b/pact-plugin/tests/test_caller_commits_before_embedding.py
@@ -53,7 +53,7 @@ import pytest
 
 from helpers import create_test_schema
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 try:
     import pysqlite3 as sqlite3

--- a/pact-plugin/tests/test_caller_path_is_not_created.py
+++ b/pact-plugin/tests/test_caller_path_is_not_created.py
@@ -51,8 +51,6 @@ from pathlib import Path
 import pytest
 
 SCRIPTS_PARENT = Path(__file__).parent.parent / "skills" / "pact-memory"
-if str(SCRIPTS_PARENT) not in sys.path:
-    sys.path.insert(0, str(SCRIPTS_PARENT))
 
 from scripts import cli  # noqa: E402
 from scripts.database import get_connection  # noqa: E402

--- a/pact-plugin/tests/test_canonical_journal_frame_gate.py
+++ b/pact-plugin/tests/test_canonical_journal_frame_gate.py
@@ -78,8 +78,6 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-
 import shared.pact_context as pc  # noqa: E402
 import task_lifecycle_gate as tlg  # noqa: E402
 

--- a/pact-plugin/tests/test_canonical_json_identity_certification.py
+++ b/pact-plugin/tests/test_canonical_json_identity_certification.py
@@ -56,12 +56,9 @@ does not see comments.
 
 import ast
 import importlib
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "hooks"))
 
 import shared.canonical_json as canonical  # noqa: E402
 

--- a/pact-plugin/tests/test_check_pin_caps.py
+++ b/pact-plugin/tests/test_check_pin_caps.py
@@ -32,10 +32,6 @@ from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
-
 from helpers import make_claude_md_with_pins, make_pin_entry  # noqa: E402
 
 

--- a/pact-plugin/tests/test_ci_env_truthiness.py
+++ b/pact-plugin/tests/test_ci_env_truthiness.py
@@ -29,16 +29,9 @@ RELATED
                                                the workflow/package parity guard
 """
 import builtins
-import os
-import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-sys.path.insert(
-    0,
-    os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory', 'scripts'),
-)
 
 from scripts.memory_init import _ci_is_declared, check_and_install_dependencies  # noqa: E402
 

--- a/pact-plugin/tests/test_ci_env_truthiness.py
+++ b/pact-plugin/tests/test_ci_env_truthiness.py
@@ -40,7 +40,7 @@ sys.path.insert(
     os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory', 'scripts'),
 )
 
-from memory_init import _ci_is_declared, check_and_install_dependencies  # noqa: E402
+from scripts.memory_init import _ci_is_declared, check_and_install_dependencies  # noqa: E402
 
 # Spellings that a human or a tool writes when it means "NOT CI". Every one of
 # these is a non-empty truthy string except the first, so every one of them was
@@ -94,7 +94,7 @@ class TestPredicateIsWiredToTheBranch:
     def test_ci_true_takes_the_skipped_ci_branch(self, monkeypatch):
         monkeypatch.setenv("CI", "true")
         with patch.object(builtins, '__import__', self._import_blocking_one_package()), \
-             patch('memory_init.subprocess.run') as mock_run:
+             patch('scripts.memory_init.subprocess.run') as mock_run:
             result = check_and_install_dependencies()
 
         assert result['status'] == 'skipped_ci'
@@ -108,7 +108,7 @@ class TestPredicateIsWiredToTheBranch:
         """
         monkeypatch.setenv("CI", "false")
         with patch.object(builtins, '__import__', self._import_blocking_one_package()), \
-             patch('memory_init.subprocess.run') as mock_run:
+             patch('scripts.memory_init.subprocess.run') as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
             result = check_and_install_dependencies()
 

--- a/pact-plugin/tests/test_claude_md_manager.py
+++ b/pact-plugin/tests/test_claude_md_manager.py
@@ -25,13 +25,9 @@ project CLAUDE.md migration to the PACT_MANAGED boundary structure:
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 import pytest
-
-# Add hooks directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_claude_md_resolver_parity.py
+++ b/pact-plugin/tests/test_claude_md_resolver_parity.py
@@ -17,7 +17,6 @@ Resolvers under test:
 """
 
 import os
-import sys
 from pathlib import Path
 from typing import Optional
 
@@ -29,8 +28,6 @@ import pytest
 # `from .database import ...` so it MUST be loaded via the `scripts.` package
 # path -- loading it standalone with importlib breaks its relative imports.
 _SCRIPTS_DIR = Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"
-if str(_SCRIPTS_DIR) not in sys.path:
-    sys.path.insert(0, str(_SCRIPTS_DIR))
 
 
 # Classification vocabulary -- shared across all resolvers

--- a/pact-plugin/tests/test_claude_md_resolver_parity.py
+++ b/pact-plugin/tests/test_claude_md_resolver_parity.py
@@ -22,13 +22,6 @@ from typing import Optional
 
 import pytest
 
-# conftest adds `hooks/` and `skills/pact-memory/` to sys.path. We also need
-# `skills/pact-memory/scripts/` on sys.path so `working_memory` imports as a
-# bare module (mirrors test_staleness.py line 31). memory_api.py uses
-# `from .database import ...` so it MUST be loaded via the `scripts.` package
-# path -- loading it standalone with importlib breaks its relative imports.
-_SCRIPTS_DIR = Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"
-
 
 # Classification vocabulary -- shared across all resolvers
 NOT_FOUND = "not_found"

--- a/pact-plugin/tests/test_claude_md_resolver_parity.py
+++ b/pact-plugin/tests/test_claude_md_resolver_parity.py
@@ -80,7 +80,7 @@ def resolver_staleness(tmp: Path, monkeypatch) -> str:
 
 def resolver_working_memory(tmp: Path, monkeypatch) -> str:
     """Mirror of staleness; same env-var-driven resolution strategy."""
-    from working_memory import _get_claude_md_path
+    from scripts.working_memory import _get_claude_md_path
 
     monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp))
     return _classify_path(_get_claude_md_path(), tmp)
@@ -313,7 +313,7 @@ class TestDisplayResolverParityInvariant:
     def test_non_worktree_checkout_resolvers_coincide(self, tmp_path, monkeypatch):
         """In a plain (non-worktree) checkout the two resolvers return the SAME
         existing path -- the equivalence the docstring promises."""
-        from working_memory import (
+        from scripts.working_memory import (
             _get_claude_md_path,
             _resolve_display_claude_md_path,
         )
@@ -341,7 +341,7 @@ class TestDisplayResolverParityInvariant:
         CLAUDE.md resolves the display path to its OWN file (branch 2) while the
         main-repo resolver still points at the main file -- so the coincidence
         above is a real property of the non-worktree case, not a constant."""
-        from working_memory import (
+        from scripts.working_memory import (
             _get_claude_md_path,
             _resolve_display_claude_md_path,
         )
@@ -386,7 +386,7 @@ class TestDisplayResolverParityInvariant:
         test_working_memory_worktree_sync.py; this asserts only that the two
         resolvers converge, which is the invariant this parity file exists for.
         """
-        from working_memory import (
+        from scripts.working_memory import (
             _get_claude_md_path,
             _resolve_display_claude_md_path,
         )

--- a/pact-plugin/tests/test_compact_summary_session_scope.py
+++ b/pact-plugin/tests/test_compact_summary_session_scope.py
@@ -15,13 +15,9 @@ test_postcompact_archive, whose frames carry session_id since #1504.
 """
 import io
 import json
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 class TestResolveCompactSummaryPath:

--- a/pact-plugin/tests/test_connection_transaction_mode.py
+++ b/pact-plugin/tests/test_connection_transaction_mode.py
@@ -40,7 +40,7 @@ import sys
 
 import pytest
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 from scripts.database import get_connection  # noqa: E402
 # THE MODULE THE FACTORY BOUND, NOT THE ONE THIS TEST CAN IMPORT. The factory

--- a/pact-plugin/tests/test_connection_transaction_mode.py
+++ b/pact-plugin/tests/test_connection_transaction_mode.py
@@ -33,14 +33,11 @@ versions before.
 from __future__ import annotations
 
 import ast
-import os
 import pathlib
 import sqlite3 as _stdlib_sqlite3
 import sys
 
 import pytest
-
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 from scripts.database import get_connection  # noqa: E402
 # THE MODULE THE FACTORY BOUND, NOT THE ONE THIS TEST CAN IMPORT. The factory

--- a/pact-plugin/tests/test_containment_certification.py
+++ b/pact-plugin/tests/test_containment_certification.py
@@ -151,7 +151,7 @@ def _load_twin(which: str):
     if which == "canonical":
         import shared.claude_md_manager as mod
         return mod
-    import working_memory as mod
+    from scripts import working_memory as mod
     return mod
 
 

--- a/pact-plugin/tests/test_containment_certification.py
+++ b/pact-plugin/tests/test_containment_certification.py
@@ -72,7 +72,6 @@ from __future__ import annotations
 
 import os
 import subprocess
-import sys
 import textwrap
 import unicodedata
 from pathlib import Path
@@ -83,12 +82,6 @@ import pytest
 # files: test_containment_guard.py adds hooks/, test_staleness.py adds the
 # scripts dir and imports the twin as a top-level `working_memory`).
 _TESTS = Path(__file__).resolve().parent
-for _p in (
-    _TESTS.parent / "hooks",
-    _TESTS.parent / "skills" / "pact-memory" / "scripts",
-):
-    if str(_p) not in sys.path:
-        sys.path.insert(0, str(_p))
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_containment_guard.py
+++ b/pact-plugin/tests/test_containment_guard.py
@@ -30,15 +30,11 @@ Real-production-entry topology (traced against merged code, not assumed):
 """
 
 import os
-import sys
 from pathlib import Path
 
 import pytest
 
 # hooks/shared on path (mirrors the other hook test files).
-_HOOKS = str(Path(__file__).resolve().parent.parent / "hooks")
-if _HOOKS not in sys.path:
-    sys.path.insert(0, _HOOKS)
 
 
 # ---------------------------------------------------------------------------
@@ -248,8 +244,6 @@ class TestSites89DisplayOverBlockAnchorIdentity:
         return main, worktree
 
     def test_external_worktree_allows_on_own_base(self, tmp_path, monkeypatch):
-        sys.path.insert(0, str(Path(__file__).resolve().parent.parent
-                               / "skills" / "pact-memory"))
         import scripts.working_memory as wm
 
         main, worktree = self._external_worktree(tmp_path)
@@ -277,8 +271,6 @@ class TestSites89DisplayOverBlockAnchorIdentity:
         is REFUSED. This is what proves the anchor is load-bearing rather than
         vacuous — anchoring on --git-common-dir (main root) over-blocks an
         external worktree's own legitimate write."""
-        sys.path.insert(0, str(Path(__file__).resolve().parent.parent
-                               / "skills" / "pact-memory"))
         import scripts.working_memory as wm
 
         main, worktree = self._external_worktree(tmp_path)

--- a/pact-plugin/tests/test_create_ingress_guard.py
+++ b/pact-plugin/tests/test_create_ingress_guard.py
@@ -33,17 +33,11 @@ mutant, at the same cost. Assert the REFUSAL, not the INTEGRITY OF THE DATA.
 from __future__ import annotations
 
 import json
-import os
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from helpers import create_test_schema
-
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 try:
     import pysqlite3 as sqlite3

--- a/pact-plugin/tests/test_create_ingress_guard.py
+++ b/pact-plugin/tests/test_create_ingress_guard.py
@@ -42,7 +42,7 @@ import pytest
 
 from helpers import create_test_schema
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 try:

--- a/pact-plugin/tests/test_cybernetic_cross_references.py
+++ b/pact-plugin/tests/test_cybernetic_cross_references.py
@@ -11,12 +11,9 @@ Tests cover:
 7. Audit protocol referenced in pact-protocols.md SSOT
 """
 import re
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 PROTOCOLS_DIR = Path(__file__).parent.parent / "protocols"
 COMMANDS_DIR = Path(__file__).parent.parent / "commands"

--- a/pact-plugin/tests/test_declared_anchor_contract.py
+++ b/pact-plugin/tests/test_declared_anchor_contract.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "skills", "pact-memory"))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 from scripts.working_memory import (  # noqa: E402

--- a/pact-plugin/tests/test_declared_anchor_contract.py
+++ b/pact-plugin/tests/test_declared_anchor_contract.py
@@ -20,15 +20,10 @@ Used by: pytest.
 """
 import ast
 import json
-import os
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 from scripts.working_memory import (  # noqa: E402
     ContainmentError,

--- a/pact-plugin/tests/test_dispatch_emission_prose.py
+++ b/pact-plugin/tests/test_dispatch_emission_prose.py
@@ -186,11 +186,7 @@ class TestRecoveryReadLastUsesTheFilteredForm:
         """Prose/CLI spelling agreement: the flag the prose names is the
         flag the parser registers, so a rename on one side reddens here
         rather than silently stranding the other."""
-        import sys
 
-        hooks = str(PLUGIN_ROOT / "hooks")
-        if hooks not in sys.path:
-            sys.path.insert(0, hooks)
         from shared import session_journal as sj
 
         parser = sj._build_cli()
@@ -216,11 +212,7 @@ class TestDiscriminatorConstant:
     prevent — so the two spellings are pinned against each other."""
 
     def test_constant_value_matches_the_prose_literal(self):
-        import sys
 
-        hooks = str(PLUGIN_ROOT / "hooks")
-        if hooks not in sys.path:
-            sys.path.insert(0, hooks)
         from shared.constants import VARIETY_ASSESSED_DISPATCH_SCOPE
 
         assert VARIETY_ASSESSED_DISPATCH_SCOPE == "dispatch"

--- a/pact-plugin/tests/test_dispatch_gate.py
+++ b/pact-plugin/tests/test_dispatch_gate.py
@@ -47,13 +47,10 @@ Disciplines applied:
 
 import io
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 _SUPPRESS_EXPECTED = {"suppressOutput": True}

--- a/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
+++ b/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
@@ -83,12 +83,9 @@ import json
 import os
 import re
 import stat
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from test_dispatch_gate import (  # noqa: E402 — sibling harness reuse
     _make_input,

--- a/pact-plugin/tests/test_dispatch_gate_integration.py
+++ b/pact-plugin/tests/test_dispatch_gate_integration.py
@@ -30,12 +30,9 @@ name -> not a uniqueness DENY) proves the DENY is coupled to the real roster rea
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import dispatch_gate  # noqa: E402
 

--- a/pact-plugin/tests/test_dispatch_gate_smoke.py
+++ b/pact-plugin/tests/test_dispatch_gate_smoke.py
@@ -31,8 +31,6 @@ from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-
 
 _SUPPRESS_EXPECTED = {"suppressOutput": True}
 _TEAM = "pact-test"

--- a/pact-plugin/tests/test_dispatch_gate_stale_diagnosis.py
+++ b/pact-plugin/tests/test_dispatch_gate_stale_diagnosis.py
@@ -44,12 +44,8 @@ Reuses the in-process harness from test_dispatch_gate.py (_run_main / _full_setu
 """
 
 import json
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from test_dispatch_gate import (  # noqa: E402 — sibling harness reuse
     _make_input,

--- a/pact-plugin/tests/test_dispatch_helpers.py
+++ b/pact-plugin/tests/test_dispatch_helpers.py
@@ -28,12 +28,8 @@ definition does not travel to a module with several consumers — the two names
 describe the same predicate, not different ones.
 """
 import json
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.dispatch_helpers import (  # noqa: E402
     is_owner_bearing_write,

--- a/pact-plugin/tests/test_dispatch_site_emit.py
+++ b/pact-plugin/tests/test_dispatch_site_emit.py
@@ -33,12 +33,9 @@ and O_EXCL marker root, with tlg.append_event spied to capture events — EXCEPT
 the seam-integration class at the bottom, which leaves the journal write real.
 """
 import json
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import task_lifecycle_gate as tlg  # noqa: E402
 import shared.session_journal as sj  # noqa: E402

--- a/pact-plugin/tests/test_dispatch_variety_teachback_ack_emit.py
+++ b/pact-plugin/tests/test_dispatch_variety_teachback_ack_emit.py
@@ -22,12 +22,8 @@ session_id and seed no leadSessionId team config, so the topology leg cannot
 resolve. These arms do NOT cover the in-process teammate frame, which emits.
 Drives tlg.evaluate_lifecycle with tlg.append_event spied to capture events.
 """
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import task_lifecycle_gate as tlg  # noqa: E402
 import shared.session_journal as sj  # noqa: E402

--- a/pact-plugin/tests/test_dogfood_livelock_invariant.py
+++ b/pact-plugin/tests/test_dogfood_livelock_invariant.py
@@ -51,7 +51,6 @@ import ast
 import io
 import json
 import subprocess
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -90,8 +89,6 @@ _REMOVED_HOOK_BASENAMES = (
 
 # Livelock-safe docstring opt-out marker (plan L127-129).
 _LIVELOCK_SAFE_MARKER = "# livelock-safe:"
-
-sys.path.insert(0, str(_HOOKS_DIR))
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_embedding_catchup.py
+++ b/pact-plugin/tests/test_embedding_catchup.py
@@ -25,7 +25,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Add paths for imports
 _scripts_path = str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts")
 
 

--- a/pact-plugin/tests/test_embedding_catchup.py
+++ b/pact-plugin/tests/test_embedding_catchup.py
@@ -61,8 +61,8 @@ def _load_embedding_catchup():
     mock_db = _make_mock_database()
 
     # The real embeddings module - import it to get the actual constant
-    sys.modules.pop("embeddings", None)
-    from embeddings import MIN_CATCHUP_RAM_MB, generate_embedding, generate_embedding_text
+    sys.modules.pop("scripts.embeddings", None)
+    from scripts.embeddings import MIN_CATCHUP_RAM_MB, generate_embedding, generate_embedding_text
     mock_emb_mod = ModuleType(f"{pkg_name}.embeddings")
     mock_emb_mod.generate_embedding = generate_embedding
     mock_emb_mod.generate_embedding_text = generate_embedding_text
@@ -104,17 +104,17 @@ class TestMinCatchupRamMbConstant:
 
     def test_constant_value_is_75(self):
         """The constant should be 75.0 MB - guards against unintended changes."""
-        from embeddings import MIN_CATCHUP_RAM_MB
+        from scripts.embeddings import MIN_CATCHUP_RAM_MB
         assert MIN_CATCHUP_RAM_MB == 75.0
 
     def test_constant_is_positive(self):
         """MIN_CATCHUP_RAM_MB must be positive to be a meaningful threshold."""
-        from embeddings import MIN_CATCHUP_RAM_MB
+        from scripts.embeddings import MIN_CATCHUP_RAM_MB
         assert MIN_CATCHUP_RAM_MB > 0
 
     def test_embed_pending_memories_default_uses_constant(self, ec_module):
         """Default min_ram_mb parameter should equal MIN_CATCHUP_RAM_MB."""
-        from embeddings import MIN_CATCHUP_RAM_MB
+        from scripts.embeddings import MIN_CATCHUP_RAM_MB
         sig = inspect.signature(ec_module.embed_pending_memories)
         default = sig.parameters["min_ram_mb"].default
         assert default == MIN_CATCHUP_RAM_MB
@@ -361,7 +361,7 @@ class TestEmbedPendingMemories:
 
     def test_default_min_ram_mb_uses_constant(self, ec_module):
         """Default min_ram_mb parameter should equal MIN_CATCHUP_RAM_MB."""
-        from embeddings import MIN_CATCHUP_RAM_MB
+        from scripts.embeddings import MIN_CATCHUP_RAM_MB
         sig = inspect.signature(ec_module.embed_pending_memories)
         default = sig.parameters["min_ram_mb"].default
         assert default == MIN_CATCHUP_RAM_MB

--- a/pact-plugin/tests/test_embedding_catchup.py
+++ b/pact-plugin/tests/test_embedding_catchup.py
@@ -27,8 +27,6 @@ import pytest
 
 # Add paths for imports
 _scripts_path = str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts")
-if _scripts_path not in sys.path:
-    sys.path.insert(0, _scripts_path)
 
 
 def _make_mock_database():

--- a/pact-plugin/tests/test_embedding_window.py
+++ b/pact-plugin/tests/test_embedding_window.py
@@ -31,12 +31,9 @@ property of the model rather than a constant of the library.
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 SCRIPTS_PARENT = Path(__file__).parent.parent / "skills" / "pact-memory"
-if str(SCRIPTS_PARENT) not in sys.path:
-    sys.path.insert(0, str(SCRIPTS_PARENT))
 
 from scripts.embeddings import (  # noqa: E402
     EMBEDDING_MAX_TOKENS,

--- a/pact-plugin/tests/test_emit_skip_accounting.py
+++ b/pact-plugin/tests/test_emit_skip_accounting.py
@@ -21,11 +21,8 @@ successfully RECORDS a skip. An emit lost without leaving a
 closes, and not zero.
 """
 import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.session_journal import (  # noqa: E402
     SKIP_CAUSE_RAISED,

--- a/pact-plugin/tests/test_environment_drift.py
+++ b/pact-plugin/tests/test_environment_drift.py
@@ -9,10 +9,6 @@ Tests cover:
 """
 import json
 import time
-from pathlib import Path
-import sys
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 class TestEnvironmentDrift:

--- a/pact-plugin/tests/test_error_output.py
+++ b/pact-plugin/tests/test_error_output.py
@@ -16,12 +16,9 @@ import io
 import json
 import os
 import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 # =============================================================================

--- a/pact-plugin/tests/test_exemption_policy_tripwires.py
+++ b/pact-plugin/tests/test_exemption_policy_tripwires.py
@@ -21,12 +21,9 @@ stay non-exempt, which depends on that dispatch carrying no `type`.
 import ast
 import json
 import re
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared import intentional_wait  # noqa: E402
 from shared.intentional_wait import (  # noqa: E402
@@ -35,8 +32,6 @@ from shared.intentional_wait import (  # noqa: E402
     is_self_complete_exempt,
     is_teachback_exempt,
 )
-
-sys.path.insert(0, str(Path(__file__).parent))
 
 from test_harvest_trigger_coherence import _claimed_boundaries  # noqa: E402 — sibling extraction rule
 

--- a/pact-plugin/tests/test_failure_cause_convention.py
+++ b/pact-plugin/tests/test_failure_cause_convention.py
@@ -24,13 +24,10 @@ other.
 import ast
 import errno
 import os
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 # A path fragment no rendering may carry. Distinctive so a partial leak is
 # still caught by the `/` assertion below.

--- a/pact-plugin/tests/test_failure_log.py
+++ b/pact-plugin/tests/test_failure_log.py
@@ -25,13 +25,10 @@ read_failures():
 16. Returns [] on outer exception (fail-open)
 """
 import json
-import sys
 import threading
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared import failure_log
 from shared.failure_log import (

--- a/pact-plugin/tests/test_file_permissions.py
+++ b/pact-plugin/tests/test_file_permissions.py
@@ -11,7 +11,6 @@ Verifies that:
 
 import os
 import stat
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -19,7 +18,6 @@ import pytest
 
 # Add the pact-memory scripts to path for direct imports
 SCRIPTS_DIR = Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"
-sys.path.insert(0, str(SCRIPTS_DIR.parent))
 
 
 # =============================================================================

--- a/pact-plugin/tests/test_file_tracker.py
+++ b/pact-plugin/tests/test_file_tracker.py
@@ -16,12 +16,9 @@ import io
 import json
 import os
 import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 class TestFileTracker:

--- a/pact-plugin/tests/test_gate_crashpath_hardening.py
+++ b/pact-plugin/tests/test_gate_crashpath_hardening.py
@@ -38,11 +38,8 @@ import inspect
 import io
 import json
 import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import bootstrap_gate as bg  # noqa: E402
 import task_lifecycle_gate as tlg  # noqa: E402

--- a/pact-plugin/tests/test_gate_invalid_mode_resolution.py
+++ b/pact-plugin/tests/test_gate_invalid_mode_resolution.py
@@ -36,11 +36,8 @@ import io
 import json
 import os
 import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 INLINE_ENV = "PACT_DISPATCH_INLINE_MISSION_MODE"
 VARIETY_ENV = "PACT_DISPATCH_VARIETY_MODE"

--- a/pact-plugin/tests/test_gh_helpers.py
+++ b/pact-plugin/tests/test_gh_helpers.py
@@ -27,13 +27,9 @@ Cross-module backcompat (#453 DC3 alias path):
 """
 
 import subprocess
-import sys
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_git_commit_check.py
+++ b/pact-plugin/tests/test_git_commit_check.py
@@ -14,13 +14,9 @@ import io
 import json
 import shutil
 import subprocess
-import sys
-from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_handoff_917_captured_regression.py
+++ b/pact-plugin/tests/test_handoff_917_captured_regression.py
@@ -41,12 +41,9 @@ written) so "emits" means "the journal write was attempted exactly once".
 import copy
 import io
 import json
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import agent_handoff_emitter as b1  # noqa: E402
 import task_lifecycle_gate as tlg  # noqa: E402

--- a/pact-plugin/tests/test_handoff_advisories.py
+++ b/pact-plugin/tests/test_handoff_advisories.py
@@ -15,12 +15,9 @@ without a HANDOFF?" is a question this gate does not answer.
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import task_lifecycle_gate as tlg  # noqa: E402
 from fixtures.emitter import VALID_HANDOFF  # noqa: E402

--- a/pact-plugin/tests/test_handoff_b1_b2_dedup.py
+++ b/pact-plugin/tests/test_handoff_b1_b2_dedup.py
@@ -27,12 +27,9 @@ Shared-marker mechanics: both paths resolve the marker dir via Path.home();
 patching Path.home (+ HOME) to one tmp_path and using one team_name/task_id/
 owner/subject makes b1 and b2 contend for the identical marker file.
 """
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import task_lifecycle_gate as tlg  # noqa: E402
 from fixtures.emitter import VALID_HANDOFF, _run_main  # noqa: E402

--- a/pact-plugin/tests/test_handoff_census.py
+++ b/pact-plugin/tests/test_handoff_census.py
@@ -15,10 +15,7 @@ arm depends on.
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 import handoff_census as hc  # noqa: E402
 

--- a/pact-plugin/tests/test_handoff_eligibility_parity.py
+++ b/pact-plugin/tests/test_handoff_eligibility_parity.py
@@ -27,12 +27,9 @@
 Test-only; no source dependency on devops's concurrent .lower() centralization
 (team names here are already lowercase, so .lower() is a no-op either way).
 """
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import task_lifecycle_gate as tlg  # noqa: E402
 from fixtures.emitter import VALID_HANDOFF, _run_main  # noqa: E402

--- a/pact-plugin/tests/test_handoff_key_annotation_pinned.py
+++ b/pact-plugin/tests/test_handoff_key_annotation_pinned.py
@@ -53,11 +53,8 @@ the drift arm and the count arm for that file.
 """
 
 from pathlib import Path
-import sys
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.handoff_schema import HANDOFF_CANONICAL_FIELDS  # noqa: E402
 

--- a/pact-plugin/tests/test_handoff_ordering_gate.py
+++ b/pact-plugin/tests/test_handoff_ordering_gate.py
@@ -22,8 +22,6 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-
 import handoff_ordering_gate as gate  # noqa: E402
 
 TEAM = "test-team"

--- a/pact-plugin/tests/test_handoff_schema.py
+++ b/pact-plugin/tests/test_handoff_schema.py
@@ -19,10 +19,6 @@ would fire on most real handoffs, so each of those has an explicit arm here.
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent))  # noqa: E402
 
 from fixtures.emitter import VALID_HANDOFF  # noqa: E402
 

--- a/pact-plugin/tests/test_handoff_unclaim_twin_917.py
+++ b/pact-plugin/tests/test_handoff_unclaim_twin_917.py
@@ -19,12 +19,9 @@ so the retry hits already_emitted()==True and the second-emit assertion FAILS
 (net: the marker-persists assertion + the re-emit assertion flip RED). Restore
 via `git worktree remove --force`.
 """
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import task_lifecycle_gate as tlg  # noqa: E402
 from shared.agent_handoff_marker import occupant_hash  # noqa: E402

--- a/pact-plugin/tests/test_handoff_writability_parity.py
+++ b/pact-plugin/tests/test_handoff_writability_parity.py
@@ -40,13 +40,10 @@ imports NO captured-frame fixture promotion — it stands alone.
 import inspect
 import io
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import agent_handoff_emitter as b1  # noqa: E402
 import task_lifecycle_gate as tlg  # noqa: E402

--- a/pact-plugin/tests/test_handoff_write_after_completion_backstop.py
+++ b/pact-plugin/tests/test_handoff_write_after_completion_backstop.py
@@ -24,12 +24,9 @@ resolves the completed-task post-state; key is_canonical_journal_frame on the fr
 teammateMode AND the in-process teammate frame, and excludes the tmux teammate.
 """
 import json
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import task_lifecycle_gate as tlg  # noqa: E402
 

--- a/pact-plugin/tests/test_harness_aware_bootstrap.py
+++ b/pact-plugin/tests/test_harness_aware_bootstrap.py
@@ -72,13 +72,10 @@ measured RED cardinality is documented in this module's HANDOFF.
 
 import io
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared import BOOTSTRAP_MARKER_NAME  # noqa: E402
 

--- a/pact-plugin/tests/test_hook_infra_classifier.py
+++ b/pact-plugin/tests/test_hook_infra_classifier.py
@@ -37,13 +37,11 @@ top-level-edge perturbation is the explicit non-vacuity anchor.
 from __future__ import annotations
 
 import ast
-import sys
 from pathlib import Path
 
 import pytest
 
 HOOKS = (Path(__file__).parent.parent / "hooks").resolve()
-sys.path.insert(0, str(HOOKS))
 
 from shared.hook_infra_classifier import (  # noqa: E402
     SEAM_DEPENDENT_HOOKS,

--- a/pact-plugin/tests/test_idle_preamble.py
+++ b/pact-plugin/tests/test_idle_preamble.py
@@ -11,13 +11,10 @@ Tests cover:
 """
 import io
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_import_identity_map.py
+++ b/pact-plugin/tests/test_import_identity_map.py
@@ -120,3 +120,41 @@ def test_diff_maps_rename_still_flags_origin_change():
 def test_diff_maps_flags_missing_file():
     b = {"t.py": {"x": "hooks/x.py"}}
     assert diff_maps(b, {}) != []
+
+
+def _fresh_state(monkeypatch):
+    import import_identity_map as iim
+
+    monkeypatch.setattr(
+        iim, "_state", {"sessionstart_path": None, "collected_files": set()}
+    )
+    return iim
+
+
+def test_hook_emits_map_when_outermost(tmp_path, monkeypatch):
+    iim = _fresh_state(monkeypatch)
+    out = tmp_path / "map.json"
+    monkeypatch.setenv("PACT_IDENTITY_MAP_OUT", str(out))
+    monkeypatch.delenv("PACT_IDENTITY_MAP_ACTIVE", raising=False)
+    iim.pytest_sessionstart(None)
+    iim.pytest_sessionfinish(None, 0)
+    assert out.exists()
+    assert "map" in json.loads(out.read_text())
+
+
+def test_hook_skips_emission_when_nested(tmp_path, monkeypatch):
+    iim = _fresh_state(monkeypatch)
+    out = tmp_path / "map.json"
+    monkeypatch.setenv("PACT_IDENTITY_MAP_OUT", str(out))
+    monkeypatch.setenv("PACT_IDENTITY_MAP_ACTIVE", "1")  # inherited mark
+    iim.pytest_sessionstart(None)
+    iim.pytest_sessionfinish(None, 0)
+    assert not out.exists()
+
+
+def test_hook_silent_without_out_env(monkeypatch):
+    iim = _fresh_state(monkeypatch)
+    monkeypatch.delenv("PACT_IDENTITY_MAP_OUT", raising=False)
+    monkeypatch.delenv("PACT_IDENTITY_MAP_ACTIVE", raising=False)
+    iim.pytest_sessionstart(None)
+    iim.pytest_sessionfinish(None, 0)  # no exception, no file

--- a/pact-plugin/tests/test_import_identity_map.py
+++ b/pact-plugin/tests/test_import_identity_map.py
@@ -1,0 +1,122 @@
+"""Tests for tests/import_identity_map.py — the layer-4 harness prototype.
+
+Mechanism tests use synthetic fixtures; live-session tests assert only what
+conftest.py guarantees in EVERY invocation shape (hooks/ on sys.path, so
+`shared` resolves) — bare `working_memory` needs a carrier insert and is
+asserted conditionally so this file passes STANDALONE as well as in the gate.
+"""
+
+import json
+import sys
+import textwrap
+
+from import_identity_map import (
+    capture_map,
+    diff_maps,
+    imported_names,
+    resolve_origins,
+)
+
+
+def _write(tmp_path, source):
+    f = tmp_path / "test_sample.py"
+    f.write_text(textwrap.dedent(source))
+    return f
+
+
+def test_imported_names_catches_module_and_function_level(tmp_path):
+    f = _write(
+        tmp_path,
+        """\
+        import os
+        import working_memory
+        from shared.marker_schema import MARKER_SCHEMA_VERSION
+
+        def test_x():
+            from bootstrap_gate import main
+            import scripts.config
+        """,
+    )
+    names = imported_names(f)
+    assert "os" in names
+    assert "working_memory" in names
+    assert "shared.marker_schema" in names  # full dotted path, not 'shared'
+    assert "bootstrap_gate" in names        # function-level import found
+    assert "scripts.config" in names
+
+
+def test_imported_names_skips_relative_imports(tmp_path):
+    f = _write(tmp_path, "from .helpers import thing\n")
+    assert imported_names(f) == set()
+
+
+def test_resolve_origins_shared_resolves_in_every_shape():
+    # hooks/ is conftest-provided in all measured invocation shapes (gate,
+    # repo-root by-path, tests-dir cwd, CI), so this must hold standalone too.
+    origins = resolve_origins(["shared.marker_schema"])
+    assert origins["shared.marker_schema"] == "hooks/shared/marker_schema.py"
+
+
+def test_resolve_origins_working_memory_conditional_on_carrier():
+    # scripts/ reaches sys.path only via a per-file insert or carrier masking;
+    # standalone this file has neither. Both outcomes prove the mechanism:
+    # resolvable -> correct file; unresolvable -> recorded None, not omitted.
+    origins = resolve_origins(["working_memory"])
+    if any(p.endswith("pact-memory/scripts") for p in sys.path):
+        assert origins["working_memory"] == (
+            "skills/pact-memory/scripts/working_memory.py"
+        )
+    else:
+        assert origins["working_memory"] is None
+
+
+def test_resolve_origins_omits_externals():
+    assert resolve_origins(["json", "pathlib", "pytest"]) == {}
+
+
+def test_resolve_origins_missing_module_recorded_none():
+    assert resolve_origins(["no_such_module_xyz"]) == {"no_such_module_xyz": None}
+
+
+def test_capture_map_keys_repo_relative(tmp_path):
+    f = _write(tmp_path, "import json\n")
+    result = capture_map([f])
+    key = next(iter(result))  # tmp files are outside PLUGIN_ROOT
+    assert result[key] == {}  # json is external -> omitted
+
+
+def test_map_is_json_diffable():
+    m = {"tests/test_a.py": {"shared.marker_schema": "hooks/shared/marker_schema.py"}}
+    assert json.loads(json.dumps(m, sort_keys=True)) == m
+
+
+def test_diff_maps_empty_when_identical():
+    m = {"t.py": {"working_memory": "skills/pact-memory/scripts/working_memory.py"}}
+    assert diff_maps(m, dict(m)) == []
+
+
+def test_diff_maps_flags_precedence_flip():
+    b = {"t.py": {"config": "skills/pact-memory/scripts/config.py"}}
+    c = {"t.py": {"config": "skills/other/scripts/config.py"}}
+    diffs = diff_maps(b, c)
+    assert len(diffs) == 1 and "config" in diffs[0]
+
+
+def test_diff_maps_rename_normalization_allows_bare_to_package():
+    origin = "skills/pact-memory/scripts/working_memory.py"
+    b = {"t.py": {"working_memory": origin}}
+    c = {"t.py": {"scripts.working_memory": origin}}
+    renames = {"working_memory": "scripts.working_memory"}
+    assert diff_maps(b, c, renames=renames) == []
+
+
+def test_diff_maps_rename_still_flags_origin_change():
+    b = {"t.py": {"working_memory": "skills/pact-memory/scripts/working_memory.py"}}
+    c = {"t.py": {"scripts.working_memory": "elsewhere/working_memory.py"}}
+    renames = {"working_memory": "scripts.working_memory"}
+    assert diff_maps(b, c, renames=renames) != []
+
+
+def test_diff_maps_flags_missing_file():
+    b = {"t.py": {"x": "hooks/x.py"}}
+    assert diff_maps(b, {}) != []

--- a/pact-plugin/tests/test_import_identity_map.py
+++ b/pact-plugin/tests/test_import_identity_map.py
@@ -71,7 +71,10 @@ def test_resolve_origins_working_memory_conditional_on_carrier():
 
 
 def test_resolve_origins_omits_externals():
-    assert resolve_origins(["json", "pathlib", "pytest"]) == {}
+    # json/pathlib/pytest: real path origins outside the plugin tree.
+    # os/sys: sentinel origins ('frozen'/'built-in') — non-path strings that
+    # must not be resolve()-anchored under cwd and leaked into the map.
+    assert resolve_origins(["json", "pathlib", "pytest", "os", "sys"]) == {}
 
 
 def test_resolve_origins_missing_module_recorded_none():

--- a/pact-plugin/tests/test_ingress_guard_mechanisms.py
+++ b/pact-plugin/tests/test_ingress_guard_mechanisms.py
@@ -27,16 +27,12 @@ shadow writes, and `total_changes` sees them without knowing their names.
 from __future__ import annotations
 
 import ast
-import os
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from helpers import create_test_schema
-
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 try:
     import pysqlite3 as sqlite3

--- a/pact-plugin/tests/test_ingress_guard_mechanisms.py
+++ b/pact-plugin/tests/test_ingress_guard_mechanisms.py
@@ -36,7 +36,7 @@ import pytest
 
 from helpers import create_test_schema
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 try:
     import pysqlite3 as sqlite3

--- a/pact-plugin/tests/test_intentional_wait.py
+++ b/pact-plugin/tests/test_intentional_wait.py
@@ -16,13 +16,10 @@ Coverage targets:
   team_name) and surface 2 (signal-task pattern, independent of team_name).
 """
 import json
-import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 # --- helpers ---------------------------------------------------------------

--- a/pact-plugin/tests/test_lead_side_handoff_emit.py
+++ b/pact-plugin/tests/test_lead_side_handoff_emit.py
@@ -19,12 +19,9 @@ the intended discriminator firing, not an unrelated missing precondition.
 is_lead reads input_data["agent_type"] DIRECTLY against
 {"PACT:pact-orchestrator", "pact-orchestrator"} (pact_context.LEAD_AGENT_TYPES).
 """
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import task_lifecycle_gate as tlg  # noqa: E402
 from fixtures.emitter import VALID_HANDOFF  # noqa: E402

--- a/pact-plugin/tests/test_lock_identity_certification.py
+++ b/pact-plugin/tests/test_lock_identity_certification.py
@@ -67,18 +67,11 @@ import hashlib
 import inspect
 import os
 import re
-import sys
 from pathlib import Path
 
 import pytest
 
 _TESTS = Path(__file__).resolve().parent
-for _p in (
-    _TESTS.parent / "hooks",
-    _TESTS.parent / "skills" / "pact-memory" / "scripts",
-):
-    if str(_p) not in sys.path:
-        sys.path.insert(0, str(_p))
 
 PLUGIN_ROOT = _TESTS.parent
 CANONICAL_REL = "hooks/shared/claude_md_manager.py"

--- a/pact-plugin/tests/test_lock_identity_certification.py
+++ b/pact-plugin/tests/test_lock_identity_certification.py
@@ -42,7 +42,7 @@ intuitive choice and a later reader will otherwise "harden" them backwards.
    and it is the reverse:
 
      `__module__`            canonical 'shared.claude_md_manager'
-                             skill     'working_memory'          -> DISCRIMINATES
+                             skill     'scripts.working_memory' -> DISCRIMINATES
      `inspect.getsourcefile` canonical contextlib.py
                              skill     contextlib.py             -> DOES NOT
 
@@ -96,14 +96,14 @@ T1_LENGTH = 672
 
 # --- module provenance ------------------------------------------------------
 CANONICAL_MODULE = "shared.claude_md_manager"
-TWIN_MODULE = "working_memory"
+TWIN_MODULE = "scripts.working_memory"
 
 
 def _load_twin(which: str):
     if which == "canonical":
         import shared.claude_md_manager as mod
         return mod, CANONICAL_MODULE
-    import working_memory as mod
+    from scripts import working_memory as mod
     return mod, TWIN_MODULE
 
 

--- a/pact-plugin/tests/test_managed_comment_emitted.py
+++ b/pact-plugin/tests/test_managed_comment_emitted.py
@@ -61,14 +61,11 @@ from __future__ import annotations
 
 import os
 import re
-import sys
 from pathlib import Path
 
 import pytest
 
 _PLUGIN_ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(_PLUGIN_ROOT / "hooks"))
-sys.path.insert(0, str(_PLUGIN_ROOT / "skills" / "pact-memory" / "scripts"))
 
 from shared.claude_md_manager import (  # noqa: E402
     _build_migrated_content,

--- a/pact-plugin/tests/test_managed_comment_emitted.py
+++ b/pact-plugin/tests/test_managed_comment_emitted.py
@@ -76,7 +76,7 @@ from shared.claude_md_manager import (  # noqa: E402
 )
 from shared.session_resume import update_session_info  # noqa: E402
 
-import working_memory as _ssot  # noqa: E402
+from scripts import working_memory as _ssot  # noqa: E402
 
 # THE SSOT, READ AS VALUES RATHER THAN RE-SPELLED. Every assertion below
 # compares emitted text against these two names, so an emitter that drifts to

--- a/pact-plugin/tests/test_marker_helper_twin_drift.py
+++ b/pact-plugin/tests/test_marker_helper_twin_drift.py
@@ -62,15 +62,9 @@ here and it does not need to be.
 from __future__ import annotations
 
 import inspect
-import sys
 import textwrap
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(
-    0, str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts")
-)
 
 # THE EXTRACTOR COMES FROM ITS SINGLE DEFINITION AND IS NOT COPIED HERE.
 # A second copy of an extractor is the same defect this file guards, one

--- a/pact-plugin/tests/test_marker_helper_twin_drift.py
+++ b/pact-plugin/tests/test_marker_helper_twin_drift.py
@@ -92,7 +92,7 @@ TWINNED = ("marker_line_span", "_narrow_to_memory_region")
 def _pair(name):
     """Return the (canonical, copy) function objects for `name`."""
     import shared.pin_markers as canonical
-    import working_memory as copy
+    from scripts import working_memory as copy
 
     return getattr(canonical, name), getattr(copy, name)
 

--- a/pact-plugin/tests/test_marker_schema.py
+++ b/pact-plugin/tests/test_marker_schema.py
@@ -31,10 +31,6 @@ writer needs to verify):
 """
 
 import hashlib
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.marker_schema import (
     MARKER_MAX_BYTES,

--- a/pact-plugin/tests/test_memory_cli.py
+++ b/pact-plugin/tests/test_memory_cli.py
@@ -34,9 +34,6 @@ from helpers import create_test_schema, make_cli_memory_dict
 # the display resolver treats "no CLAUDE.md here" as "keep looking".
 from test_working_memory_concurrency_comprehensive import _seed_claude_md
 
-# Add pact-memory skill root to path so `from scripts.cli import ...` works
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
-
 from scripts.cli import build_parser, cmd_save, cmd_search, cmd_list, cmd_get, cmd_status, cmd_setup, cmd_update, cmd_delete, main, _COMMANDS, _refuse_live_db_under_pytest
 from scripts.memory_api import PACTMemory
 

--- a/pact-plugin/tests/test_memory_cli.py
+++ b/pact-plugin/tests/test_memory_cli.py
@@ -35,7 +35,7 @@ from helpers import create_test_schema, make_cli_memory_dict
 from test_working_memory_concurrency_comprehensive import _seed_claude_md
 
 # Add pact-memory skill root to path so `from scripts.cli import ...` works
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 from scripts.cli import build_parser, cmd_save, cmd_search, cmd_list, cmd_get, cmd_status, cmd_setup, cmd_update, cmd_delete, main, _COMMANDS, _refuse_live_db_under_pytest
 from scripts.memory_api import PACTMemory

--- a/pact-plugin/tests/test_memory_ct_fields.py
+++ b/pact-plugin/tests/test_memory_ct_fields.py
@@ -20,7 +20,7 @@ import pytest
 # Add paths for imports — scripts/ is a package with __init__.py,
 # so we add its parent to sys.path for proper relative imports.
 import sys
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 from scripts.database import (
     get_connection,

--- a/pact-plugin/tests/test_memory_ct_fields.py
+++ b/pact-plugin/tests/test_memory_ct_fields.py
@@ -11,7 +11,6 @@ database.py, models.py, and working_memory.py.
 """
 
 import json
-import os
 import tempfile
 from pathlib import Path
 
@@ -19,8 +18,6 @@ import pytest
 
 # Add paths for imports — scripts/ is a package with __init__.py,
 # so we add its parent to sys.path for proper relative imports.
-import sys
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 from scripts.database import (
     get_connection,

--- a/pact-plugin/tests/test_memory_ct_fields.py
+++ b/pact-plugin/tests/test_memory_ct_fields.py
@@ -16,9 +16,6 @@ from pathlib import Path
 
 import pytest
 
-# Add paths for imports — scripts/ is a package with __init__.py,
-# so we add its parent to sys.path for proper relative imports.
-
 from scripts.database import (
     get_connection,
     init_schema,

--- a/pact-plugin/tests/test_memory_database.py
+++ b/pact-plugin/tests/test_memory_database.py
@@ -21,7 +21,7 @@ import pytest
 
 from helpers import create_test_schema
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 # Use the same sqlite3 module that database.py uses (pysqlite3 if available)
 try:

--- a/pact-plugin/tests/test_memory_database.py
+++ b/pact-plugin/tests/test_memory_database.py
@@ -13,15 +13,12 @@ Tests cover:
 """
 import json
 import os
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from helpers import create_test_schema
-
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 # Use the same sqlite3 module that database.py uses (pysqlite3 if available)
 try:
@@ -523,10 +520,6 @@ class TestPACTMemoryDeleteVecTableHandling:
 
     def test_delete_silently_handles_missing_vec_memories_table(self, tmp_path):
         """Real-DB path: schema has no vec_memories table; delete must succeed."""
-        sys.path.insert(
-            0,
-            os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'),
-        )
         from scripts.memory_api import PACTMemory
 
         db_path = tmp_path / "vec_absent.db"
@@ -561,10 +554,6 @@ class TestPACTMemoryDeleteVecTableHandling:
         propagating it surfaces real problems (lock contention, disk I/O,
         etc.) instead of silently leaving stale vector entries.
         """
-        sys.path.insert(
-            0,
-            os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'),
-        )
         from scripts.memory_api import PACTMemory
         import scripts.memory_api as memory_api_mod
 
@@ -2094,10 +2083,6 @@ class TestBug1EmbeddingSkipOnIdempotentUpdate:
         self, tmp_path,
     ):
         """Second identical update must NOT call _store_embedding."""
-        sys.path.insert(
-            0,
-            os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'),
-        )
         from scripts.memory_api import PACTMemory
 
         db_path = tmp_path / "embed_skip_test.db"

--- a/pact-plugin/tests/test_memory_graph.py
+++ b/pact-plugin/tests/test_memory_graph.py
@@ -20,15 +20,11 @@ Tests cover:
 16. get_file_context: tracked, untracked
 17. get_graph_stats: empty, populated, project filter
 """
-import os
-import sys
 from unittest.mock import patch
 
 import pytest
 
 from helpers import create_test_schema
-
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 # graph.py imports standard `import sqlite3` (not pysqlite3), so its
 # `except sqlite3.IntegrityError` catches the standard library exception.

--- a/pact-plugin/tests/test_memory_graph.py
+++ b/pact-plugin/tests/test_memory_graph.py
@@ -28,7 +28,7 @@ import pytest
 
 from helpers import create_test_schema
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 # graph.py imports standard `import sqlite3` (not pysqlite3), so its
 # `except sqlite3.IntegrityError` catches the standard library exception.

--- a/pact-plugin/tests/test_memory_init.py
+++ b/pact-plugin/tests/test_memory_init.py
@@ -1583,10 +1583,6 @@ class TestMemoryAPIRealIntegration:
 
         reset_initialization()
 
-        # Import memory_api module to access PACTMemory
-        scripts_path = Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"
-        sys.path.insert(0, str(scripts_path.parent.parent.parent))
-
         # We need to mock ensure_memory_ready at the memory_api module level
         # because memory_api imports it with: from .memory_init import ensure_memory_ready
         with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \

--- a/pact-plugin/tests/test_memory_init.py
+++ b/pact-plugin/tests/test_memory_init.py
@@ -24,9 +24,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Add paths for imports
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"))
-
 
 class TestEnsureMemoryReady:
     """Tests for ensure_memory_ready() - the main lazy initialization entry point."""

--- a/pact-plugin/tests/test_memory_init.py
+++ b/pact-plugin/tests/test_memory_init.py
@@ -33,13 +33,13 @@ class TestEnsureMemoryReady:
 
     def test_returns_dict_with_expected_keys(self):
         """Test that ensure_memory_ready returns expected result structure."""
-        from memory_init import ensure_memory_ready, reset_initialization
+        from scripts.memory_init import ensure_memory_ready, reset_initialization
 
         reset_initialization()
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {'status': 'ok', 'installed': [], 'failed': []}
             mock_migrate.return_value = {'status': 'ok', 'message': None}
@@ -55,13 +55,13 @@ class TestEnsureMemoryReady:
 
     def test_idempotent_only_runs_once(self):
         """Test that ensure_memory_ready only runs initialization once per session."""
-        from memory_init import ensure_memory_ready, reset_initialization
+        from scripts.memory_init import ensure_memory_ready, reset_initialization
 
         reset_initialization()
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {'status': 'ok', 'installed': [], 'failed': []}
             mock_migrate.return_value = {'status': 'ok', 'message': None}
@@ -84,7 +84,7 @@ class TestEnsureMemoryReady:
 
     def test_runs_all_three_steps(self):
         """Test that all three initialization steps are called in order."""
-        from memory_init import ensure_memory_ready, reset_initialization
+        from scripts.memory_init import ensure_memory_ready, reset_initialization
 
         reset_initialization()
 
@@ -102,9 +102,9 @@ class TestEnsureMemoryReady:
             call_order.append('embed')
             return {'status': 'ok', 'message': None}
 
-        with patch('memory_init.check_and_install_dependencies', side_effect=track_deps), \
-             patch('memory_init.maybe_migrate_embeddings', side_effect=track_migrate), \
-             patch('memory_init.maybe_embed_pending', side_effect=track_embed):
+        with patch('scripts.memory_init.check_and_install_dependencies', side_effect=track_deps), \
+             patch('scripts.memory_init.maybe_migrate_embeddings', side_effect=track_migrate), \
+             patch('scripts.memory_init.maybe_embed_pending', side_effect=track_embed):
 
             ensure_memory_ready()
 
@@ -116,13 +116,13 @@ class TestResetInitialization:
 
     def test_reset_allows_reinitialization(self):
         """Test that reset_initialization allows initialization to run again."""
-        from memory_init import ensure_memory_ready, reset_initialization, is_initialized
+        from scripts.memory_init import ensure_memory_ready, reset_initialization, is_initialized
 
         reset_initialization()
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {'status': 'ok', 'installed': [], 'failed': []}
             mock_migrate.return_value = {'status': 'ok', 'message': None}
@@ -150,11 +150,11 @@ class TestResetInitialization:
         reset that unlinks it reaches outside the test process. Resetting the
         in-memory flag is the only behaviour tests need.
         """
-        from memory_init import reset_initialization, _get_embedding_attempted_path
+        from scripts.memory_init import reset_initialization, _get_embedding_attempted_path
 
         test_session_id = f"test-routef-{time.time()}"
 
-        with patch("memory_init.get_session_id_from_context_file", return_value=test_session_id):
+        with patch("scripts.memory_init.get_session_id_from_context_file", return_value=test_session_id):
             marker_path = _get_embedding_attempted_path()
             marker_path.touch()
             try:
@@ -171,11 +171,11 @@ class TestResetInitialization:
 
     def test_clear_embedding_marker_removes_it(self):
         """The deletion still exists, but only under its own name."""
-        from memory_init import clear_embedding_marker, _get_embedding_attempted_path
+        from scripts.memory_init import clear_embedding_marker, _get_embedding_attempted_path
 
         test_session_id = f"test-clearmarker-{time.time()}"
 
-        with patch("memory_init.get_session_id_from_context_file", return_value=test_session_id):
+        with patch("scripts.memory_init.get_session_id_from_context_file", return_value=test_session_id):
             marker_path = _get_embedding_attempted_path()
             marker_path.touch()
             try:
@@ -193,20 +193,20 @@ class TestIsInitialized:
 
     def test_returns_false_before_initialization(self):
         """Test is_initialized returns False before ensure_memory_ready is called."""
-        from memory_init import reset_initialization, is_initialized
+        from scripts.memory_init import reset_initialization, is_initialized
 
         reset_initialization()
         assert is_initialized() is False
 
     def test_returns_true_after_initialization(self):
         """Test is_initialized returns True after ensure_memory_ready completes."""
-        from memory_init import ensure_memory_ready, reset_initialization, is_initialized
+        from scripts.memory_init import ensure_memory_ready, reset_initialization, is_initialized
 
         reset_initialization()
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {'status': 'ok', 'installed': [], 'failed': []}
             mock_migrate.return_value = {'status': 'ok', 'message': None}
@@ -221,7 +221,7 @@ class TestThreadSafety:
 
     def test_concurrent_calls_only_initialize_once(self):
         """Test that multiple concurrent calls only run initialization once."""
-        from memory_init import ensure_memory_ready, reset_initialization
+        from scripts.memory_init import ensure_memory_ready, reset_initialization
 
         reset_initialization()
 
@@ -235,9 +235,9 @@ class TestThreadSafety:
             time.sleep(0.05)
             return {'status': 'ok', 'installed': [], 'failed': []}
 
-        with patch('memory_init.check_and_install_dependencies', side_effect=counting_deps), \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies', side_effect=counting_deps), \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_migrate.return_value = {'status': 'ok', 'message': None}
             mock_embed.return_value = {'status': 'ok', 'message': None}
@@ -259,7 +259,7 @@ class TestThreadSafety:
 
     def test_double_check_locking_pattern(self):
         """Test that double-check locking prevents race conditions."""
-        from memory_init import ensure_memory_ready, reset_initialization
+        from scripts.memory_init import ensure_memory_ready, reset_initialization
 
         reset_initialization()
 
@@ -275,10 +275,10 @@ class TestThreadSafety:
             def __exit__(self, *args):
                 return original_lock.__exit__(*args)
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed, \
-             patch('memory_init._init_lock', TrackingLock()):
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed, \
+             patch('scripts.memory_init._init_lock', TrackingLock()):
 
             mock_deps.return_value = {'status': 'ok', 'installed': [], 'failed': []}
             mock_migrate.return_value = {'status': 'ok', 'message': None}
@@ -300,7 +300,7 @@ class TestCheckAndInstallDependencies:
 
     def test_all_dependencies_present_returns_ok(self):
         """Test when all dependencies are already installed - returns ok status."""
-        from memory_init import check_and_install_dependencies
+        from scripts.memory_init import check_and_install_dependencies
 
         # When deps are already importable, function returns ok with empty lists
         # The actual function checks via __import__, and if successful, returns ok
@@ -316,7 +316,7 @@ class TestCheckAndInstallDependencies:
     def test_subprocess_called_for_missing_deps(self, monkeypatch):
         """Test that subprocess.run is called when deps are missing."""
         import builtins
-        from memory_init import check_and_install_dependencies
+        from scripts.memory_init import check_and_install_dependencies
 
         monkeypatch.delenv("CI", raising=False)   # pins the installer, so the gate must be OPEN
         original_import = builtins.__import__
@@ -328,7 +328,7 @@ class TestCheckAndInstallDependencies:
             return original_import(name, *args, **kwargs)
 
         with patch.object(builtins, '__import__', mock_import), \
-             patch('memory_init.subprocess.run') as mock_run:
+             patch('scripts.memory_init.subprocess.run') as mock_run:
 
             mock_run.return_value = MagicMock(returncode=0)
 
@@ -340,7 +340,7 @@ class TestCheckAndInstallDependencies:
     def test_installation_failure_recorded(self, monkeypatch):
         """Test that installation failures are recorded in result."""
         import builtins
-        from memory_init import check_and_install_dependencies
+        from scripts.memory_init import check_and_install_dependencies
 
         monkeypatch.delenv("CI", raising=False)   # pins the installer, so the gate must be OPEN
         original_import = builtins.__import__
@@ -352,7 +352,7 @@ class TestCheckAndInstallDependencies:
             return original_import(name, *args, **kwargs)
 
         with patch.object(builtins, '__import__', mock_import), \
-             patch('memory_init.subprocess.run') as mock_run:
+             patch('scripts.memory_init.subprocess.run') as mock_run:
 
             mock_run.return_value = MagicMock(returncode=1)  # All installations fail
 
@@ -365,7 +365,7 @@ class TestCheckAndInstallDependencies:
         """Test that installation timeout is handled gracefully."""
         import builtins
         import subprocess
-        from memory_init import check_and_install_dependencies
+        from scripts.memory_init import check_and_install_dependencies
 
         monkeypatch.delenv("CI", raising=False)   # pins the installer, so the gate must be OPEN
         original_import = builtins.__import__
@@ -376,7 +376,7 @@ class TestCheckAndInstallDependencies:
             return original_import(name, *args, **kwargs)
 
         with patch.object(builtins, '__import__', mock_import), \
-             patch('memory_init.subprocess.run') as mock_run:
+             patch('scripts.memory_init.subprocess.run') as mock_run:
 
             mock_run.side_effect = subprocess.TimeoutExpired(cmd='pip', timeout=60)
 
@@ -388,7 +388,7 @@ class TestCheckAndInstallDependencies:
     def test_install_path_inert_when_ci_set(self, monkeypatch):
         """The gate FIRES: under CI the install path returns before subprocess."""
         import builtins
-        from memory_init import check_and_install_dependencies
+        from scripts.memory_init import check_and_install_dependencies
 
         monkeypatch.setenv("CI", "true")
         original_import = builtins.__import__
@@ -399,7 +399,7 @@ class TestCheckAndInstallDependencies:
             return original_import(name, *args, **kwargs)
 
         with patch.object(builtins, '__import__', mock_import), \
-             patch('memory_init.subprocess.run') as mock_run:
+             patch('scripts.memory_init.subprocess.run') as mock_run:
 
             result = check_and_install_dependencies()
 
@@ -465,10 +465,10 @@ class TestDependencyDriftIsDetectable:
         docstring. It also does not prove the reverse direction: CI may install
         packages this module does not know about, which is harmless.
         """
-        from memory_init import check_and_install_dependencies  # noqa: F401
+        from scripts.memory_init import check_and_install_dependencies  # noqa: F401
         import inspect
 
-        import memory_init
+        from scripts import memory_init
 
         source = inspect.getsource(memory_init.check_and_install_dependencies)
         declared = re.findall(r"\(\s*'([^']+)'\s*,\s*'[^']+'\s*\)", source)
@@ -591,7 +591,7 @@ class TestDependencyDriftIsDetectable:
         import warnings
         from contextlib import redirect_stderr
 
-        from memory_init import check_and_install_dependencies
+        from scripts.memory_init import check_and_install_dependencies
 
         original_import = builtins.__import__
 
@@ -603,7 +603,7 @@ class TestDependencyDriftIsDetectable:
         buf = io.StringIO()
         with patch.dict(os.environ, {"CI": "true"}), \
                 patch.object(builtins, '__import__', mock_import), \
-                patch('memory_init.subprocess.run') as mock_run, \
+                patch('scripts.memory_init.subprocess.run') as mock_run, \
                 warnings.catch_warnings(record=True) as caught, \
                 redirect_stderr(buf):
             warnings.simplefilter("always")
@@ -634,12 +634,12 @@ class TestMaybeEmbedPending:
 
     def test_session_scoped_only_runs_once(self, tmp_path):
         """Test that maybe_embed_pending only runs once per session via marker file."""
-        from memory_init import maybe_embed_pending, _get_embedding_attempted_path
+        from scripts.memory_init import maybe_embed_pending, _get_embedding_attempted_path
 
         # Use a unique session ID for this test
         test_session_id = f"test-once-{time.time()}"
 
-        with patch("memory_init.get_session_id_from_context_file", return_value=test_session_id):
+        with patch("scripts.memory_init.get_session_id_from_context_file", return_value=test_session_id):
             marker_path = _get_embedding_attempted_path()
 
             # Clean up any existing marker
@@ -668,11 +668,11 @@ class TestMaybeEmbedPending:
 
     def test_marker_file_created_on_first_call(self, tmp_path):
         """Test that the marker file is created on first call."""
-        from memory_init import maybe_embed_pending, _get_embedding_attempted_path
+        from scripts.memory_init import maybe_embed_pending, _get_embedding_attempted_path
 
         test_session_id = f"test-marker-{time.time()}"
 
-        with patch("memory_init.get_session_id_from_context_file", return_value=test_session_id):
+        with patch("scripts.memory_init.get_session_id_from_context_file", return_value=test_session_id):
             marker_path = _get_embedding_attempted_path()
 
             # Ensure marker doesn't exist
@@ -693,11 +693,11 @@ class TestMaybeEmbedPending:
 
     def test_skips_when_marker_exists(self, tmp_path):
         """Test that function skips immediately when marker exists."""
-        from memory_init import maybe_embed_pending, _get_embedding_attempted_path
+        from scripts.memory_init import maybe_embed_pending, _get_embedding_attempted_path
 
         test_session_id = f"test-skip-{time.time()}"
 
-        with patch("memory_init.get_session_id_from_context_file", return_value=test_session_id):
+        with patch("scripts.memory_init.get_session_id_from_context_file", return_value=test_session_id):
             marker_path = _get_embedding_attempted_path()
 
             # Pre-create the marker
@@ -722,14 +722,14 @@ class TestMemoryAPIIntegration:
 
     def test_ensure_ready_helper_calls_ensure_memory_ready(self):
         """Test that _ensure_ready() calls ensure_memory_ready()."""
-        from memory_init import reset_initialization, is_initialized, ensure_memory_ready
+        from scripts.memory_init import reset_initialization, is_initialized, ensure_memory_ready
 
         reset_initialization()
         assert is_initialized() is False
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {'status': 'ok', 'installed': [], 'failed': []}
             mock_migrate.return_value = {'status': 'ok', 'message': None}
@@ -743,13 +743,13 @@ class TestMemoryAPIIntegration:
 
     def test_repeated_ensure_ready_calls_are_idempotent(self):
         """Test that calling ensure_memory_ready multiple times only initializes once."""
-        from memory_init import reset_initialization, ensure_memory_ready
+        from scripts.memory_init import reset_initialization, ensure_memory_ready
 
         reset_initialization()
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {'status': 'ok', 'installed': [], 'failed': []}
             mock_migrate.return_value = {'status': 'ok', 'message': None}
@@ -767,13 +767,13 @@ class TestMemoryAPIIntegration:
 
     def test_fast_path_returns_immediately(self):
         """Test that fast path (already_initialized=True) returns without work."""
-        from memory_init import reset_initialization, ensure_memory_ready
+        from scripts.memory_init import reset_initialization, ensure_memory_ready
 
         reset_initialization()
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {'status': 'ok', 'installed': [], 'failed': []}
             mock_migrate.return_value = {'status': 'ok', 'message': None}
@@ -797,7 +797,7 @@ class TestMemoryAPIIntegration:
 
     def test_api_pattern_simulation(self):
         """Simulate how memory_api uses _ensure_ready pattern."""
-        from memory_init import reset_initialization, ensure_memory_ready, is_initialized
+        from scripts.memory_init import reset_initialization, ensure_memory_ready, is_initialized
 
         reset_initialization()
 
@@ -807,9 +807,9 @@ class TestMemoryAPIIntegration:
             ensure_memory_ready()  # This is what _ensure_ready() does
             return "operation completed"
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {'status': 'ok', 'installed': [], 'failed': []}
             mock_migrate.return_value = {'status': 'ok', 'message': None}
@@ -835,13 +835,13 @@ class TestGracefulDegradation:
 
     def test_continues_after_dep_failure(self):
         """Test that initialization continues even if dependency installation fails."""
-        from memory_init import ensure_memory_ready, reset_initialization
+        from scripts.memory_init import ensure_memory_ready, reset_initialization
 
         reset_initialization()
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {'status': 'failed', 'installed': [], 'failed': ['pysqlite3']}
             mock_migrate.return_value = {'status': 'ok', 'message': None}
@@ -856,13 +856,13 @@ class TestGracefulDegradation:
 
     def test_continues_after_migration_error(self):
         """Test that initialization continues even if migration fails."""
-        from memory_init import ensure_memory_ready, reset_initialization
+        from scripts.memory_init import ensure_memory_ready, reset_initialization
 
         reset_initialization()
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {'status': 'ok', 'installed': [], 'failed': []}
             mock_migrate.return_value = {'status': 'error', 'message': 'Migration failed'}
@@ -876,13 +876,13 @@ class TestGracefulDegradation:
 
     def test_continues_after_embedding_error(self):
         """Test that initialization completes even if embedding fails."""
-        from memory_init import ensure_memory_ready, reset_initialization, is_initialized
+        from scripts.memory_init import ensure_memory_ready, reset_initialization, is_initialized
 
         reset_initialization()
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {'status': 'ok', 'installed': [], 'failed': []}
             mock_migrate.return_value = {'status': 'ok', 'message': None}
@@ -896,13 +896,13 @@ class TestGracefulDegradation:
 
     def test_all_steps_fail_still_marks_initialized(self):
         """Test that even if all steps fail, system is marked initialized."""
-        from memory_init import ensure_memory_ready, reset_initialization, is_initialized
+        from scripts.memory_init import ensure_memory_ready, reset_initialization, is_initialized
 
         reset_initialization()
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {'status': 'failed', 'installed': [], 'failed': ['all']}
             mock_migrate.return_value = {'status': 'error', 'message': 'Failed'}
@@ -920,13 +920,13 @@ class TestEdgeCases:
 
     def test_empty_deps_result(self):
         """Test handling of empty dependency check result."""
-        from memory_init import ensure_memory_ready, reset_initialization
+        from scripts.memory_init import ensure_memory_ready, reset_initialization
 
         reset_initialization()
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {}  # Empty dict
             mock_migrate.return_value = {'status': 'ok', 'message': None}
@@ -938,13 +938,13 @@ class TestEdgeCases:
 
     def test_none_values_in_results(self):
         """Test handling of None values in step results."""
-        from memory_init import ensure_memory_ready, reset_initialization
+        from scripts.memory_init import ensure_memory_ready, reset_initialization
 
         reset_initialization()
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {'status': 'ok', 'installed': None, 'failed': None}
             mock_migrate.return_value = {'status': 'ok', 'message': None}
@@ -956,7 +956,7 @@ class TestEdgeCases:
 
     def test_reset_during_initialization(self):
         """Test that reset during initialization is handled safely."""
-        from memory_init import ensure_memory_ready, reset_initialization
+        from scripts.memory_init import ensure_memory_ready, reset_initialization
 
         reset_initialization()
 
@@ -964,9 +964,9 @@ class TestEdgeCases:
             time.sleep(0.1)
             return {'status': 'ok', 'installed': [], 'failed': []}
 
-        with patch('memory_init.check_and_install_dependencies', side_effect=slow_deps), \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies', side_effect=slow_deps), \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_migrate.return_value = {'status': 'ok', 'message': None}
             mock_embed.return_value = {'status': 'ok', 'message': None}
@@ -1507,11 +1507,19 @@ class TestMaybeMigrateEmbeddings:
         """Test: actual maybe_migrate_embeddings returns skipped_deps when deps unavailable.
 
         This tests the real function to ensure it gracefully handles
-        the ImportError when pysqlite3/sqlite_vec aren't available in test env.
+        the ImportError from an unavailable dependency. The unavailability
+        is FORCED: all three deps (pysqlite3, sqlite_vec, model2vec) are
+        importable in a dev environment, so a None entry in sys.modules
+        makes the import system raise ImportError deterministically,
+        independent of what the runner has installed. (This arm previously
+        passed on bare-imported memory_init's broken relative lazy leg
+        manufacturing that ImportError; the package-style conversion
+        repaired the leg, so the condition is now forced explicitly.)
         """
-        from memory_init import maybe_migrate_embeddings
+        from scripts.memory_init import maybe_migrate_embeddings
 
-        result = maybe_migrate_embeddings()
+        with patch.dict(sys.modules, {"pysqlite3": None}):
+            result = maybe_migrate_embeddings()
 
         # Without proper deps installed, function returns skipped_deps (graceful degradation)
         assert result['status'] == 'skipped_deps'
@@ -1524,13 +1532,13 @@ class TestLogging:
     def test_logs_installed_dependencies(self, caplog):
         """Test that installed dependencies are logged."""
         import logging
-        from memory_init import ensure_memory_ready, reset_initialization
+        from scripts.memory_init import ensure_memory_ready, reset_initialization
 
         reset_initialization()
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {'status': 'ok', 'installed': ['sqlite-vec'], 'failed': []}
             mock_migrate.return_value = {'status': 'ok', 'message': None}
@@ -1544,13 +1552,13 @@ class TestLogging:
     def test_logs_failed_installations(self, caplog):
         """Test that failed installations are logged as warnings."""
         import logging
-        from memory_init import ensure_memory_ready, reset_initialization
+        from scripts.memory_init import ensure_memory_ready, reset_initialization
 
         reset_initialization()
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {'status': 'partial', 'installed': [], 'failed': ['pysqlite3']}
             mock_migrate.return_value = {'status': 'ok', 'message': None}
@@ -1574,7 +1582,7 @@ class TestMemoryAPIRealIntegration:
 
     def test_pact_memory_save_triggers_ensure_ready(self):
         """Test that PACTMemory.save() triggers ensure_memory_ready()."""
-        from memory_init import reset_initialization
+        from scripts.memory_init import reset_initialization
 
         reset_initialization()
 
@@ -1584,16 +1592,16 @@ class TestMemoryAPIRealIntegration:
 
         # We need to mock ensure_memory_ready at the memory_api module level
         # because memory_api imports it with: from .memory_init import ensure_memory_ready
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {'status': 'ok', 'installed': [], 'failed': []}
             mock_migrate.return_value = {'status': 'ok', 'message': None}
             mock_embed.return_value = {'status': 'ok', 'message': None}
 
             # Import the ensure_memory_ready we're testing
-            from memory_init import ensure_memory_ready, is_initialized
+            from scripts.memory_init import ensure_memory_ready, is_initialized
 
             # Verify not initialized yet
             assert is_initialized() is False
@@ -1619,7 +1627,7 @@ class TestMemoryAPIRealIntegration:
         2. Importing PACTMemory (which imports ensure_memory_ready)
         3. Verifying that calling an API method would trigger initialization
         """
-        from memory_init import reset_initialization, is_initialized
+        from scripts.memory_init import reset_initialization, is_initialized
 
         reset_initialization()
 
@@ -1630,15 +1638,15 @@ class TestMemoryAPIRealIntegration:
         # So if we verify that ensure_memory_ready is called when we
         # simulate what _ensure_ready does, the integration is verified.
 
-        with patch('memory_init.check_and_install_dependencies') as mock_deps, \
-             patch('memory_init.maybe_migrate_embeddings') as mock_migrate, \
-             patch('memory_init.maybe_embed_pending') as mock_embed:
+        with patch('scripts.memory_init.check_and_install_dependencies') as mock_deps, \
+             patch('scripts.memory_init.maybe_migrate_embeddings') as mock_migrate, \
+             patch('scripts.memory_init.maybe_embed_pending') as mock_embed:
 
             mock_deps.return_value = {'status': 'ok', 'installed': [], 'failed': []}
             mock_migrate.return_value = {'status': 'ok', 'message': None}
             mock_embed.return_value = {'status': 'ok', 'message': None}
 
-            from memory_init import ensure_memory_ready
+            from scripts.memory_init import ensure_memory_ready
 
             # Before any call
             assert is_initialized() is False
@@ -1714,7 +1722,7 @@ class TestMemoryAPIRealIntegration:
 @pytest.fixture(autouse=True)
 def reset_init_state():
     """Reset initialization state before and after each test."""
-    from memory_init import reset_initialization
+    from scripts.memory_init import reset_initialization
     reset_initialization()
     yield
     reset_initialization()

--- a/pact-plugin/tests/test_memory_init.py
+++ b/pact-plugin/tests/test_memory_init.py
@@ -1518,7 +1518,7 @@ class TestMaybeMigrateEmbeddings:
         with patch.dict(sys.modules, {"pysqlite3": None}):
             result = maybe_migrate_embeddings()
 
-        # Without proper deps installed, function returns skipped_deps (graceful degradation)
+        # The forced ImportError (None entry above) -> skipped_deps (graceful degradation)
         assert result['status'] == 'skipped_deps'
         assert result['message'] == 'Dependencies not available'
 

--- a/pact-plugin/tests/test_memory_layer_composition.py
+++ b/pact-plugin/tests/test_memory_layer_composition.py
@@ -47,15 +47,12 @@ from __future__ import annotations
 
 import os
 import struct
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from helpers import create_test_schema
-
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 try:
     import pysqlite3 as sqlite3

--- a/pact-plugin/tests/test_memory_layer_composition.py
+++ b/pact-plugin/tests/test_memory_layer_composition.py
@@ -55,7 +55,7 @@ import pytest
 
 from helpers import create_test_schema
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 try:
     import pysqlite3 as sqlite3

--- a/pact-plugin/tests/test_memory_models.py
+++ b/pact-plugin/tests/test_memory_models.py
@@ -12,13 +12,9 @@ Tests cover:
 7. memory_from_db_row: basic conversion, file injection
 """
 import json
-import os
-import sys
 from datetime import datetime, timezone
 
 import pytest
-
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_memory_models.py
+++ b/pact-plugin/tests/test_memory_models.py
@@ -18,7 +18,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_memory_reachability.py
+++ b/pact-plugin/tests/test_memory_reachability.py
@@ -11,8 +11,6 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
-
 import memory_reachability as mr  # noqa: E402
 
 

--- a/pact-plugin/tests/test_memory_store_isolation.py
+++ b/pact-plugin/tests/test_memory_store_isolation.py
@@ -32,7 +32,6 @@ from pathlib import Path
 import pytest
 
 SCRIPTS_PARENT = Path(__file__).parent.parent / "skills" / "pact-memory"
-sys.path.insert(0, str(SCRIPTS_PARENT))
 
 from scripts.config import (  # noqa: E402
     MEMORY_DIR_ENV,

--- a/pact-plugin/tests/test_memory_store_scope.py
+++ b/pact-plugin/tests/test_memory_store_scope.py
@@ -41,7 +41,6 @@ from __future__ import annotations
 
 import ast
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
 from uuid import uuid4
@@ -49,8 +48,6 @@ from uuid import uuid4
 import pytest
 
 SCRIPTS_PARENT = Path(__file__).parent.parent / "skills" / "pact-memory"
-if str(SCRIPTS_PARENT) not in sys.path:
-    sys.path.insert(0, str(SCRIPTS_PARENT))
 
 from scripts import cli as cli_module  # noqa: E402
 from scripts import memory_api as memory_api_module  # noqa: E402

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -34,8 +34,6 @@ from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-
 
 # =============================================================================
 # merge_guard_post.py tests

--- a/pact-plugin/tests/test_merge_guard_1037_narrow.py
+++ b/pact-plugin/tests/test_merge_guard_1037_narrow.py
@@ -28,10 +28,6 @@ Dangerous literals are authored IN-FILE only (never on a Bash command line — t
 installed merge-guard hook false-positives on them). Backslash and single-quote
 are built from char vars so the escaped-quote vectors are unambiguous.
 """
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import pytest
 

--- a/pact-plugin/tests/test_merge_guard_1118_output_selector.py
+++ b/pact-plugin/tests/test_merge_guard_1118_output_selector.py
@@ -24,10 +24,6 @@ Dangerous substrings are constructed at runtime (M / MS / GR) so this file carri
 `gh pr merge` / `git/refs` literal — mirrors the architect probe-harness convention and
 keeps the file inert to any literal-scanning tool.
 """
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import pytest  # noqa: E402
 

--- a/pact-plugin/tests/test_merge_guard_1118_output_selector_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1118_output_selector_cert.py
@@ -31,10 +31,6 @@ Dangerous substrings are assembled at runtime (M / MS / GR / PR_MERGE) so this f
 no raw `gh pr merge` / `git/refs` literal — mirrors the coder file + architect probe-harness
 convention and keeps the file inert to any literal-scanning tool.
 """
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import pytest  # noqa: E402
 

--- a/pact-plugin/tests/test_merge_guard_1118_recert.py
+++ b/pact-plugin/tests/test_merge_guard_1118_recert.py
@@ -30,12 +30,9 @@ Dangerous substrings are assembled at runtime (M / GR / PR_MERGE) so this file c
 `gh pr merge` / `git/refs` literal — mirrors the coder + cert files' probe-harness convention.
 """
 import subprocess
-import sys
 import importlib.util
 from pathlib import Path
 from typing import Any
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import pytest  # noqa: E402
 

--- a/pact-plugin/tests/test_merge_guard_1129_r1_branch_set.py
+++ b/pact-plugin/tests/test_merge_guard_1129_r1_branch_set.py
@@ -22,10 +22,6 @@ file carries no raw force-delete literal — mirrors the sibling probe-harness c
 and keeps the file inert to any literal-scanning tool.
 """
 import json
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import pytest  # noqa: E402
 

--- a/pact-plugin/tests/test_merge_guard_1129_r1_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1129_r1_cert.py
@@ -41,13 +41,10 @@ inside the TestNonVacuity bodies, via monkeypatch, at run time.
 """
 import io
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest  # noqa: E402
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import merge_guard_post  # noqa: E402
 import merge_guard_pre  # noqa: E402

--- a/pact-plugin/tests/test_merge_guard_1129_r2_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1129_r2_cert.py
@@ -57,14 +57,11 @@ stays inert to the live guard.
 import io
 import json
 import subprocess
-import sys
 import types
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest  # noqa: E402
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import merge_guard_post  # noqa: E402
 import merge_guard_pre  # noqa: E402

--- a/pact-plugin/tests/test_merge_guard_1129_r3_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1129_r3_cert.py
@@ -78,13 +78,10 @@ so a reader needs no external design doc. Destructive verbs are assembled at run
 inert to the live guard; probe forms are never run as shell.
 """
 import subprocess
-import sys
 import types
 from pathlib import Path
 
 import pytest  # noqa: E402
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import shared.merge_guard_common as mgc  # noqa: E402
 

--- a/pact-plugin/tests/test_merge_guard_1134_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1134_cert.py
@@ -114,14 +114,10 @@ Destructive verbs are assembled at runtime so this file stays inert to the live 
 """
 import io
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
 
 import merge_guard_post as mgpost  # noqa: E402
 import merge_guard_pre as mgpre  # noqa: E402

--- a/pact-plugin/tests/test_merge_guard_1136_canonical_join_ssot.py
+++ b/pact-plugin/tests/test_merge_guard_1136_canonical_join_ssot.py
@@ -32,14 +32,11 @@ import io
 import json
 import random
 import subprocess
-import sys
 import types
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest  # noqa: E402
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import merge_guard_post  # noqa: E402
 import merge_guard_pre  # noqa: E402

--- a/pact-plugin/tests/test_merge_guard_1140_carrier5_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1140_carrier5_cert.py
@@ -58,13 +58,10 @@ Destructive verbs are assembled at runtime (BD/BDR/PF/M5) so this file carries n
 force-delete / force-push / merge literal and stays inert to the live guard.
 """
 import subprocess
-import sys
 import types
 from pathlib import Path
 
 import pytest  # noqa: E402
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import shared.merge_guard_common as mgc  # noqa: E402
 

--- a/pact-plugin/tests/test_merge_guard_1148_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1148_cert.py
@@ -29,13 +29,8 @@ Summary: BIDIRECTIONAL certification for the quote-aware comment excision (step 
          Destructive verbs are assembled at runtime so this file stays inert to the
          live guard.
 """
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
 
 import shared.merge_guard_common as mgc  # noqa: E402
 from merge_guard_baseline_loader import load_baseline  # noqa: E402

--- a/pact-plugin/tests/test_merge_guard_1155_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1155_cert.py
@@ -32,13 +32,8 @@ Summary: BIDIRECTIONAL certification for the cross-auth recognition fix (detect 
          Destructive verbs are assembled at runtime so this file stays inert to the
          live guard.
 """
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
 
 import shared.merge_guard_common as mgc  # noqa: E402
 import merge_guard_pre  # noqa: E402

--- a/pact-plugin/tests/test_merge_guard_1178_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1178_cert.py
@@ -41,13 +41,10 @@ Summary: COMPREHENSIVE BIDIRECTIONAL certification for #1178 — the positional-
          the live guard. Mirrors test_merge_guard_1140_carrier5_cert.py.
 """
 import subprocess
-import sys
 import types
 from pathlib import Path
 
 import pytest  # noqa: E402
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import shared.merge_guard_common as mgc  # noqa: E402
 

--- a/pact-plugin/tests/test_merge_guard_1178_f2_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1178_f2_cert.py
@@ -35,13 +35,10 @@ Summary: Durable BIDIRECTIONAL companion cert for the F2 over-block closure (com
          source proof that busybox RECURSE membership is load-bearing for the retention.
 """
 import subprocess
-import sys
 import types
 from pathlib import Path
 
 import pytest  # noqa: E402
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import shared.merge_guard_common as mgc  # noqa: E402
 

--- a/pact-plugin/tests/test_merge_guard_1181_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1181_cert.py
@@ -35,13 +35,8 @@ Summary: BIDIRECTIONAL certification for the read-verb value over-block class â€
          Destructive verbs are assembled at runtime so this file carries no raw
          force-delete / force-push / merge literal and stays inert to the live guard.
 """
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
 
 import shared.merge_guard_common as mgc  # noqa: E402
 from merge_guard_baseline_loader import load_baseline  # noqa: E402

--- a/pact-plugin/tests/test_merge_guard_1203_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1203_cert.py
@@ -78,14 +78,10 @@ Destructive verbs are assembled at runtime so this file stays inert to the live 
 """
 import io
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
 
 import merge_guard_post as mgpost  # noqa: E402
 import merge_guard_pre as mgpre  # noqa: E402

--- a/pact-plugin/tests/test_merge_guard_mint_parity.py
+++ b/pact-plugin/tests/test_merge_guard_mint_parity.py
@@ -28,12 +28,8 @@ Summary: STANDING mint-parity regression suite (permanent, not a one-arc cert) â
          Destructive verbs are assembled at runtime so this file stays inert to the
          live guard.
 """
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import merge_guard_pre  # noqa: E402
 from merge_guard_post import _mint_context_from_bundle, _target_value  # noqa: E402

--- a/pact-plugin/tests/test_merge_guard_obs_cert.py
+++ b/pact-plugin/tests/test_merge_guard_obs_cert.py
@@ -24,14 +24,10 @@ Summary: GOOD-FAITH over-block sweep certification (PR #1195 OBS). Certifies aga
 import ast
 import io
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
 
 import merge_guard_post as mgpost  # noqa: E402
 import merge_guard_pre as mgpre  # noqa: E402

--- a/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
+++ b/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
@@ -33,12 +33,8 @@ the real mint path _mint_context_from_bundle / _target_value / _token_matches_co
 
 import contextlib
 import re as _real_re
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import shared.merge_guard_common as mgc  # noqa: E402  (module handle for counter-mutation)
 from shared.merge_guard_common import (  # noqa: E402

--- a/pact-plugin/tests/test_merge_guard_output_side_process_sub.py
+++ b/pact-plugin/tests/test_merge_guard_output_side_process_sub.py
@@ -55,12 +55,8 @@ the new output-side coverage and re-pins the input-side parity that F2 must not
 disturb.
 """
 
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from merge_guard_pre import (  # noqa: E402
     _has_process_substitution_to_shell,

--- a/pact-plugin/tests/test_merge_guard_over_block_batch.py
+++ b/pact-plugin/tests/test_merge_guard_over_block_batch.py
@@ -36,13 +36,9 @@ Sibling per-lane suites (do not duplicate):
 
 import io
 import json
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.merge_guard_common import (  # noqa: E402
     is_dangerous_command as D,

--- a/pact-plugin/tests/test_merge_guard_overblock_cluster_monotonicity.py
+++ b/pact-plugin/tests/test_merge_guard_overblock_cluster_monotonicity.py
@@ -75,13 +75,8 @@ Summary: TEST-phase CORPUS-WIDE monotonicity sweep + intended-closure accounting
          Destructive verbs are assembled at runtime so this file carries no raw
          force-delete / force-push / merge literal and stays inert to the live guard.
 """
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
 
 import shared.merge_guard_common as mgc  # noqa: E402
 import merge_guard_pre  # noqa: E402  # R1/F2 e2e launder smoke

--- a/pact-plugin/tests/test_merge_guard_perf.py
+++ b/pact-plugin/tests/test_merge_guard_perf.py
@@ -59,13 +59,10 @@ targeted case goes RED. Expected cardinality: reverting the shared constants
 cases.
 """
 
-import sys
 import time
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from merge_guard_pre import is_dangerous_command  # noqa: E402
 from shared.merge_guard_common import detect_command_operation_type  # noqa: E402

--- a/pact-plugin/tests/test_merge_guard_pre.py
+++ b/pact-plugin/tests/test_merge_guard_pre.py
@@ -33,11 +33,7 @@ tests pinning the fixes; the new `test_authorization_mismatch_attack` test
 pins the end-to-end attack shape that the heredoc-side fix prevents.
 """
 
-import sys
-from pathlib import Path
 
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from merge_guard_pre import _GH_PR_NUMBER_RE  # noqa: E402
 

--- a/pact-plugin/tests/test_migration_section_comment.py
+++ b/pact-plugin/tests/test_migration_section_comment.py
@@ -29,13 +29,11 @@ traded it away with nothing going red.
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 import pytest
 
 _PLUGIN_ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(_PLUGIN_ROOT / "hooks"))
 
 from shared.claude_md_manager import (  # noqa: E402
     MANAGED_START_MARKER,

--- a/pact-plugin/tests/test_missed_wake_scan.py
+++ b/pact-plugin/tests/test_missed_wake_scan.py
@@ -33,13 +33,9 @@ append_event (module-global on missed_wake_scan), per devops's confirmed levers.
 """
 import io
 import json
-import sys
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import missed_wake_scan as mw  # noqa: E402
 from fixtures.role_frames import (  # noqa: E402

--- a/pact-plugin/tests/test_missed_wake_scan_integration.py
+++ b/pact-plugin/tests/test_missed_wake_scan_integration.py
@@ -50,13 +50,10 @@ the broken wiring" -> caught by UN-MOCKING the seam, not by revert alone.
 ================================================================================
 """
 import json
-import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import missed_wake_scan as mw  # noqa: E402
 import teammate_idle  # noqa: E402

--- a/pact-plugin/tests/test_orchestration_retrospective.py
+++ b/pact-plugin/tests/test_orchestration_retrospective.py
@@ -13,12 +13,9 @@ Tests cover:
 """
 import json
 import re
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.teachback_schema import resolve_variety_total  # noqa: E402
 from shared.variety_divergence import (  # noqa: E402

--- a/pact-plugin/tests/test_pact_config.py
+++ b/pact-plugin/tests/test_pact_config.py
@@ -20,12 +20,8 @@ Core invariants under test:
 - call-time read: setting an env var AFTER import still changes the result
   (proves no import-time caching).
 """
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import shared.pact_config as pact_config
 from shared.pact_config import get_bool, get_enum, llm_options

--- a/pact-plugin/tests/test_pact_config_gate_migration.py
+++ b/pact-plugin/tests/test_pact_config_gate_migration.py
@@ -29,11 +29,8 @@ Two layers:
 import importlib
 import os
 import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import shared.pact_config as pact_config
 

--- a/pact-plugin/tests/test_pact_context.py
+++ b/pact-plugin/tests/test_pact_context.py
@@ -133,13 +133,9 @@ Library module init() contract:
 
 import json
 import os
-import sys
 from pathlib import Path
 
 import pytest
-
-# Add hooks directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 class TestGetPactContext:

--- a/pact-plugin/tests/test_pact_harvest_cli.py
+++ b/pact-plugin/tests/test_pact_harvest_cli.py
@@ -52,7 +52,6 @@ from pathlib import Path
 import pytest
 
 _HOOKS_DIR = Path(__file__).parent.parent / "hooks"
-sys.path.insert(0, str(_HOOKS_DIR))
 
 import shared.pact_context as pact_context  # noqa: E402
 from shared.pact_harvest import _resolve_session_dir  # noqa: E402

--- a/pact-plugin/tests/test_path_setup_pin.py
+++ b/pact-plugin/tests/test_path_setup_pin.py
@@ -3,10 +3,10 @@
 The suite's path setup now lives in the two conftests (pact-plugin/conftest.py
 and tests/conftest.py). This pin keeps it that way:
 
-1. MODULE-LEVEL arm — no module-level path insert outside MODULE_ALLOWLIST
+1. MODULE-LEVEL arm — no module-level path mutation outside MODULE_ALLOWLIST
    (the files whose inserts are load-bearing at import time: spawn-parent
    setup and the baseline loader).
-2. ANY-FORM arm — no path insert of ANY kind (module-level, function-level,
+2. ANY-FORM arm — no path mutation of ANY kind (module-level, function-level,
    or embedded in a codegen string) outside KEEP_SET. Spawn workers must
    rebuild sys.path in the child (it does not cross a spawn boundary) and
    subprocess harnesses generate their own path lines; both stay legitimate,
@@ -15,6 +15,15 @@ and tests/conftest.py). This pin keeps it that way:
    Zero collisions today; a future skills/<new>/scripts/config.py shadowing
    pact-memory's config.py is the silent wrong-module failure this arm
    exists to catch.
+
+Matched mutation forms: sys.path.insert/append/extend calls and
+slice-assignment (sys.path[0:0] = [...]) — append/extend/slice-assign were
+added after a review finding that they dodged all three arms while append in
+particular is a plausible honest-mistake form, not an adversarial
+construction. ACCEPTED UNDER-BLOCK (adversarial-only, documented boundary):
+aliasing sys (`import sys as s`, `from sys import path`), `getattr(sys.path,
+...)`, and slice-assignment with exotic spacing inside codegen strings —
+this pin is an honest-mistake guard, not an adversary-proof one.
 
 Population: tests/**/*.py plus skills-adjacent test files
 (skills/*/test_*.py). conftest.py files are the mechanism and are exempt.
@@ -32,10 +41,12 @@ from pathlib import Path
 
 PLUGIN_ROOT = Path(__file__).resolve().parent.parent
 
-# Built as a concatenation so THIS file's own source never contains the
-# needle as a contiguous literal — the any-form arm scans string constants
-# and must not flag the pin itself.
-_NEEDLE = "sys.path" + ".insert("
+# Built as concatenations so THIS file's own source never contains a needle
+# as a contiguous literal — the any-form arm scans string constants and must
+# not flag the pin itself. Call-form tokens only; slice-assignment inside a
+# codegen string is accepted under-block (see module docstring).
+_STR_TOKENS = tuple("sys.path" + t for t in (".insert(", ".append(", ".extend("))
+_STR_VERBS = (".insert", ".append", ".extend")
 
 _MODULE_ALLOWLIST = {
     "tests/merge_guard_baseline_loader.py",
@@ -95,20 +106,42 @@ def _population():
     return [f for f in files if f.name != "conftest.py"]
 
 
-def _is_insert_call(node):
+def _is_sys_path(value):
     return (
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "insert"
-        and isinstance(node.func.value, ast.Attribute)
-        and node.func.value.attr == "path"
-        and isinstance(node.func.value.value, ast.Name)
-        and node.func.value.value.id == "sys"
+        isinstance(value, ast.Attribute)
+        and value.attr == "path"
+        and isinstance(value.value, ast.Name)
+        and value.value.id == "sys"
     )
 
 
-def _module_level_inserts(path):
-    """Line numbers of path inserts in MODULE scope only (defs/classes
+_MUTATION_VERBS = frozenset({"insert", "append", "extend"})
+
+
+def _is_mutation_call(node):
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in _MUTATION_VERBS
+        and _is_sys_path(node.func.value)
+    )
+
+
+def _is_slice_assign(node):
+    """sys.path[0:0] = [...] — an Assign whose target subscripts sys.path.
+    Insert-equivalent precedence, but not a Call, so the call predicate
+    structurally cannot see it."""
+    return isinstance(node, ast.Assign) and any(
+        isinstance(t, ast.Subscript) and _is_sys_path(t.value) for t in node.targets
+    )
+
+
+def _is_path_mutation(node):
+    return _is_mutation_call(node) or _is_slice_assign(node)
+
+
+def _module_level_mutations(path):
+    """Line numbers of path mutations in MODULE scope only (defs/classes
     excluded — a spawn worker's in-function rebuild is not module setup)."""
     tree = ast.parse(path.read_text(encoding="utf-8"))
     lines = []
@@ -120,7 +153,7 @@ def _module_level_inserts(path):
             ):
                 walk(child, True)
                 continue
-            if _is_insert_call(child) and not in_def:
+            if _is_path_mutation(child) and not in_def:
                 lines.append(child.lineno)
             walk(child, in_def)
 
@@ -129,17 +162,17 @@ def _module_level_inserts(path):
 
 
 def _any_form_present(path):
-    """True if the file contains a path insert at any level OR embeds the
-    needle in a string constant (codegen). Comments are AST-invisible and
-    never match."""
+    """True if the file contains a path mutation at any level OR embeds a
+    mutation token in a string constant (codegen). Comments are
+    AST-invisible and never match."""
     tree = ast.parse(path.read_text(encoding="utf-8"))
     for node in ast.walk(tree):
-        if _is_insert_call(node):
+        if _is_path_mutation(node):
             return True
         if (
             isinstance(node, ast.Constant)
             and isinstance(node.value, str)
-            and _NEEDLE in node.value
+            and any(tok in node.value for tok in _STR_TOKENS)
         ):
             return True
         if isinstance(node, ast.JoinedStr):
@@ -148,7 +181,7 @@ def _any_form_present(path):
                 for c in node.values
                 if isinstance(c, ast.Constant) and isinstance(c.value, str)
             )
-            if "sys.path" in text and ".insert" in text:
+            if "sys.path" in text and any(v in text for v in _STR_VERBS):
                 return True
     return False
 
@@ -163,10 +196,10 @@ def test_no_module_level_insert_outside_allowlist():
         rel = _rel(f)
         if rel in _MODULE_ALLOWLIST:
             continue
-        for ln in _module_level_inserts(f):
+        for ln in _module_level_mutations(f):
             violations.append(f"{rel}:{ln}")
     assert not violations, (
-        "module-level path insert outside the allowlist (path setup is "
+        "module-level path mutation outside the allowlist (path setup is "
         "conftest-owned now): " + ", ".join(violations)
     )
 

--- a/pact-plugin/tests/test_path_setup_pin.py
+++ b/pact-plugin/tests/test_path_setup_pin.py
@@ -1,0 +1,209 @@
+"""Structural pin: path setup is centralized — no per-file path inserts return.
+
+The suite's path setup now lives in the two conftests (pact-plugin/conftest.py
+and tests/conftest.py). This pin keeps it that way:
+
+1. MODULE-LEVEL arm — no module-level path insert outside MODULE_ALLOWLIST
+   (the files whose inserts are load-bearing at import time: spawn-parent
+   setup and the baseline loader).
+2. ANY-FORM arm — no path insert of ANY kind (module-level, function-level,
+   or embedded in a codegen string) outside KEEP_SET. Spawn workers must
+   rebuild sys.path in the child (it does not cross a spawn boundary) and
+   subprocess harnesses generate their own path lines; both stay legitimate,
+   but their file set is FIXED here so the set cannot grow silently.
+3. COLLISION arm — no two sanctioned path roots expose the same module stem.
+   Zero collisions today; a future skills/<new>/scripts/config.py shadowing
+   pact-memory's config.py is the silent wrong-module failure this arm
+   exists to catch.
+
+Population: tests/**/*.py plus skills-adjacent test files
+(skills/*/test_*.py). conftest.py files are the mechanism and are exempt.
+
+Keep-set provenance (enumerated from the tree, not inherited from plan
+text): 5 module-level carriers, 2 function-level (spawn-worker) carriers,
+12 codegen-string carriers. Plan-level expectations counted pre-deletion
+category memberships (16 spawn/subprocess + 8 top-level-scripts importers);
+the 8 top-level-scripts importers retain no inserts at all once scripts/ is
+conftest-owned, so they do not appear here.
+"""
+
+import ast
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+
+# Built as a concatenation so THIS file's own source never contains the
+# needle as a contiguous literal — the any-form arm scans string constants
+# and must not flag the pin itself.
+_NEEDLE = "sys.path" + ".insert("
+
+_MODULE_ALLOWLIST = {
+    "tests/merge_guard_baseline_loader.py",
+    "tests/test_session_journal.py",
+    "tests/test_task_claim_gate.py",
+    "tests/test_task_utils.py",
+    "tests/test_working_memory_concurrency.py",
+}
+
+_KEEP_SET = _MODULE_ALLOWLIST | {
+    # function-level (spawn workers re-derive path in the child process)
+    "tests/test_session_registry_concurrency.py",
+    "tests/test_working_memory_concurrency_comprehensive.py",
+    # codegen strings (subprocess harnesses embed path lines in child code)
+    "tests/test_agent_handoff_marker.py",
+    "tests/test_containment_certification.py",
+    "tests/test_embedding_status_contract.py",
+    "tests/test_memory_cli.py",
+    "tests/test_memory_init.py",
+    "tests/test_memory_reachability.py",
+    "tests/test_memory_store_isolation.py",
+    "tests/test_merge_guard.py",
+    "tests/test_pact_session_config_dir_parity.py",
+    "tests/test_pin_marker_writer_adversarial.py",
+    "tests/test_project_dir_resolution.py",
+    "tests/test_sync_result_contract.py",
+}
+
+# Sanctioned path roots, mirroring the two conftests: tests/conftest.py owns
+# tests/, hooks/, skills/pact-memory/, skills/pact-memory/scripts/,
+# skills/pact-coding-standards/scripts/, scripts/; the root conftest owns
+# skills/*/scripts (glob, future skills included) and the plugin root.
+# tests/fixtures/ is reachable via an allowlisted per-file insert.
+def _sanctioned_roots():
+    roots = [
+        PLUGIN_ROOT / "tests",
+        PLUGIN_ROOT / "tests" / "fixtures",
+        PLUGIN_ROOT / "hooks",
+        PLUGIN_ROOT / "skills" / "pact-memory",
+        PLUGIN_ROOT / "scripts",
+        PLUGIN_ROOT,  # telegram package family
+    ]
+    roots.extend(sorted(PLUGIN_ROOT.glob("skills/*/scripts")))
+    # resolve() so equivalent spellings dedupe
+    seen, out = set(), []
+    for r in roots:
+        key = str(r.resolve())
+        if key not in seen and r.is_dir():
+            seen.add(key)
+            out.append(r.resolve())
+    return out
+
+
+def _population():
+    files = sorted(PLUGIN_ROOT.glob("tests/**/*.py"))
+    files += sorted(PLUGIN_ROOT.glob("skills/*/test_*.py"))
+    return [f for f in files if f.name != "conftest.py"]
+
+
+def _is_insert_call(node):
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "insert"
+        and isinstance(node.func.value, ast.Attribute)
+        and node.func.value.attr == "path"
+        and isinstance(node.func.value.value, ast.Name)
+        and node.func.value.value.id == "sys"
+    )
+
+
+def _module_level_inserts(path):
+    """Line numbers of path inserts in MODULE scope only (defs/classes
+    excluded — a spawn worker's in-function rebuild is not module setup)."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    lines = []
+
+    def walk(node, in_def):
+        for child in ast.iter_child_nodes(node):
+            if isinstance(
+                child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            ):
+                walk(child, True)
+                continue
+            if _is_insert_call(child) and not in_def:
+                lines.append(child.lineno)
+            walk(child, in_def)
+
+    walk(tree, False)
+    return lines
+
+
+def _any_form_present(path):
+    """True if the file contains a path insert at any level OR embeds the
+    needle in a string constant (codegen). Comments are AST-invisible and
+    never match."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if _is_insert_call(node):
+            return True
+        if (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and _NEEDLE in node.value
+        ):
+            return True
+        if isinstance(node, ast.JoinedStr):
+            text = "".join(
+                c.value
+                for c in node.values
+                if isinstance(c, ast.Constant) and isinstance(c.value, str)
+            )
+            if "sys.path" in text and ".insert" in text:
+                return True
+    return False
+
+
+def _rel(path):
+    return str(path.resolve().relative_to(PLUGIN_ROOT))
+
+
+def test_no_module_level_insert_outside_allowlist():
+    violations = []
+    for f in _population():
+        rel = _rel(f)
+        if rel in _MODULE_ALLOWLIST:
+            continue
+        for ln in _module_level_inserts(f):
+            violations.append(f"{rel}:{ln}")
+    assert not violations, (
+        "module-level path insert outside the allowlist (path setup is "
+        "conftest-owned now): " + ", ".join(violations)
+    )
+
+
+def test_no_insert_of_any_form_outside_keep_set():
+    violations = []
+    for f in _population():
+        rel = _rel(f)
+        if rel in _KEEP_SET:
+            continue
+        if _any_form_present(f):
+            violations.append(rel)
+    assert not violations, (
+        "path insert (real or codegen) outside the keep-set — spawn-worker "
+        "and subprocess files are a FIXED set; adding one means updating "
+        "this pin deliberately: " + ", ".join(violations)
+    )
+
+
+def test_no_basename_collision_across_sanctioned_roots():
+    """No two sanctioned roots may expose the same module stem. A collision
+    makes resolution order decide which module an import gets — the silent
+    wrong-module failure the identity map can only see after the fact.
+    Scope: .py stems (dunder-init excluded). Directory-name duality (the
+    plugin-root scripts/ dir vs the pact-memory scripts package) is a
+    designed state and out of scope for this arm."""
+    stems = {}  # stem -> root that first exposed it
+    collisions = []
+    for root in _sanctioned_roots():
+        for py in sorted(root.glob("*.py")):
+            if py.name in ("__init__.py", "conftest.py"):
+                continue
+            stem = py.stem
+            if stem in stems and stems[stem] != root:
+                collisions.append(
+                    f"{stem}.py exposed by both {stems[stem]} and {root}"
+                )
+            else:
+                stems.setdefault(stem, root)
+    assert not collisions, "module-stem collision(s): " + "; ".join(collisions)

--- a/pact-plugin/tests/test_path_setup_pin.py
+++ b/pact-plugin/tests/test_path_setup_pin.py
@@ -21,10 +21,10 @@ Matched mutation forms: sys.path.insert/append/extend calls, slice-assignment
 insert were added after review findings that they dodged every arm while
 being plausible honest-mistake forms, not adversarial constructions.
 ACCEPTED UNDER-BLOCK (adversarial-only, documented boundary): aliasing sys
-(`import sys as s`, `from sys import path`), `getattr(sys.path, ...)` with a
-verb string, and slice-assign/augmented forms with exotic spacing inside
-codegen strings — this pin is an honest-mistake guard, not an
-adversary-proof one. OUT OF PARTITION (different failure mode): removal
+(`import sys as s`, `from sys import path`), wholesale rebinding
+(`sys.path = [...]`), `getattr(sys.path, ...)` with a verb string, and
+slice-assign/augmented forms with exotic spacing inside codegen strings —
+this pin is an honest-mistake guard, not an adversary-proof one. OUT OF PARTITION (different failure mode): removal
 mutations (remove/pop/clear/del) sabotage conftest setup rather than
 re-introduce per-file path setup; zero occurrences at introduction, and the
 failure would be loud (imports break), unlike a silent added root.

--- a/pact-plugin/tests/test_path_setup_pin.py
+++ b/pact-plugin/tests/test_path_setup_pin.py
@@ -16,14 +16,25 @@ and tests/conftest.py). This pin keeps it that way:
    pact-memory's config.py is the silent wrong-module failure this arm
    exists to catch.
 
-Matched mutation forms: sys.path.insert/append/extend calls and
-slice-assignment (sys.path[0:0] = [...]) — append/extend/slice-assign were
-added after a review finding that they dodged all three arms while append in
-particular is a plausible honest-mistake form, not an adversarial
-construction. ACCEPTED UNDER-BLOCK (adversarial-only, documented boundary):
-aliasing sys (`import sys as s`, `from sys import path`), `getattr(sys.path,
-...)`, and slice-assignment with exotic spacing inside codegen strings —
-this pin is an honest-mistake guard, not an adversary-proof one.
+Matched mutation forms: sys.path.insert/append/extend calls, slice-assignment
+(sys.path[0:0] = [...]), and augmented assignment (+=) on sys.path — all but
+insert were added after review findings that they dodged every arm while
+being plausible honest-mistake forms, not adversarial constructions.
+ACCEPTED UNDER-BLOCK (adversarial-only, documented boundary): aliasing sys
+(`import sys as s`, `from sys import path`), `getattr(sys.path, ...)` with a
+verb string, and slice-assign/augmented forms with exotic spacing inside
+codegen strings — this pin is an honest-mistake guard, not an
+adversary-proof one. OUT OF PARTITION (different failure mode): removal
+mutations (remove/pop/clear/del) sabotage conftest setup rather than
+re-introduce per-file path setup; zero occurrences at introduction, and the
+failure would be loud (imports break), unlike a silent added root.
+
+The matcher legs are pinned against silent rot by a committed negative
+fixture (tests/fixtures/pin_negative_path_mutations.py) carrying one
+violation per leg, plus test_negative_fixture_flags_every_matcher_leg
+asserting the matcher flags each fixture line exactly. The fixture is
+exempt from arms 1/2 via _NEGATIVE_FIXTURE — a single exact path, pinned
+by the self-test so the exemption cannot widen silently.
 
 Population: tests/**/*.py plus skills-adjacent test files
 (skills/*/test_*.py). conftest.py files are the mechanism and are exempt.
@@ -43,10 +54,13 @@ PLUGIN_ROOT = Path(__file__).resolve().parent.parent
 
 # Built as concatenations so THIS file's own source never contains a needle
 # as a contiguous literal — the any-form arm scans string constants and must
-# not flag the pin itself. Call-form tokens only; slice-assignment inside a
-# codegen string is accepted under-block (see module docstring).
-_STR_TOKENS = tuple("sys.path" + t for t in (".insert(", ".append(", ".extend("))
-_STR_VERBS = (".insert", ".append", ".extend")
+# not flag the pin itself. Call-form tokens plus augmented assignment in its
+# two common spacings; slice-assignment inside a codegen string is accepted
+# under-block (see module docstring).
+_STR_TOKENS = tuple(
+    "sys.path" + t for t in (".insert(", ".append(", ".extend(", " += ", "+=")
+)
+_STR_VERBS = (".insert", ".append", ".extend", "+=")
 
 _MODULE_ALLOWLIST = {
     "tests/merge_guard_baseline_loader.py",
@@ -128,16 +142,24 @@ def _is_mutation_call(node):
 
 
 def _is_slice_assign(node):
-    """sys.path[0:0] = [...] — an Assign whose target subscripts sys.path.
+    """An Assign whose target subscripts sys.path (sys.path[0:0] = [...]).
     Insert-equivalent precedence, but not a Call, so the call predicate
-    structurally cannot see it."""
+    structurally cannot see it. Any subscript target matches (index
+    replacement included) — all of them rewrite the search path."""
     return isinstance(node, ast.Assign) and any(
         isinstance(t, ast.Subscript) and _is_sys_path(t.value) for t in node.targets
     )
 
 
+def _is_aug_assign(node):
+    """An AugAssign whose target is the sys.path attribute (the += form).
+    Extend-equivalent, and neither a Call nor an Assign, so both other
+    predicates structurally miss it."""
+    return isinstance(node, ast.AugAssign) and _is_sys_path(node.target)
+
+
 def _is_path_mutation(node):
-    return _is_mutation_call(node) or _is_slice_assign(node)
+    return _is_mutation_call(node) or _is_slice_assign(node) or _is_aug_assign(node)
 
 
 def _module_level_mutations(path):
@@ -190,11 +212,18 @@ def _rel(path):
     return str(path.resolve().relative_to(PLUGIN_ROOT))
 
 
+# The committed negative fixture is DELIBERATE violation evidence (pinned by
+# test_negative_fixture_flags_every_matcher_leg), so the population arms skip
+# exactly this one path. The self-test asserts this constant's value — an
+# exemption widening requires editing this line and failing the self-test.
+_NEGATIVE_FIXTURE = "tests/fixtures/pin_negative_path_mutations.py"
+
+
 def test_no_module_level_insert_outside_allowlist():
     violations = []
     for f in _population():
         rel = _rel(f)
-        if rel in _MODULE_ALLOWLIST:
+        if rel in _MODULE_ALLOWLIST or rel == _NEGATIVE_FIXTURE:
             continue
         for ln in _module_level_mutations(f):
             violations.append(f"{rel}:{ln}")
@@ -208,15 +237,31 @@ def test_no_insert_of_any_form_outside_keep_set():
     violations = []
     for f in _population():
         rel = _rel(f)
-        if rel in _KEEP_SET:
+        if rel in _KEEP_SET or rel == _NEGATIVE_FIXTURE:
             continue
         if _any_form_present(f):
             violations.append(rel)
     assert not violations, (
-        "path insert (real or codegen) outside the keep-set — spawn-worker "
+        "path mutation (real or codegen) outside the keep-set — spawn-worker "
         "and subprocess files are a FIXED set; adding one means updating "
         "this pin deliberately: " + ", ".join(violations)
     )
+
+
+def test_negative_fixture_flags_every_matcher_leg():
+    """Pins the pin: the matcher must flag each committed violation line.
+
+    The fixture carries one module-level mutation per leg — insert, append,
+    extend (call leg), slice-assign, augmented assign. Exact line numbers
+    are the assertion: editing the fixture without updating this test fails
+    here, so neither silent matcher rot nor silent fixture drift is
+    possible. Also pins the exemption to exactly the fixture path."""
+    fixture = PLUGIN_ROOT / _NEGATIVE_FIXTURE
+    assert fixture.is_file(), f"negative fixture missing: {_NEGATIVE_FIXTURE}"
+    assert _module_level_mutations(fixture) == [18, 19, 20, 21, 22]
+    assert _any_form_present(fixture)
+    assert _NEGATIVE_FIXTURE not in _MODULE_ALLOWLIST
+    assert _NEGATIVE_FIXTURE not in _KEEP_SET
 
 
 def test_no_basename_collision_across_sanctioned_roots():

--- a/pact-plugin/tests/test_peer_inject.py
+++ b/pact-plugin/tests/test_peer_inject.py
@@ -16,13 +16,10 @@ Tests cover:
 """
 import io
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 class TestPeerInject:

--- a/pact-plugin/tests/test_per_dispatch_variety.py
+++ b/pact-plugin/tests/test_per_dispatch_variety.py
@@ -30,12 +30,9 @@ cases (None feature variety, empty dispatches, mixed coverage per D8).
 """
 
 import json
-import sys
 from pathlib import Path
 
 
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import task_lifecycle_gate as tlg  # noqa: E402
 

--- a/pact-plugin/tests/test_per_write_adversarial_matrix.py
+++ b/pact-plugin/tests/test_per_write_adversarial_matrix.py
@@ -52,8 +52,6 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-
 import shared.task_metadata_snapshot as tms  # noqa: E402
 import task_lifecycle_gate as tlg  # noqa: E402
 from shared.agent_handoff_marker import sanitize_path_component  # noqa: E402

--- a/pact-plugin/tests/test_per_write_snapshot_seam.py
+++ b/pact-plugin/tests/test_per_write_snapshot_seam.py
@@ -19,12 +19,9 @@ Used by: pytest (CODE-phase verification for the per-write seam; adversarial
 """
 
 import json
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import shared.task_metadata_snapshot as tms  # noqa: E402
 import task_lifecycle_gate as tlg  # noqa: E402

--- a/pact-plugin/tests/test_pin_caps.py
+++ b/pact-plugin/tests/test_pin_caps.py
@@ -10,12 +10,8 @@ gotcha — duplicate test class basenames across files silently drop the
 losing file's tests.
 """
 
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 class TestParsePins_ParsingSemantics:

--- a/pact-plugin/tests/test_pin_caps_adversarial.py
+++ b/pact-plugin/tests/test_pin_caps_adversarial.py
@@ -17,12 +17,8 @@ matrix does not cover:
 Risk tier: CRITICAL. These probe CVE-adjacent surfaces.
 """
 
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 class TestPinCapsAdversarial_PathResolution:

--- a/pact-plugin/tests/test_pin_caps_gate.py
+++ b/pact-plugin/tests/test_pin_caps_gate.py
@@ -19,13 +19,8 @@ Minimum coverage shipped in the code-phase commit:
 """
 
 import json
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
 
 from helpers import make_claude_md_with_pins, make_pin_entry  # noqa: E402
 

--- a/pact-plugin/tests/test_pin_caps_gate_counter_test.py
+++ b/pact-plugin/tests/test_pin_caps_gate_counter_test.py
@@ -23,13 +23,8 @@ If any counter-test produces 0 fails, the target test is phantom-green
 and must be rewritten.
 """
 
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
 
 from helpers import make_claude_md_with_pins, make_pin_entry  # noqa: E402
 

--- a/pact-plugin/tests/test_pin_caps_gate_low_priority.py
+++ b/pact-plugin/tests/test_pin_caps_gate_low_priority.py
@@ -18,14 +18,9 @@ covered in test_prune_memory_integration.py.
 """
 
 import json
-import sys
 import threading
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
 
 from helpers import make_claude_md_with_pins, make_pin_entry  # noqa: E402
 

--- a/pact-plugin/tests/test_pin_caps_gate_matrix.py
+++ b/pact-plugin/tests/test_pin_caps_gate_matrix.py
@@ -33,13 +33,8 @@ Invariants enforced:
 """
 
 import json
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
 
 from helpers import make_claude_md_with_pins, make_pin_entry  # noqa: E402
 

--- a/pact-plugin/tests/test_pin_caps_integration.py
+++ b/pact-plugin/tests/test_pin_caps_integration.py
@@ -14,13 +14,9 @@ Risk tier: CRITICAL.
 """
 
 import re
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
 
 from helpers import make_claude_md_with_pins, make_pin_entry  # noqa: E402
 

--- a/pact-plugin/tests/test_pin_caps_phantom_green.py
+++ b/pact-plugin/tests/test_pin_caps_phantom_green.py
@@ -17,14 +17,9 @@ update this test file to document the new surface.
 import json
 import os
 import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
-sys.path.insert(0, str(Path(__file__).parent))
 
 from helpers import make_claude_md_with_pins, make_pin_entry  # noqa: E402
 

--- a/pact-plugin/tests/test_pin_comment_dominance.py
+++ b/pact-plugin/tests/test_pin_comment_dominance.py
@@ -30,13 +30,8 @@ the losing file's tests.
 """
 
 import itertools
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
 
 from helpers import make_claude_md_with_pins  # noqa: E402
 

--- a/pact-plugin/tests/test_pin_comment_pipeline.py
+++ b/pact-plugin/tests/test_pin_comment_pipeline.py
@@ -29,14 +29,9 @@ something it promised not to do.
 Used with: hooks/pin_caps.py.
 """
 
-import sys
 import time
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
 
 
 STALE_MARKER = "<!-- STALE: Last relevant 2026-01-01 -->"

--- a/pact-plugin/tests/test_pin_marker_writer.py
+++ b/pact-plugin/tests/test_pin_marker_writer.py
@@ -194,7 +194,7 @@ class TestMarkerLiterals:
         monkeypatch.syspath_prepend(
             str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts")
         )
-        from working_memory import _PACT_BOUNDARY_ALT, _SESSION_BOUNDARY_ALT
+        from scripts.working_memory import _PACT_BOUNDARY_ALT, _SESSION_BOUNDARY_ALT
 
         hooks_alt = "|".join(PACT_BOUNDARY_PREFIXES)
         skills_alt = f"{_PACT_BOUNDARY_ALT}|{_SESSION_BOUNDARY_ALT}"
@@ -623,7 +623,7 @@ class TestAdjacencySurvivesBothMachineWriters:
         return _is_already_marked(region[0], heading.start())
 
     def test_the_above_heading_writer_cannot_break_adjacency(self, tmp_path, monkeypatch):
-        import working_memory as wm
+        from scripts import working_memory as wm
         target = self._project(tmp_path, monkeypatch)
         before = target.read_text(encoding="utf-8")
 
@@ -646,7 +646,7 @@ class TestAdjacencySurvivesBothMachineWriters:
         assert self._adjacent(after) is True
 
     def test_the_below_heading_writer_cannot_break_adjacency(self, tmp_path, monkeypatch):
-        import working_memory as wm
+        from scripts import working_memory as wm
         target = self._project(tmp_path, monkeypatch)
         before = target.read_text(encoding="utf-8")
 
@@ -680,7 +680,7 @@ class TestAdjacencySurvivesBothMachineWriters:
         silently ACCEPT a fused line, reporting marked while the marker is not
         where the writer puts it.)
         """
-        import working_memory as wm
+        from scripts import working_memory as wm
         from shared.claude_md_manager import extract_managed_region
         from shared.pin_markers import _PINNED_HEADING
         target = self._project(tmp_path, monkeypatch)
@@ -703,7 +703,7 @@ class TestAdjacencySurvivesBothMachineWriters:
         it, a carrier could occupy the adjacent line and adjacency would
         degrade SILENTLY with no other failing test.
         """
-        import working_memory as wm
+        from scripts import working_memory as wm
         from shared.claude_md_manager import extract_managed_region
         from shared.pin_markers import _PINNED_HEADING
         target = self._project(tmp_path, monkeypatch)

--- a/pact-plugin/tests/test_pin_staleness_gate.py
+++ b/pact-plugin/tests/test_pin_staleness_gate.py
@@ -15,9 +15,6 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent))
-
 from helpers import make_claude_md_with_pins, make_pin_entry  # noqa: E402
 
 

--- a/pact-plugin/tests/test_pin_staleness_gate_two_rules.py
+++ b/pact-plugin/tests/test_pin_staleness_gate_two_rules.py
@@ -15,14 +15,11 @@ class at the end is what shows each rule earns its place IN THE PRESENCE OF
 the other, which a mutation of one rule alone cannot show.
 """
 import re
-import sys
 from pathlib import Path
 
 import pytest
 
 HOOKS = Path(__file__).parent.parent / "hooks"
-if str(HOOKS) not in sys.path:
-    sys.path.insert(0, str(HOOKS))
 
 from shared.claude_md_manager import (  # noqa: E402
     MANAGED_START_MARKER,

--- a/pact-plugin/tests/test_pin_staleness_marker_clear.py
+++ b/pact-plugin/tests/test_pin_staleness_marker_clear.py
@@ -46,12 +46,8 @@ the staleness signal was CONSULTED, and asserts the opposite answer for the
 two commands under one fixture: an ordinary command must not reach the
 re-read, and the archive command must reach it.
 """
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 # The archive command shape the deny text tells a user to run. The token the
 # Bash leg tests for is `archive_pin.py`, so this string must carry it.

--- a/pact-plugin/tests/test_plugin_manifest.py
+++ b/pact-plugin/tests/test_plugin_manifest.py
@@ -16,12 +16,9 @@ UnicodeDecodeError, newline sanitization, etc.) is TEST phase work.
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 def _make_plugin_root(tmp_path: Path, manifest: str | None) -> Path:

--- a/pact-plugin/tests/test_postcompact_archive.py
+++ b/pact-plugin/tests/test_postcompact_archive.py
@@ -31,8 +31,6 @@ from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-
 
 HOOK_PATH = str(Path(__file__).parent.parent / "hooks" / "postcompact_archive.py")
 

--- a/pact-plugin/tests/test_pr4_drain_survival_harvest.py
+++ b/pact-plugin/tests/test_pr4_drain_survival_harvest.py
@@ -37,9 +37,6 @@ from pathlib import Path
 
 import pytest
 
-import sys
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.session_journal import append_event, make_event, read_events  # noqa: E402
 

--- a/pact-plugin/tests/test_pr4_revision_v2_on_journal.py
+++ b/pact-plugin/tests/test_pr4_revision_v2_on_journal.py
@@ -55,8 +55,6 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-
 import agent_handoff_emitter as ahe  # noqa: E402
 from shared.session_journal import read_events  # noqa: E402
 

--- a/pact-plugin/tests/test_precompact_state_reminder.py
+++ b/pact-plugin/tests/test_precompact_state_reminder.py
@@ -27,8 +27,6 @@ from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-
 
 HOOK_PATH = str(Path(__file__).parent.parent / "hooks" / "precompact_state_reminder.py")
 

--- a/pact-plugin/tests/test_prune_memory_integration.py
+++ b/pact-plugin/tests/test_prune_memory_integration.py
@@ -27,10 +27,6 @@ from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
-sys.path.insert(0, str(Path(__file__).parent))
-
 from helpers import make_claude_md_with_pins, make_pin_entry  # noqa: E402
 
 

--- a/pact-plugin/tests/test_recovery_pointer_fallback.py
+++ b/pact-plugin/tests/test_recovery_pointer_fallback.py
@@ -52,7 +52,6 @@ asserting the cut line would have PINNED AN OPEN DEFECT. The source now defers
 that id to the acceptor, so the arms assert the REFUSAL rather than the cut.
 """
 import ast
-import sys
 from pathlib import Path
 
 import pytest
@@ -60,10 +59,6 @@ import pytest
 _SOURCE_PATH = (
     Path(__file__).parent.parent
     / "skills" / "pact-memory" / "scripts" / "working_memory.py"
-)
-
-sys.path.insert(
-    0, str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts")
 )
 
 _ORDINARY_ID = "a1b2c3d4-e5f6"

--- a/pact-plugin/tests/test_recovery_pointer_fallback.py
+++ b/pact-plugin/tests/test_recovery_pointer_fallback.py
@@ -108,7 +108,7 @@ def _pointer_lines(entry, module):
 
 @pytest.fixture
 def working_memory():
-    import working_memory as module
+    from scripts import working_memory as module
 
     return module
 

--- a/pact-plugin/tests/test_resume_team_realign_1507.py
+++ b/pact-plugin/tests/test_resume_team_realign_1507.py
@@ -55,13 +55,10 @@ the FAIL counts — an xfailed cell reports xfailed, not failed):
 import io
 import json
 import os
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 _SUPPRESS_EXPECTED = {"suppressOutput": True}
 _NAME = "tester"

--- a/pact-plugin/tests/test_seam_line_ending_call_sites.py
+++ b/pact-plugin/tests/test_seam_line_ending_call_sites.py
@@ -28,14 +28,8 @@ SITES THIS FILE DOES NOT DRIVE ARE NAMED WITH THEIR REASON, in
 that names its misses is worth more than a higher count that does not.
 """
 import ast
-import sys
 from collections import Counter
 from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(
-    0, str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts")
-)
 
 _MANAGED_START = (
     "<!-- PACT_MANAGED_START: Managed by pact-plugin - do not edit this block -->"

--- a/pact-plugin/tests/test_session_block_substitution.py
+++ b/pact-plugin/tests/test_session_block_substitution.py
@@ -39,11 +39,6 @@ SESSION markers) build their content by f-string and `str.replace`, which have
 no replacement grammar, so no production of this family reaches them. A future
 edit that routes Case 2 through `re.sub` would be outside this file.
 """
-import sys
-from pathlib import Path
-
-# Add hooks directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 SESSION_START = "<!-- SESSION_START -->"
 SESSION_END = "<!-- SESSION_END -->"

--- a/pact-plugin/tests/test_session_consolidated_integration.py
+++ b/pact-plugin/tests/test_session_consolidated_integration.py
@@ -40,13 +40,10 @@ AC#3 true-positive preservation:
 
 import re
 import subprocess
-import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 # Absolute path to session_journal.py for subprocess-level bash tests. Computed
 # here so the bash-template tests (TestPauseBashConditionalEmission,

--- a/pact-plugin/tests/test_session_end.py
+++ b/pact-plugin/tests/test_session_end.py
@@ -15,14 +15,11 @@ Tests cover:
 """
 import io
 import json
-import sys
 from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 class TestGetProjectSlug:

--- a/pact-plugin/tests/test_session_end_integration.py
+++ b/pact-plugin/tests/test_session_end_integration.py
@@ -50,12 +50,9 @@ the task. Empirically confirmed via isolated worktree @ <fix-sha>^: {3 failed}.
 ================================================================================
 """
 import json
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import session_end  # noqa: E402
 

--- a/pact-plugin/tests/test_session_end_survives_a_forged_heading.py
+++ b/pact-plugin/tests/test_session_end_survives_a_forged_heading.py
@@ -69,16 +69,10 @@ THE FIXTURE RULES, AND EACH ONE ANSWERS A MEASURED FAILURE
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 from shared.claude_md_manager import MEMORY_START_MARKER, MEMORY_END_MARKER
 from tests.test_pin_marker_writer import build_claude_md
-
-sys.path.insert(
-    0, str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts")
-)
 
 SESSION_END = "<!-- SESSION_END -->"
 

--- a/pact-plugin/tests/test_session_end_survives_a_forged_heading.py
+++ b/pact-plugin/tests/test_session_end_survives_a_forged_heading.py
@@ -150,7 +150,7 @@ def _write_and_sync(tmp_path, document, call):
     target = tmp_path / "CLAUDE.md"
     target.write_text(document, encoding="utf-8")
     with patch(
-        "working_memory._resolve_display_claude_md_with_base",
+        "scripts.working_memory._resolve_display_claude_md_with_base",
         return_value=(target, target.parent),
     ):
         call()
@@ -198,7 +198,7 @@ class TestWorkingMemorySectionStopsAtTheSessionEnd:
     def test_the_marker_survives_a_forged_heading_in_the_session_block(
         self, tmp_path
     ):
-        from working_memory import sync_to_claude_md
+        from scripts.working_memory import sync_to_claude_md
 
         document = _build(self.HEADING)
         count_in = _assert_the_document_is_the_measured_shape(document, self.HEADING)
@@ -227,7 +227,7 @@ class TestRetrievedContextSectionStopsAtTheSessionEnd:
     def test_the_marker_survives_a_forged_heading_in_the_session_block(
         self, tmp_path
     ):
-        from working_memory import sync_retrieved_to_claude_md
+        from scripts.working_memory import sync_retrieved_to_claude_md
 
         document = _build(self.HEADING)
         count_in = _assert_the_document_is_the_measured_shape(document, self.HEADING)

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -44,7 +44,6 @@ from __future__ import annotations
 import io
 import json
 import re
-import sys
 from contextlib import ExitStack
 from datetime import datetime, timezone
 from pathlib import Path
@@ -52,9 +51,6 @@ from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-# Add hooks directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.constants import COMPACT_SUMMARY_ORPHAN_NAME  # noqa: E402
 

--- a/pact-plugin/tests/test_session_init_integration.py
+++ b/pact-plugin/tests/test_session_init_integration.py
@@ -38,12 +38,9 @@ safety-net shape) proves the assertion is coupled to the real resolution.
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 # Surgical: exercise the caller-3 resolver via task_utils directly. session_init
 # caller-3 (session_init.py ~:1211) calls the SAME function — session_init

--- a/pact-plugin/tests/test_session_init_primary_frame_keeps_the_ladder.py
+++ b/pact-plugin/tests/test_session_init_primary_frame_keeps_the_ladder.py
@@ -38,15 +38,12 @@ provably reached the emission point.
 """
 import io
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 _HOOKS = Path(__file__).parent.parent / "hooks"
-if str(_HOOKS) not in sys.path:
-    sys.path.insert(0, str(_HOOKS))
 
 import session_init  # noqa: E402
 from session_init import _build_safety_net_context, _UNKNOWN_ROLE_NOTICE  # noqa: E402

--- a/pact-plugin/tests/test_session_init_three_way_role_gate.py
+++ b/pact-plugin/tests/test_session_init_three_way_role_gate.py
@@ -39,15 +39,12 @@ means the branch declined rather than that the run died.
 """
 import io
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 _HOOKS = Path(__file__).parent.parent / "hooks"
-if str(_HOOKS) not in sys.path:
-    sys.path.insert(0, str(_HOOKS))
 
 import session_init  # noqa: E402
 from session_init import _build_safety_net_context, _UNKNOWN_ROLE_NOTICE  # noqa: E402

--- a/pact-plugin/tests/test_session_resume.py
+++ b/pact-plugin/tests/test_session_resume.py
@@ -50,13 +50,9 @@ from __future__ import annotations
 import datetime as _dt
 import errno
 import os
-import sys
 from pathlib import Path
 
 import pytest
-
-# Add hooks directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 class TestUpdateSessionInfo:

--- a/pact-plugin/tests/test_session_state.py
+++ b/pact-plugin/tests/test_session_state.py
@@ -21,12 +21,9 @@ invariants; they are load-bearing).
 
 from __future__ import annotations
 import json
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.session_journal import make_event
 from shared.session_state import (

--- a/pact-plugin/tests/test_setup_memory.py
+++ b/pact-plugin/tests/test_setup_memory.py
@@ -9,11 +9,8 @@ Tests cover:
 5. _get_recommendations: dependency-based recommendations
 """
 import os
-import sys
 from unittest.mock import patch
 
-
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_setup_memory.py
+++ b/pact-plugin/tests/test_setup_memory.py
@@ -13,7 +13,7 @@ import sys
 from unittest.mock import patch
 
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_shred_detect.py
+++ b/pact-plugin/tests/test_shred_detect.py
@@ -39,12 +39,9 @@ import ast
 import hashlib
 import json
 import sqlite3
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from memory_repair import shred_detect  # noqa: E402
 

--- a/pact-plugin/tests/test_snapshot_adversarial_matrix.py
+++ b/pact-plugin/tests/test_snapshot_adversarial_matrix.py
@@ -25,12 +25,9 @@ record, not an endorsed contract.
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.agent_handoff_marker import occupant_hash  # noqa: E402
 from shared.session_journal import read_events  # noqa: E402

--- a/pact-plugin/tests/test_snapshot_empty_team_dedup_cert.py
+++ b/pact-plugin/tests/test_snapshot_empty_team_dedup_cert.py
@@ -40,12 +40,9 @@ Used by: pytest. Companion file test_snapshot_marker_root_fallback.py
 """
 
 import os
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import shared.pact_context as pact_context_module  # noqa: E402
 import shared.session_journal as session_journal  # noqa: E402

--- a/pact-plugin/tests/test_snapshot_provenance_semantics.py
+++ b/pact-plugin/tests/test_snapshot_provenance_semantics.py
@@ -26,12 +26,9 @@ from __future__ import annotations
 
 import copy
 import json
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.session_journal import read_events  # noqa: E402
 from shared.task_metadata_snapshot import (  # noqa: E402

--- a/pact-plugin/tests/test_snapshot_roundtrip.py
+++ b/pact-plugin/tests/test_snapshot_roundtrip.py
@@ -13,10 +13,7 @@ Used by: pytest (the acceptance-criteria trace: load-bearing keys survive
 """
 
 import json
-import sys
 from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import shared.session_journal as session_journal  # noqa: E402
 import task_lifecycle_gate as tlg  # noqa: E402

--- a/pact-plugin/tests/test_snapshot_seams_gate.py
+++ b/pact-plugin/tests/test_snapshot_seams_gate.py
@@ -16,12 +16,9 @@ Used by: pytest (CODE-phase verification for the gate seams; edge/matrix
 """
 
 import json
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import shared.task_metadata_snapshot as tms  # noqa: E402
 import task_lifecycle_gate as tlg  # noqa: E402

--- a/pact-plugin/tests/test_snapshot_subprocess_seam.py
+++ b/pact-plugin/tests/test_snapshot_subprocess_seam.py
@@ -62,10 +62,8 @@ from pathlib import Path
 
 HOOKS_DIR = Path(__file__).parent.parent / "hooks"
 
-# For the occupant-join oracle only (computing the expected discriminator
-# with the shared SSOT fn) — the modules under test run in SUBPROCESSES and
-# are never imported, patched, or stubbed here.
-sys.path.insert(0, str(HOOKS_DIR))
+# The modules under test run in SUBPROCESSES and are never imported,
+# patched, or stubbed here.
 
 TEAM = "session-subproc"
 SID = "bbbbbbbb-2222-3333-4444-555555555555"

--- a/pact-plugin/tests/test_spawn_overhead_benchmark.py
+++ b/pact-plugin/tests/test_spawn_overhead_benchmark.py
@@ -17,11 +17,9 @@ introduce the per-teammate-spawn cost the v4.0.0 cutover eliminated.
 """
 
 import json
-import sys
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).parent.parent
-sys.path.insert(0, str(_REPO_ROOT / "hooks"))
 
 # Sentinel teammate for the regression check. backend-coder is one of the
 # larger teammate bodies; if it stays under THRESHOLD_BYTES the rest do

--- a/pact-plugin/tests/test_splice_window_memory_region.py
+++ b/pact-plugin/tests/test_splice_window_memory_region.py
@@ -37,14 +37,10 @@ IS.
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 from shared.claude_md_manager import MEMORY_START_MARKER, MEMORY_END_MARKER
 from tests.test_pin_marker_writer import build_claude_md
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"))
 
 
 # The text this suite looks for in the emitted document. It is deliberately

--- a/pact-plugin/tests/test_splice_window_memory_region.py
+++ b/pact-plugin/tests/test_splice_window_memory_region.py
@@ -72,7 +72,7 @@ def _write_and_sync(tmp_path, document, sync):
     target = tmp_path / "CLAUDE.md"
     target.write_text(document, encoding="utf-8")
     with patch(
-        "working_memory._resolve_display_claude_md_with_base",
+        "scripts.working_memory._resolve_display_claude_md_with_base",
         return_value=(target, target.parent),
     ):
         sync()
@@ -103,7 +103,7 @@ class TestWorkingMemorySpliceWindow:
     HEADING = "## Working Memory"
 
     def _sync(self, tmp_path, document):
-        from working_memory import sync_to_claude_md
+        from scripts.working_memory import sync_to_claude_md
 
         return _write_and_sync(
             tmp_path,
@@ -169,7 +169,7 @@ class TestRetrievedContextSpliceWindow:
     HEADING = "## Retrieved Context"
 
     def _sync(self, tmp_path, document):
-        from working_memory import sync_retrieved_to_claude_md
+        from scripts.working_memory import sync_retrieved_to_claude_md
 
         return _write_and_sync(
             tmp_path,
@@ -248,7 +248,7 @@ class TestMissingPairKeepsTodayBehaviour:
     def test_a_document_with_no_memory_pair_is_written_without_raising(
         self, tmp_path
     ):
-        from working_memory import sync_to_claude_md
+        from scripts.working_memory import sync_to_claude_md
 
         document = build_claude_md(managed=False)
         # PRECONDITION: this class covers a document with NO memory pair.

--- a/pact-plugin/tests/test_stale_session.py
+++ b/pact-plugin/tests/test_stale_session.py
@@ -21,12 +21,9 @@ detector's contract DIRECTLY:
   - the positive mismatch case (returns the warning naming recorded + actual).
 """
 
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.stale_session import (  # noqa: E402 — sys.path insert above
     detect_stale_session_block,

--- a/pact-plugin/tests/test_stale_session.py
+++ b/pact-plugin/tests/test_stale_session.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import pytest
 
-from shared.stale_session import (  # noqa: E402 — sys.path insert above
+from shared.stale_session import (
     detect_stale_session_block,
     _RESUME_LINE_RE,
 )

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -17,7 +17,6 @@ import ast
 import inspect
 import os
 import re
-import sys
 import tempfile
 import textwrap
 from datetime import datetime, timedelta
@@ -25,11 +24,6 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
-
-# Add hooks directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-# Add working_memory scripts directory to path for twin-copy equivalence test
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"))
 
 # THE ONE SPELLING OF THE WARNING MARKER, imported rather than repeated. Every
 # assertion and fixture below is built from this, so a rename in the source

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -1506,7 +1506,7 @@ class TestEstimateTokensEquivalence:
         the executable lines (the actual logic) are compared.
         """
         from staleness import estimate_tokens as staleness_fn
-        from working_memory import _estimate_tokens as working_memory_fn
+        from scripts.working_memory import _estimate_tokens as working_memory_fn
 
         staleness_source = inspect.getsource(staleness_fn)
         working_memory_source = inspect.getsource(working_memory_fn)
@@ -1523,7 +1523,7 @@ class TestEstimateTokensEquivalence:
     def test_both_use_word_count_times_1_3(self):
         """Both copies must use the word_count * 1.3 formula."""
         from staleness import estimate_tokens as staleness_fn
-        from working_memory import _estimate_tokens as working_memory_fn
+        from scripts.working_memory import _estimate_tokens as working_memory_fn
 
         staleness_source = inspect.getsource(staleness_fn)
         working_memory_source = inspect.getsource(working_memory_fn)
@@ -1540,7 +1540,7 @@ class TestEstimateTokensEquivalence:
     def test_both_return_zero_for_empty(self):
         """Both copies must return 0 for empty/falsy input."""
         from staleness import estimate_tokens as staleness_fn
-        from working_memory import _estimate_tokens as working_memory_fn
+        from scripts.working_memory import _estimate_tokens as working_memory_fn
 
         assert staleness_fn("") == 0
         assert working_memory_fn("") == 0
@@ -1549,7 +1549,7 @@ class TestEstimateTokensEquivalence:
     def test_both_produce_same_result(self):
         """Both copies must produce identical results for the same input."""
         from staleness import estimate_tokens as staleness_fn
-        from working_memory import _estimate_tokens as working_memory_fn
+        from scripts.working_memory import _estimate_tokens as working_memory_fn
 
         test_inputs = [
             "",
@@ -1979,7 +1979,7 @@ class TestPinCapsTwinCopyDrift:
 
     def test_pin_count_cap_twins_match(self):
         import pin_caps
-        import working_memory
+        from scripts import working_memory
 
         assert pin_caps.PIN_COUNT_CAP == working_memory.PIN_COUNT_CAP, (
             "PIN_COUNT_CAP drift between hooks/pin_caps.py and "
@@ -1989,7 +1989,7 @@ class TestPinCapsTwinCopyDrift:
 
     def test_pin_size_cap_twins_match(self):
         import pin_caps
-        import working_memory
+        from scripts import working_memory
 
         assert pin_caps.PIN_SIZE_CAP == working_memory.PIN_SIZE_CAP, (
             "PIN_SIZE_CAP drift between hooks/pin_caps.py and "
@@ -1999,7 +1999,7 @@ class TestPinCapsTwinCopyDrift:
 
     def test_pin_stale_block_threshold_twins_match(self):
         import pin_caps
-        import working_memory
+        from scripts import working_memory
 
         assert pin_caps.PIN_STALE_BLOCK_THRESHOLD == working_memory.PIN_STALE_BLOCK_THRESHOLD, (
             "PIN_STALE_BLOCK_THRESHOLD drift between hooks/pin_caps.py and "
@@ -2009,7 +2009,7 @@ class TestPinCapsTwinCopyDrift:
 
     def test_override_rationale_max_twins_match(self):
         import pin_caps
-        import working_memory
+        from scripts import working_memory
 
         assert pin_caps.OVERRIDE_RATIONALE_MAX == working_memory.OVERRIDE_RATIONALE_MAX, (
             "OVERRIDE_RATIONALE_MAX drift between hooks/pin_caps.py and "
@@ -2260,7 +2260,7 @@ class TestFileLockTwinCopyDrift:
         are allowed to differ.
         """
         from shared.claude_md_manager import file_lock as canonical
-        from working_memory import file_lock as twin
+        from scripts.working_memory import file_lock as twin
 
         canonical_body = self._extract_body(inspect.getsource(canonical))
         twin_body = self._extract_body(inspect.getsource(twin))
@@ -2276,7 +2276,7 @@ class TestFileLockTwinCopyDrift:
     def test_lock_timeout_constants_match(self):
         """The two lock-tuning constants are part of the twin and must match."""
         import shared.claude_md_manager as cmm
-        import working_memory as wm
+        from scripts import working_memory as wm
 
         assert cmm._LOCK_TIMEOUT_SECONDS == wm._LOCK_TIMEOUT_SECONDS, (
             "_LOCK_TIMEOUT_SECONDS drift between claude_md_manager.py and "
@@ -2386,7 +2386,7 @@ class TestSanitizePromptFieldTwinCopyDrift:
         and the guard would hold on only one of the two writers.
         """
         from shared.session_resume import _sanitize_prompt_field as canonical
-        from working_memory import _sanitize_prompt_field as twin
+        from scripts.working_memory import _sanitize_prompt_field as twin
 
         canonical_body = self._extract_body(canonical)
         twin_body = self._extract_body(twin)
@@ -2423,7 +2423,7 @@ class TestSanitizePromptFieldTwinCopyDrift:
         and neither one covers the other.
         """
         from shared.session_resume import _sanitize_prompt_field as canonical
-        from working_memory import _sanitize_prompt_field as twin
+        from scripts.working_memory import _sanitize_prompt_field as twin
 
         canonical_signature = self._extract_signature(canonical)
         twin_signature = self._extract_signature(twin)
@@ -2463,7 +2463,7 @@ class TestSanitizePromptFieldTwinCopyDrift:
         the widest default.
         """
         import shared.session_resume as sr
-        import working_memory as wm
+        from scripts import working_memory as wm
 
         assert sr._REFRESH_FIELD_TRUNCATION_LIMIT == wm._REFRESH_FIELD_TRUNCATION_LIMIT, (
             "_REFRESH_FIELD_TRUNCATION_LIMIT drift between session_resume.py "
@@ -2665,7 +2665,7 @@ class TestAtomicWriteTwinCopyDrift:
         test_containment_certification.py, which drives both independently.
         """
         from shared.claude_md_manager import _atomic_write_text as canonical
-        from working_memory import _atomic_write_text as twin
+        from scripts.working_memory import _atomic_write_text as twin
 
         canonical_body = self._extract_body(inspect.getsource(canonical))
         twin_body = self._extract_body(inspect.getsource(twin))
@@ -2729,7 +2729,7 @@ class TestLineEndingHelperTwinCopyDrift:
     def test_line_ending_helper_bodies_are_identical(self, helper):
         """Each helper's body MUST be byte-identical across the twins."""
         import shared.claude_md_manager as canonical_mod
-        import working_memory as twin_mod
+        from scripts import working_memory as twin_mod
 
         canonical_body = self._extract_body(
             inspect.getsource(getattr(canonical_mod, helper))
@@ -2755,7 +2755,7 @@ class TestLineEndingHelperTwinCopyDrift:
         LOUDEST in the state this gate exists to catch: two copies that share
         nothing. Prove the extractor separates two functions that genuinely
         differ before trusting it to report that two agree."""
-        import working_memory as twin_mod
+        from scripts import working_memory as twin_mod
 
         detect = self._extract_body(
             inspect.getsource(twin_mod._detect_line_ending)
@@ -2924,7 +2924,7 @@ class TestRestoreNormalisesBeforeItApplies:
 
     # THE TWO TWINS, as import targets. Parametrized rather than looped so a
     # failure names WHICH copy broke.
-    _TWINS = ("shared.claude_md_manager", "working_memory")
+    _TWINS = ("shared.claude_md_manager", "scripts.working_memory")
 
     @staticmethod
     def _restore(module_name):
@@ -3010,7 +3010,7 @@ class TestContainmentErrorTwinCopyDrift:
 
     def test_containment_error_shapes_are_identical(self):
         from shared.claude_md_manager import ContainmentError as canonical
-        from working_memory import ContainmentError as twin
+        from scripts.working_memory import ContainmentError as twin
 
         assert self._executable_shape(canonical) == self._executable_shape(twin), (
             "ContainmentError twin drift between "
@@ -3023,8 +3023,8 @@ class TestContainmentErrorTwinCopyDrift:
     def test_the_gate_can_tell_the_shapes_apart(self):
         """NON-VACUITY. An AST comparison that returns equal for everything
         would pass the assertion above forever."""
-        from working_memory import ContainmentError as twin
-        from working_memory import _project_root_of as unrelated
+        from scripts.working_memory import ContainmentError as twin
+        from scripts.working_memory import _project_root_of as unrelated
 
         assert self._executable_shape(twin) != self._executable_shape(unrelated), (
             "the shape extractor cannot distinguish two different definitions, "
@@ -3057,7 +3057,7 @@ class TestProjectRootLayoutKnowledgeDrift:
             _LEGACY_RELATIVE,
             resolve_project_claude_md_path,
         )
-        from working_memory import _project_root_of
+        from scripts.working_memory import _project_root_of
 
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)

--- a/pact-plugin/tests/test_store_scope_decorator_contract.py
+++ b/pact-plugin/tests/test_store_scope_decorator_contract.py
@@ -41,7 +41,7 @@ import os
 import pathlib
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 from scripts.memory_api import PACTMemory  # noqa: E402
 

--- a/pact-plugin/tests/test_store_scope_decorator_contract.py
+++ b/pact-plugin/tests/test_store_scope_decorator_contract.py
@@ -37,11 +37,7 @@ exempt method.
 from __future__ import annotations
 
 import ast
-import os
 import pathlib
-import sys
-
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 from scripts.memory_api import PACTMemory  # noqa: E402
 

--- a/pact-plugin/tests/test_symlinks.py
+++ b/pact-plugin/tests/test_symlinks.py
@@ -16,12 +16,8 @@ setup_plugin_symlinks():
 """
 
 import os
-import sys
 from pathlib import Path
 from unittest.mock import patch
-
-# Add hooks directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 class TestSetupPluginSymlinks:

--- a/pact-plugin/tests/test_sync_result_contract.py
+++ b/pact-plugin/tests/test_sync_result_contract.py
@@ -30,8 +30,6 @@ from pathlib import Path
 
 import pytest
 
-# scripts/ is a package; add skills/pact-memory so `scripts.*` imports resolve.
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 from scripts.working_memory import SyncResult
 

--- a/pact-plugin/tests/test_sync_result_contract.py
+++ b/pact-plugin/tests/test_sync_result_contract.py
@@ -31,7 +31,7 @@ from pathlib import Path
 import pytest
 
 # scripts/ is a package; add skills/pact-memory so `scripts.*` imports resolve.
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "skills", "pact-memory"))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 from scripts.working_memory import SyncResult
 

--- a/pact-plugin/tests/test_task_claim_gate.py
+++ b/pact-plugin/tests/test_task_claim_gate.py
@@ -44,7 +44,6 @@ from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 sys.path.insert(0, str(Path(__file__).parent / "fixtures"))
 
 import task_claim_gate as gate  # noqa: E402

--- a/pact-plugin/tests/test_task_integration.py
+++ b/pact-plugin/tests/test_task_integration.py
@@ -15,14 +15,10 @@ build_refresh_from_tasks in #444).
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 from typing import Any
 
 import pytest
-
-# Add hooks directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 # =============================================================================

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -44,8 +44,6 @@ from unittest.mock import patch
 import pytest
 
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-
 import task_lifecycle_gate as tlg  # noqa: E402
 # #958: imported from the SSOT module so the message-body echo assertions
 # below are coupled to the EXACT constant the gate appends — a substring check

--- a/pact-plugin/tests/test_task_lifecycle_gate_smoke.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate_smoke.py
@@ -31,8 +31,6 @@ from unittest.mock import patch
 import pytest
 
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-
 import task_lifecycle_gate as tlg  # noqa: E402
 
 

--- a/pact-plugin/tests/test_task_utils.py
+++ b/pact-plugin/tests/test_task_utils.py
@@ -15,7 +15,6 @@ from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks" / "shared"))
 
 

--- a/pact-plugin/tests/test_teachback_subject_hoist_parity.py
+++ b/pact-plugin/tests/test_teachback_subject_hoist_parity.py
@@ -25,12 +25,9 @@ from the literal `TEACHBACK for ` to a word boundary:
      superset, never a re-aim.
 """
 import re
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import task_lifecycle_gate as tlg  # noqa: E402
 from shared.task_utils import is_teachback_subject  # noqa: E402

--- a/pact-plugin/tests/test_team_name_detect_align.py
+++ b/pact-plugin/tests/test_team_name_detect_align.py
@@ -39,12 +39,9 @@ empty-SSOT short-circuit returns "" even when a matchable dir IS present (so the
 
 import json
 import os
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 # ── Two real-shaped session ids + the divergent dir-naming schemes ────────────

--- a/pact-plugin/tests/test_team_name_resolution_both_modes.py
+++ b/pact-plugin/tests/test_team_name_resolution_both_modes.py
@@ -79,13 +79,10 @@ pre-fix parent and re-running:
 
 import io
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 _SUPPRESS_EXPECTED = {"suppressOutput": True}
 _NAME = "tester"

--- a/pact-plugin/tests/test_teammate_idle.py
+++ b/pact-plugin/tests/test_teammate_idle.py
@@ -19,13 +19,10 @@ Tests cover:
 - Concurrent multi-agent tracking independence.
 """
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 def make_task(task_id="1", subject="CODE: auth", status="in_progress",

--- a/pact-plugin/tests/test_teammate_mode.py
+++ b/pact-plugin/tests/test_teammate_mode.py
@@ -65,9 +65,6 @@ from pathlib import Path
 
 import pytest
 
-# Add hooks directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-
 import shared.teammate_mode as teammate_mode
 from shared.teammate_mode import (
     VALID_TEAMMATE_MODES,

--- a/pact-plugin/tests/test_telegram_client.py
+++ b/pact-plugin/tests/test_telegram_client.py
@@ -14,14 +14,10 @@ Tests cover:
 9. Security: unauthorized chat_id rejection, inbound sanitization
 """
 
-import sys
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from telegram.telegram_client import (
     TelegramClient,

--- a/pact-plugin/tests/test_telegram_config.py
+++ b/pact-plugin/tests/test_telegram_config.py
@@ -13,14 +13,9 @@ Tests cover:
 """
 
 import subprocess
-import sys
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-# Add telegram package to path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from telegram.config import (
     ConfigError,

--- a/pact-plugin/tests/test_telegram_content_filter.py
+++ b/pact-plugin/tests/test_telegram_content_filter.py
@@ -11,11 +11,7 @@ Tests cover:
 6. Edge cases: empty strings, None-like, very long inputs
 """
 
-import sys
-from pathlib import Path
 
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from telegram.content_filter import (
     TELEGRAM_MAX_MESSAGE_LENGTH,

--- a/pact-plugin/tests/test_telegram_deps.py
+++ b/pact-plugin/tests/test_telegram_deps.py
@@ -9,11 +9,7 @@ Tests cover:
 """
 
 import subprocess
-import sys
-from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from telegram.deps import (
     check_dependencies,

--- a/pact-plugin/tests/test_telegram_main.py
+++ b/pact-plugin/tests/test_telegram_main.py
@@ -8,13 +8,10 @@ Tests cover:
 """
 
 import sys
-from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Mock the mcp module tree before importing anything that touches server.py
 if "mcp" not in sys.modules:

--- a/pact-plugin/tests/test_telegram_notify.py
+++ b/pact-plugin/tests/test_telegram_notify.py
@@ -13,15 +13,11 @@ Tests cover:
 import io
 import json
 import os
-import sys
 import urllib.error
 import urllib.request
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from telegram.notify import (
     _filter_message,

--- a/pact-plugin/tests/test_telegram_routing.py
+++ b/pact-plugin/tests/test_telegram_routing.py
@@ -14,14 +14,11 @@ Tests cover:
 import fcntl
 import json
 import os
-import sys
 import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from telegram.config import get_or_create_session_id
 from telegram.routing import (

--- a/pact-plugin/tests/test_telegram_server.py
+++ b/pact-plugin/tests/test_telegram_server.py
@@ -11,13 +11,10 @@ Tests cover:
 
 import asyncio
 import sys
-from pathlib import Path
 from types import ModuleType
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Mock the mcp module tree before importing server.py (mcp may not be installed)
 if "mcp" not in sys.modules:

--- a/pact-plugin/tests/test_telegram_tools.py
+++ b/pact-plugin/tests/test_telegram_tools.py
@@ -12,14 +12,10 @@ Tests cover:
 
 import asyncio
 import os
-import sys
 import time
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from telegram.tools import (
     ToolContext,

--- a/pact-plugin/tests/test_telegram_voice.py
+++ b/pact-plugin/tests/test_telegram_voice.py
@@ -10,15 +10,12 @@ Tests cover:
 6. Security: temp file always deleted, no credentials in errors, size limits
 """
 
-import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from telegram.voice import (
     VoiceTranscriber,

--- a/pact-plugin/tests/test_token_budget.py
+++ b/pact-plugin/tests/test_token_budget.py
@@ -11,13 +11,8 @@ Tests cover:
 
 import os
 import re
-import sys
-from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-
-# Add paths for imports
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"))
 
 
 class TestEstimateTokens:

--- a/pact-plugin/tests/test_token_budget.py
+++ b/pact-plugin/tests/test_token_budget.py
@@ -25,29 +25,29 @@ class TestEstimateTokens:
 
     def test_empty_string_returns_zero(self):
         """Empty string should return 0 tokens."""
-        from working_memory import _estimate_tokens
+        from scripts.working_memory import _estimate_tokens
         assert _estimate_tokens("") == 0
 
     def test_single_word(self):
         """Single word should return int(1 * 1.3) = 1."""
-        from working_memory import _estimate_tokens
+        from scripts.working_memory import _estimate_tokens
         assert _estimate_tokens("hello") == 1
 
     def test_ten_words(self):
         """Ten words should return int(10 * 1.3) = 13."""
-        from working_memory import _estimate_tokens
+        from scripts.working_memory import _estimate_tokens
         text = "one two three four five six seven eight nine ten"
         assert _estimate_tokens(text) == 13
 
     def test_returns_integer(self):
         """Should always return an integer, not a float."""
-        from working_memory import _estimate_tokens
+        from scripts.working_memory import _estimate_tokens
         result = _estimate_tokens("some words here")
         assert isinstance(result, int)
 
     def test_longer_text_scales_proportionally(self):
         """Longer text should produce proportionally larger estimates."""
-        from working_memory import _estimate_tokens
+        from scripts.working_memory import _estimate_tokens
         short = _estimate_tokens("a b c")
         long_val = _estimate_tokens("a b c d e f g h i j k l m n o")
         assert long_val > short
@@ -58,7 +58,7 @@ class TestCompressMemoryEntry:
 
     def test_extracts_context_first_sentence(self):
         """Should extract first sentence from Context field."""
-        from working_memory import _compress_memory_entry
+        from scripts.working_memory import _compress_memory_entry
 
         entry = (
             "### 2026-01-15 10:30\n"
@@ -82,7 +82,7 @@ class TestCompressMemoryEntry:
 
     def test_truncates_long_context_without_period(self):
         """Should truncate to 120 chars with ellipsis when no period found early."""
-        from working_memory import _compress_memory_entry
+        from scripts.working_memory import _compress_memory_entry
 
         long_context = "A" * 200
         entry = f"### 2026-01-15 10:30\n**Context**: {long_context}"
@@ -95,7 +95,7 @@ class TestCompressMemoryEntry:
 
     def test_handles_context_with_early_period(self):
         """Should take first sentence if period appears before 120 chars."""
-        from working_memory import _compress_memory_entry
+        from scripts.working_memory import _compress_memory_entry
 
         entry = (
             "### 2026-02-01 08:00\n"
@@ -106,7 +106,7 @@ class TestCompressMemoryEntry:
 
     def test_preserves_date_header(self):
         """Date header line should always be preserved."""
-        from working_memory import _compress_memory_entry
+        from scripts.working_memory import _compress_memory_entry
 
         entry = "### 2026-03-15 14:22\n**Context**: Some context"
         result = _compress_memory_entry(entry)
@@ -114,7 +114,7 @@ class TestCompressMemoryEntry:
 
     def test_falls_back_to_first_field_when_no_context(self):
         """Should use first bold field if no Context field present."""
-        from working_memory import _compress_memory_entry
+        from scripts.working_memory import _compress_memory_entry
 
         entry = (
             "### 2026-01-20 12:00\n"
@@ -127,12 +127,12 @@ class TestCompressMemoryEntry:
 
     def test_empty_entry_returns_entry(self):
         """Empty entry should return itself."""
-        from working_memory import _compress_memory_entry
+        from scripts.working_memory import _compress_memory_entry
         assert _compress_memory_entry("") == ""
 
     def test_header_only_entry(self):
         """Entry with only date header should return just the header."""
-        from working_memory import _compress_memory_entry
+        from scripts.working_memory import _compress_memory_entry
         result = _compress_memory_entry("### 2026-01-01 00:00")
         assert result == "### 2026-01-01 00:00"
 
@@ -142,12 +142,12 @@ class TestApplyTokenBudget:
 
     def test_empty_entries_returns_empty(self):
         """Empty list should return empty list."""
-        from working_memory import _apply_token_budget
+        from scripts.working_memory import _apply_token_budget
         assert _apply_token_budget([], 800) == []
 
     def test_under_budget_no_change(self):
         """Entries under budget should be returned unchanged."""
-        from working_memory import _apply_token_budget
+        from scripts.working_memory import _apply_token_budget
 
         entries = [
             "### 2026-01-15 10:00\n**Context**: Short entry",
@@ -158,7 +158,7 @@ class TestApplyTokenBudget:
 
     def test_over_budget_compresses_older_entries(self):
         """When over budget, older entries should be compressed (newest stays full)."""
-        from working_memory import _apply_token_budget
+        from scripts.working_memory import _apply_token_budget
 
         long_text = "word " * 100  # ~130 tokens per entry
         entries = [
@@ -190,7 +190,7 @@ class TestApplyTokenBudget:
         put its input out of reach of the mechanism it names. A fixture
         computed from the constants moves WITH them.
         """
-        from working_memory import (
+        from scripts.working_memory import (
             _apply_token_budget,
             _estimate_tokens,
             COMPRESSED_ENTRY_TOKEN_CEILING,
@@ -260,7 +260,7 @@ class TestApplyTokenBudget:
         and none for a neighbour, so the loop must run at any value of the
         constants.
         """
-        from working_memory import (
+        from scripts.working_memory import (
             _apply_token_budget,
             COMPRESSED_ENTRY_TOKEN_CEILING,
             MAX_WORKING_MEMORIES,
@@ -294,7 +294,7 @@ class TestApplyTokenBudget:
 
     def test_single_entry_always_kept(self):
         """A single entry should never be dropped, even if over budget."""
-        from working_memory import _apply_token_budget
+        from scripts.working_memory import _apply_token_budget
 
         huge_text = "word " * 1000
         entries = [f"### 2026-01-15 10:00\n**Context**: {huge_text}"]
@@ -303,7 +303,7 @@ class TestApplyTokenBudget:
 
     def test_budget_of_zero_keeps_first_entry(self):
         """Budget of zero should still keep at least the first entry."""
-        from working_memory import _apply_token_budget
+        from scripts.working_memory import _apply_token_budget
 
         entries = ["### 2026-01-15\n**Context**: Some text"]
         result = _apply_token_budget(entries, 0)
@@ -320,7 +320,7 @@ class TestSyncToClaudeMdBudgetEnforcement:
 
     def test_large_entries_compressed_during_sync(self, tmp_path):
         """sync_to_claude_md should compress older entries to stay within budget."""
-        from working_memory import sync_to_claude_md
+        from scripts.working_memory import sync_to_claude_md
 
         long_text = "word " * 200
         existing_content = (
@@ -333,7 +333,7 @@ class TestSyncToClaudeMdBudgetEnforcement:
         )
         claude_md = self._create_claude_md(tmp_path, existing_content)
 
-        with patch("working_memory._resolve_display_claude_md_with_base", return_value=(claude_md, claude_md.parent)):
+        with patch("scripts.working_memory._resolve_display_claude_md_with_base", return_value=(claude_md, claude_md.parent)):
             result = sync_to_claude_md(
                 {"context": "New context entry", "goal": "New goal"},
                 memory_id="test123"
@@ -350,7 +350,7 @@ class TestSyncToClaudeMdBudgetEnforcement:
 
     def test_sync_with_budget_produces_valid_markdown(self, tmp_path):
         """Output should be valid markdown with proper section structure."""
-        from working_memory import sync_to_claude_md
+        from scripts.working_memory import sync_to_claude_md
 
         content = (
             "# Project\n\n"
@@ -361,7 +361,7 @@ class TestSyncToClaudeMdBudgetEnforcement:
         )
         claude_md = self._create_claude_md(tmp_path, content)
 
-        with patch("working_memory._resolve_display_claude_md_with_base", return_value=(claude_md, claude_md.parent)):
+        with patch("scripts.working_memory._resolve_display_claude_md_with_base", return_value=(claude_md, claude_md.parent)):
             result = sync_to_claude_md({"context": "Test"}, memory_id="id1")
 
         new_content = claude_md.read_text(encoding="utf-8")
@@ -381,7 +381,7 @@ class TestSyncToClaudeMdBudgetEnforcement:
 
     def test_entry_count_trimmed_to_max_working_memories(self, tmp_path):
         """sync_to_claude_md should trim entries to MAX_WORKING_MEMORIES (3)."""
-        from working_memory import sync_to_claude_md, MAX_WORKING_MEMORIES
+        from scripts.working_memory import sync_to_claude_md, MAX_WORKING_MEMORIES
 
         existing_content = (
             "# Project\n\n"
@@ -397,7 +397,7 @@ class TestSyncToClaudeMdBudgetEnforcement:
         )
         claude_md = self._create_claude_md(tmp_path, existing_content)
 
-        with patch("working_memory._resolve_display_claude_md_with_base", return_value=(claude_md, claude_md.parent)):
+        with patch("scripts.working_memory._resolve_display_claude_md_with_base", return_value=(claude_md, claude_md.parent)):
             result = sync_to_claude_md(
                 {"context": "Brand new entry"},
                 memory_id="new123"
@@ -443,7 +443,7 @@ class TestSyncRetrievedBudgetEnforcement:
 
     def test_retrieved_entries_reduced_when_over_budget(self, tmp_path):
         """Should drop old retrieved entries when over budget."""
-        from working_memory import sync_retrieved_to_claude_md
+        from scripts.working_memory import sync_retrieved_to_claude_md
 
         long_text = "word " * 200
         existing_content = (
@@ -458,7 +458,7 @@ class TestSyncRetrievedBudgetEnforcement:
         )
         claude_md = self._create_claude_md(tmp_path, existing_content)
 
-        with patch("working_memory._resolve_display_claude_md_with_base", return_value=(claude_md, claude_md.parent)):
+        with patch("scripts.working_memory._resolve_display_claude_md_with_base", return_value=(claude_md, claude_md.parent)):
             result = sync_retrieved_to_claude_md(
                 [{"context": "New retrieved", "goal": "test"}],
                 query="test search",
@@ -479,7 +479,7 @@ class TestSyncRetrievedBudgetEnforcement:
 
     def test_no_memories_returns_false(self):
         """sync_retrieved_to_claude_md with an empty list reports `empty`."""
-        from working_memory import sync_retrieved_to_claude_md, SyncResult
+        from scripts.working_memory import sync_retrieved_to_claude_md, SyncResult
         result = sync_retrieved_to_claude_md([], query="test")
         # `empty` is the subject, not mere falsiness. This test NAMES its cause
         # in its own name: there was nothing to write. `unresolved` or `failed`
@@ -492,7 +492,7 @@ class TestFormatMemoryEntry:
 
     def test_basic_fields(self):
         """Should format context, goal, and memory_id into markdown."""
-        from working_memory import _format_memory_entry
+        from scripts.working_memory import _format_memory_entry
 
         memory = {"context": "Working on auth", "goal": "Add JWT support"}
         result = _format_memory_entry(memory, memory_id="abc123")
@@ -504,7 +504,7 @@ class TestFormatMemoryEntry:
 
     def test_decisions_as_list_of_strings(self):
         """Decisions provided as a list of strings should be joined with commas."""
-        from working_memory import _format_memory_entry
+        from scripts.working_memory import _format_memory_entry
 
         memory = {"context": "Test", "decisions": ["Use Redis", "Add caching"]}
         result = _format_memory_entry(memory)
@@ -513,7 +513,7 @@ class TestFormatMemoryEntry:
 
     def test_decisions_as_list_of_dicts(self):
         """Decisions provided as list of dicts should extract 'decision' key."""
-        from working_memory import _format_memory_entry
+        from scripts.working_memory import _format_memory_entry
 
         memory = {"context": "Test", "decisions": [
             {"decision": "Use Redis"},
@@ -525,7 +525,7 @@ class TestFormatMemoryEntry:
 
     def test_decisions_as_string(self):
         """Decisions provided as a plain string should be used directly."""
-        from working_memory import _format_memory_entry
+        from scripts.working_memory import _format_memory_entry
 
         memory = {"context": "Test", "decisions": "Use Redis for storage"}
         result = _format_memory_entry(memory)
@@ -534,7 +534,7 @@ class TestFormatMemoryEntry:
 
     def test_lessons_as_list(self):
         """Lessons provided as a list should be joined with commas."""
-        from working_memory import _format_memory_entry
+        from scripts.working_memory import _format_memory_entry
 
         memory = {"context": "Test", "lessons_learned": ["Cache invalidation is hard", "Use TTL"]}
         result = _format_memory_entry(memory)
@@ -543,7 +543,7 @@ class TestFormatMemoryEntry:
 
     def test_lessons_as_string(self):
         """Lessons provided as a string should be used directly."""
-        from working_memory import _format_memory_entry
+        from scripts.working_memory import _format_memory_entry
 
         memory = {"context": "Test", "lessons_learned": "Always use TTL for caches"}
         result = _format_memory_entry(memory)
@@ -552,7 +552,7 @@ class TestFormatMemoryEntry:
 
     def test_missing_optional_fields(self):
         """Missing optional fields should be omitted from output."""
-        from working_memory import _format_memory_entry
+        from scripts.working_memory import _format_memory_entry
 
         memory = {"context": "Just context, nothing else"}
         result = _format_memory_entry(memory)
@@ -566,7 +566,7 @@ class TestFormatMemoryEntry:
 
     def test_files_list(self):
         """Files list should be formatted as comma-separated values."""
-        from working_memory import _format_memory_entry
+        from scripts.working_memory import _format_memory_entry
 
         memory = {"context": "Test"}
         result = _format_memory_entry(memory, files=["src/auth.py", "tests/test_auth.py"])
@@ -575,7 +575,7 @@ class TestFormatMemoryEntry:
 
     def test_empty_memory_dict(self):
         """Empty memory dict should produce only the date header line."""
-        from working_memory import _format_memory_entry
+        from scripts.working_memory import _format_memory_entry
 
         result = _format_memory_entry({})
         lines = result.strip().split("\n")
@@ -588,7 +588,7 @@ class TestFormatRetrievedEntry:
 
     def test_basic_formatting(self):
         """Should format query, context, and goal into markdown."""
-        from working_memory import _format_retrieved_entry
+        from scripts.working_memory import _format_retrieved_entry
 
         memory = {"context": "Auth implementation", "goal": "Add JWT"}
         result = _format_retrieved_entry(memory, query="authentication", memory_id="mem1")
@@ -601,7 +601,7 @@ class TestFormatRetrievedEntry:
 
     def test_context_truncation_at_200_chars(self):
         """Context longer than 200 chars should be truncated with ellipsis."""
-        from working_memory import _format_retrieved_entry
+        from scripts.working_memory import _format_retrieved_entry
 
         long_context = "A" * 250
         memory = {"context": long_context}
@@ -614,7 +614,7 @@ class TestFormatRetrievedEntry:
 
     def test_score_formatting(self):
         """Score should be formatted to 2 decimal places."""
-        from working_memory import _format_retrieved_entry
+        from scripts.working_memory import _format_retrieved_entry
 
         memory = {"context": "Test"}
         result = _format_retrieved_entry(memory, query="test", score=0.87654)
@@ -623,7 +623,7 @@ class TestFormatRetrievedEntry:
 
     def test_no_score_omits_relevance(self):
         """When score is None, Relevance line should be omitted."""
-        from working_memory import _format_retrieved_entry
+        from scripts.working_memory import _format_retrieved_entry
 
         memory = {"context": "Test"}
         result = _format_retrieved_entry(memory, query="test")
@@ -632,7 +632,7 @@ class TestFormatRetrievedEntry:
 
     def test_missing_optional_fields(self):
         """Missing context and goal should be omitted."""
-        from working_memory import _format_retrieved_entry
+        from scripts.working_memory import _format_retrieved_entry
 
         result = _format_retrieved_entry({}, query="test")
 
@@ -646,7 +646,7 @@ class TestParseWorkingMemorySection:
 
     def test_section_not_found(self):
         """When no Working Memory section exists, should return empty entries."""
-        from working_memory import _parse_working_memory_section
+        from scripts.working_memory import _parse_working_memory_section
 
         content = "# Project\n\n## Some Other Section\nContent here\n"
         before, header, after, entries = _parse_working_memory_section(content)
@@ -658,7 +658,7 @@ class TestParseWorkingMemorySection:
 
     def test_no_next_section(self):
         """Working Memory at end of file (no next section) should capture to EOF."""
-        from working_memory import _parse_working_memory_section
+        from scripts.working_memory import _parse_working_memory_section
 
         content = (
             "# Project\n\n"
@@ -675,7 +675,7 @@ class TestParseWorkingMemorySection:
 
     def test_entries_without_proper_date_headers(self):
         """Entries without ### YYYY-MM-DD pattern should not be parsed as entries."""
-        from working_memory import _parse_working_memory_section
+        from scripts.working_memory import _parse_working_memory_section
 
         content = (
             "## Working Memory\n"
@@ -692,7 +692,7 @@ class TestParseWorkingMemorySection:
 
     def test_empty_section(self):
         """Section with header but no entries should return empty list."""
-        from working_memory import _parse_working_memory_section
+        from scripts.working_memory import _parse_working_memory_section
 
         content = (
             "## Working Memory\n"
@@ -707,7 +707,7 @@ class TestParseWorkingMemorySection:
 
     def test_multiple_entries_parsed_correctly(self):
         """Multiple entries should be parsed as separate items."""
-        from working_memory import _parse_working_memory_section
+        from scripts.working_memory import _parse_working_memory_section
 
         content = (
             "## Working Memory\n"
@@ -731,7 +731,7 @@ class TestParseRetrievedContextSection:
 
     def test_section_not_found(self):
         """When no Retrieved Context section exists, should return empty entries."""
-        from working_memory import _parse_retrieved_context_section
+        from scripts.working_memory import _parse_retrieved_context_section
 
         content = "# Project\n\n## Working Memory\nContent here\n"
         before, header, after, entries = _parse_retrieved_context_section(content)
@@ -743,7 +743,7 @@ class TestParseRetrievedContextSection:
 
     def test_no_next_section(self):
         """Retrieved Context at end of file should capture to EOF."""
-        from working_memory import _parse_retrieved_context_section
+        from scripts.working_memory import _parse_retrieved_context_section
 
         content = (
             "# Project\n\n"
@@ -761,7 +761,7 @@ class TestParseRetrievedContextSection:
 
     def test_empty_section(self):
         """Section with header but no entries should return empty list."""
-        from working_memory import _parse_retrieved_context_section
+        from scripts.working_memory import _parse_retrieved_context_section
 
         content = (
             "## Retrieved Context\n"
@@ -775,7 +775,7 @@ class TestParseRetrievedContextSection:
 
     def test_entries_without_date_headers_ignored(self):
         """Non-date ### headings should not be parsed as entries."""
-        from working_memory import _parse_retrieved_context_section
+        from scripts.working_memory import _parse_retrieved_context_section
 
         content = (
             "## Retrieved Context\n"
@@ -790,7 +790,7 @@ class TestParseRetrievedContextSection:
 
     def test_preserves_before_and_after_content(self):
         """Should correctly split content around the Retrieved Context section."""
-        from working_memory import _parse_retrieved_context_section
+        from scripts.working_memory import _parse_retrieved_context_section
 
         content = (
             "# Project\n\n"
@@ -817,14 +817,14 @@ class TestFindExistingClaudeMd:
 
     def test_returns_none_when_neither_exists(self, tmp_path):
         """Empty directory -> None."""
-        from working_memory import _find_existing_claude_md
+        from scripts.working_memory import _find_existing_claude_md
 
         result = _find_existing_claude_md(tmp_path)
         assert result is None
 
     def test_finds_legacy_claude_md(self, tmp_path):
         """Legacy ./CLAUDE.md at base -> returns it."""
-        from working_memory import _find_existing_claude_md
+        from scripts.working_memory import _find_existing_claude_md
 
         legacy = tmp_path / "CLAUDE.md"
         legacy.write_text("# legacy\n")
@@ -834,7 +834,7 @@ class TestFindExistingClaudeMd:
 
     def test_finds_new_default_claude_md(self, tmp_path):
         """New default .claude/CLAUDE.md at base -> returns it."""
-        from working_memory import _find_existing_claude_md
+        from scripts.working_memory import _find_existing_claude_md
 
         (tmp_path / ".claude").mkdir()
         new_default = tmp_path / ".claude" / "CLAUDE.md"
@@ -845,7 +845,7 @@ class TestFindExistingClaudeMd:
 
     def test_prefers_new_default_when_both_exist(self, tmp_path):
         """When both locations exist, .claude/CLAUDE.md wins."""
-        from working_memory import _find_existing_claude_md
+        from scripts.working_memory import _find_existing_claude_md
 
         (tmp_path / ".claude").mkdir()
         new_default = tmp_path / ".claude" / "CLAUDE.md"
@@ -868,7 +868,7 @@ class TestGetClaudeMdPathDualLocation:
 
     def test_env_var_finds_legacy_claude_md(self, tmp_path):
         """Env var strategy finds legacy ./CLAUDE.md."""
-        from working_memory import _get_claude_md_path
+        from scripts.working_memory import _get_claude_md_path
 
         legacy = tmp_path / "CLAUDE.md"
         legacy.write_text("# legacy\n")
@@ -879,7 +879,7 @@ class TestGetClaudeMdPathDualLocation:
 
     def test_env_var_finds_new_default_claude_md(self, tmp_path):
         """Env var strategy finds .claude/CLAUDE.md (new default)."""
-        from working_memory import _get_claude_md_path
+        from scripts.working_memory import _get_claude_md_path
 
         (tmp_path / ".claude").mkdir()
         new_default = tmp_path / ".claude" / "CLAUDE.md"
@@ -891,7 +891,7 @@ class TestGetClaudeMdPathDualLocation:
 
     def test_env_var_prefers_new_default_over_legacy(self, tmp_path):
         """Env var strategy: .claude/CLAUDE.md wins over ./CLAUDE.md."""
-        from working_memory import _get_claude_md_path
+        from scripts.working_memory import _get_claude_md_path
 
         (tmp_path / ".claude").mkdir()
         new_default = tmp_path / ".claude" / "CLAUDE.md"
@@ -907,7 +907,7 @@ class TestGetClaudeMdPathDualLocation:
         """Env var set but no CLAUDE.md at either location -> fall through to
         next strategy (which will either find git root or fall back to cwd).
         """
-        from working_memory import _get_claude_md_path
+        from scripts.working_memory import _get_claude_md_path
 
         # Neither location exists under tmp_path -> env var strategy returns None
         # -> falls through to git/cwd strategies.
@@ -922,7 +922,7 @@ class TestGetClaudeMdPathDualLocation:
 
     def test_git_root_finds_new_default_claude_md(self, tmp_path):
         """Git root strategy finds .claude/CLAUDE.md (new default)."""
-        from working_memory import _get_claude_md_path
+        from scripts.working_memory import _get_claude_md_path
 
         repo_root = tmp_path / "myrepo"
         (repo_root / ".claude").mkdir(parents=True)
@@ -943,7 +943,7 @@ class TestGetClaudeMdPathDualLocation:
 
     def test_git_root_finds_legacy_claude_md(self, tmp_path):
         """Git root strategy finds legacy ./CLAUDE.md."""
-        from working_memory import _get_claude_md_path
+        from scripts.working_memory import _get_claude_md_path
 
         repo_root = tmp_path / "myrepo"
         repo_root.mkdir()
@@ -964,7 +964,7 @@ class TestGetClaudeMdPathDualLocation:
 
     def test_git_root_prefers_new_default_over_legacy(self, tmp_path):
         """Git root strategy: .claude/CLAUDE.md wins over ./CLAUDE.md."""
-        from working_memory import _get_claude_md_path
+        from scripts.working_memory import _get_claude_md_path
 
         repo_root = tmp_path / "myrepo"
         (repo_root / ".claude").mkdir(parents=True)
@@ -989,7 +989,7 @@ class TestGetClaudeMdPathDualLocation:
 
     def test_cwd_finds_legacy_claude_md(self, tmp_path):
         """CWD strategy finds legacy ./CLAUDE.md."""
-        from working_memory import _get_claude_md_path
+        from scripts.working_memory import _get_claude_md_path
 
         legacy = tmp_path / "CLAUDE.md"
         legacy.write_text("# legacy\n")
@@ -1003,7 +1003,7 @@ class TestGetClaudeMdPathDualLocation:
 
     def test_cwd_finds_new_default_claude_md(self, tmp_path):
         """CWD strategy finds .claude/CLAUDE.md (new default)."""
-        from working_memory import _get_claude_md_path
+        from scripts.working_memory import _get_claude_md_path
 
         (tmp_path / ".claude").mkdir()
         new_default = tmp_path / ".claude" / "CLAUDE.md"
@@ -1018,7 +1018,7 @@ class TestGetClaudeMdPathDualLocation:
 
     def test_cwd_prefers_new_default_over_legacy(self, tmp_path):
         """CWD strategy: .claude/CLAUDE.md wins over ./CLAUDE.md."""
-        from working_memory import _get_claude_md_path
+        from scripts.working_memory import _get_claude_md_path
 
         (tmp_path / ".claude").mkdir()
         new_default = tmp_path / ".claude" / "CLAUDE.md"
@@ -1035,7 +1035,7 @@ class TestGetClaudeMdPathDualLocation:
 
     def test_cwd_returns_none_when_nothing_found(self, tmp_path):
         """All strategies fail -> returns None."""
-        from working_memory import _get_claude_md_path
+        from scripts.working_memory import _get_claude_md_path
 
         # tmp_path is empty -- no CLAUDE.md at either location
         env = {k: v for k, v in os.environ.items() if k != "CLAUDE_PROJECT_DIR"}

--- a/pact-plugin/tests/test_token_budget_constants_coupling.py
+++ b/pact-plugin/tests/test_token_budget_constants_coupling.py
@@ -75,13 +75,13 @@ def _exempt_lines(entry):
     `TestTheExemptSetIsTheHeaderAndThePointer`, which is what turns a widened
     exemption into a red rather than into a quietly different number.
     """
-    from working_memory import _apply_entry_token_ceiling
+    from scripts.working_memory import _apply_entry_token_ceiling
 
     return _apply_entry_token_ceiling(entry, EXEMPT_DERIVATION_CEILING)
 
 
 def _worst_case_memory():
-    from working_memory import _REFRESH_FIELD_TRUNCATION_LIMIT
+    from scripts.working_memory import _REFRESH_FIELD_TRUNCATION_LIMIT
 
     dense = _densest(_REFRESH_FIELD_TRUNCATION_LIMIT)
     return {
@@ -115,7 +115,7 @@ class TestTheExemptSetIsTheHeaderAndThePointer:
     """
 
     def _entry(self):
-        from working_memory import (
+        from scripts.working_memory import (
             _format_retrieved_entry,
             _REFRESH_IDENTIFIER_TRUNCATION_LIMIT,
         )
@@ -126,7 +126,7 @@ class TestTheExemptSetIsTheHeaderAndThePointer:
         )
 
     def test_the_derived_exempt_set_is_the_header_and_the_pointer(self):
-        from working_memory import _MEMORY_ID_LABEL
+        from scripts.working_memory import _MEMORY_ID_LABEL
 
         entry = self._entry()
         entry_lines = entry.split("\n")
@@ -203,7 +203,7 @@ class TestCompressedEntryCeilingCoupling:
         AND `COMPRESSED_ENTRY_TOKEN_CEILING` DOES NOT FOLLOW. That coupling
         is stated in a comment at the constant and enforced by nothing else.
         """
-        from working_memory import (
+        from scripts.working_memory import (
             _compress_memory_entry,
             _estimate_tokens,
             _format_memory_entry,
@@ -268,7 +268,7 @@ class TestCompressedEntryCeilingCoupling:
         the FIELD VALUE, as below, does not: the slice still happens in
         production.
         """
-        from working_memory import (
+        from scripts.working_memory import (
             _compress_memory_entry,
             _estimate_tokens,
             _format_memory_entry,
@@ -328,7 +328,7 @@ class TestCompressedEntryCeilingCoupling:
         stops holding, the worst case is no longer the dense shape and the
         arms above measure the wrong end of the axis.
         """
-        from working_memory import (
+        from scripts.working_memory import (
             _compress_memory_entry,
             _estimate_tokens,
             _format_memory_entry,
@@ -359,7 +359,7 @@ class TestWorkingMemorySectionBudget:
         identity is true by construction and cannot fail. The measured total
         can, and it is what a reader of the constants cares about.
         """
-        from working_memory import (
+        from scripts.working_memory import (
             _apply_token_budget,
             _estimate_tokens,
             _format_memory_entry,
@@ -398,7 +398,7 @@ class TestWorkingMemorySectionBudget:
         THE COMPANION ARM IN THE PRIMARY FILE DRIVES THE LOOP AT A
         NON-PRODUCTION BUDGET. The two cover different mechanisms.
         """
-        from working_memory import (
+        from scripts.working_memory import (
             _apply_token_budget,
             _format_memory_entry,
             MAX_WORKING_MEMORIES,
@@ -444,7 +444,7 @@ class TestRetrievedContextThinMargin:
         remaining half, which is that the cost measured here must be the
         cost of a PROPER slice.
         """
-        from working_memory import (
+        from scripts.working_memory import (
             _estimate_tokens,
             _format_retrieved_entry,
             MAX_RETRIEVED_MEMORIES,
@@ -496,7 +496,7 @@ class TestRetrievedContextThinMargin:
         that accurate at the worst input, so the claim is armed here rather
         than left to a reader of the comment.
         """
-        from working_memory import (
+        from scripts.working_memory import (
             _apply_entry_token_ceiling,
             _estimate_tokens,
             _format_retrieved_entry,
@@ -572,7 +572,7 @@ class TestDegenerateEdgeAtTheLiveCeilings:
         return found
 
     def _live_ceilings(self):
-        from working_memory import (
+        from scripts.working_memory import (
             COMPRESSED_ENTRY_TOKEN_CEILING,
             MAX_RETRIEVED_MEMORIES,
             MAX_WORKING_MEMORIES,
@@ -596,7 +596,7 @@ class TestDegenerateEdgeAtTheLiveCeilings:
         The cut drops whole lines, so it cannot put a value at the START of a
         line, which is the shape the sanitize exists to prevent.
         """
-        from working_memory import _apply_entry_token_ceiling, _format_memory_entry
+        from scripts.working_memory import _apply_entry_token_ceiling, _format_memory_entry
 
         entry = _format_memory_entry(
             memory, memory_id=("0123456789abcdef" * 2) if with_id else None
@@ -637,7 +637,7 @@ class TestDegenerateEdgeAtTheLiveCeilings:
         there to show the ceilings do NOT touch an ordinary entry. So the
         requirement sits at the level where the population makes it true.
         """
-        from working_memory import _apply_entry_token_ceiling, _format_memory_entry
+        from scripts.working_memory import _apply_entry_token_ceiling, _format_memory_entry
 
         ceilings = self._live_ceilings()
         cells = 0
@@ -691,7 +691,7 @@ class TestDegenerateEdgeAtTheLiveCeilings:
         unrelated cause. This asserts the positive fact: the entry is the
         exempt lines and nothing else.
         """
-        from working_memory import _apply_entry_token_ceiling, _format_memory_entry
+        from scripts.working_memory import _apply_entry_token_ceiling, _format_memory_entry
 
         entry = _format_memory_entry(
             {"context": "A save that carries one context field and no more."},
@@ -770,12 +770,12 @@ class TestAfterSectionSurvivesTheSync:
 
     def _sync_working(self, tmp_path, doc):
         from unittest.mock import patch
-        from working_memory import sync_to_claude_md
+        from scripts.working_memory import sync_to_claude_md
 
         target = tmp_path / "CLAUDE.md"
         target.write_text(doc, encoding="utf-8")
         with patch(
-            "working_memory._resolve_display_claude_md_with_base",
+            "scripts.working_memory._resolve_display_claude_md_with_base",
             return_value=(target, target.parent),
         ):
             sync_to_claude_md({"context": "new one", "goal": "g"}, memory_id="abc123")
@@ -783,12 +783,12 @@ class TestAfterSectionSurvivesTheSync:
 
     def _sync_retrieved(self, tmp_path, doc):
         from unittest.mock import patch
-        from working_memory import sync_retrieved_to_claude_md
+        from scripts.working_memory import sync_retrieved_to_claude_md
 
         target = tmp_path / "CLAUDE.md"
         target.write_text(doc, encoding="utf-8")
         with patch(
-            "working_memory._resolve_display_claude_md_with_base",
+            "scripts.working_memory._resolve_display_claude_md_with_base",
             return_value=(target, target.parent),
         ):
             sync_retrieved_to_claude_md(
@@ -797,7 +797,7 @@ class TestAfterSectionSurvivesTheSync:
         return target.read_text(encoding="utf-8")
 
     def test_working_memory_sync_keeps_the_after_section(self, tmp_path):
-        from working_memory import WORKING_MEMORY_COMMENT
+        from scripts.working_memory import WORKING_MEMORY_COMMENT
 
         doc = self._doc("## Working Memory", WORKING_MEMORY_COMMENT, with_tail=True)
         assert self.MARKER in doc  # NON-VACUITY: the marker is present before.
@@ -809,7 +809,7 @@ class TestAfterSectionSurvivesTheSync:
         )
 
     def test_retrieved_sync_keeps_the_after_section(self, tmp_path):
-        from working_memory import RETRIEVED_CONTEXT_COMMENT
+        from scripts.working_memory import RETRIEVED_CONTEXT_COMMENT
 
         doc = self._doc("## Retrieved Context", RETRIEVED_CONTEXT_COMMENT, with_tail=True)
         assert self.MARKER in doc
@@ -827,7 +827,7 @@ class TestAfterSectionSurvivesTheSync:
         memory before. That branch keeps `content[insert_pos:]`, which is the
         Working Memory section AND everything below it.
         """
-        from working_memory import WORKING_MEMORY_COMMENT
+        from scripts.working_memory import WORKING_MEMORY_COMMENT
 
         return (
             "# Project\n\n"
@@ -866,7 +866,7 @@ class TestAfterSectionSurvivesTheSync:
     # a shape added for one arm is a shape the completeness arm also counts.
     # Two lists would let the two drift, which is the defect this class had.
     def _drivers(self):
-        from working_memory import RETRIEVED_CONTEXT_COMMENT, WORKING_MEMORY_COMMENT
+        from scripts.working_memory import RETRIEVED_CONTEXT_COMMENT, WORKING_MEMORY_COMMENT
 
         return [
             ("working_sync_with_tail", self._sync_working,
@@ -1098,7 +1098,7 @@ class TestAfterSectionSurvivesTheSync:
         to the parser makes a newline-leading after-section reachable, this
         goes red and the exclusion above stops being safe.
         """
-        from working_memory import (
+        from scripts.working_memory import (
             RETRIEVED_CONTEXT_COMMENT,
             _MANAGED_END_MARKER,
             _MANAGED_START_MARKER,
@@ -1165,7 +1165,7 @@ class TestAfterSectionSurvivesTheSync:
         such as a probe that reads its own input, reports a survivor that the
         sync did not produce.
         """
-        from working_memory import WORKING_MEMORY_COMMENT
+        from scripts.working_memory import WORKING_MEMORY_COMMENT
 
         doc = self._doc("## Working Memory", WORKING_MEMORY_COMMENT, with_tail=False)
         assert self.MARKER not in doc
@@ -1278,7 +1278,7 @@ class TestFieldNameSurvivesTheCut:
         count to be above zero. Both parametrizations reach the cut in the
         hundreds, so the requirement costs no false red.
         """
-        from working_memory import _apply_entry_token_ceiling, _format_memory_entry
+        from scripts.working_memory import _apply_entry_token_ceiling, _format_memory_entry
 
         cells = 0
         reached = 0
@@ -1330,7 +1330,7 @@ class TestFieldNameSurvivesTheCut:
         change of the rendering makes this arm red and returns the decision
         to a person.
         """
-        from working_memory import _apply_entry_token_ceiling, _format_memory_entry
+        from scripts.working_memory import _apply_entry_token_ceiling, _format_memory_entry
 
         entry = _format_memory_entry({"context": "value words here"})
         hit = None
@@ -1358,7 +1358,7 @@ class TestFieldNameSurvivesTheCut:
         how far the shipped constants sit from the input that produces it,
         so it moves when a constant moves.
         """
-        from working_memory import (
+        from scripts.working_memory import (
             _estimate_tokens,
             _format_retrieved_entry,
             COMPRESSED_ENTRY_TOKEN_CEILING,
@@ -1463,7 +1463,7 @@ class TestMemoryIdLabelSites:
         """
         import ast
 
-        from working_memory import _MEMORY_ID_LABEL
+        from scripts.working_memory import _MEMORY_ID_LABEL
 
         tree = ast.parse(self._module_source())
         target = None
@@ -1536,13 +1536,13 @@ class TestTheFloorWhenEveryLineIsExempt:
     LOW_CEILING = 3
 
     def _exempt_only_entry(self):
-        from working_memory import _format_memory_entry
+        from scripts.working_memory import _format_memory_entry
 
         return _format_memory_entry({}, memory_id="0123456789abcdef" * 2)
 
     def test_an_entry_of_exempt_lines_alone_comes_back_whole(self):
         """No line is droppable, so the ceiling cannot be met. Return it."""
-        from working_memory import (
+        from scripts.working_memory import (
             _MEMORY_ID_LABEL,
             _apply_entry_token_ceiling,
             _estimate_tokens,
@@ -1576,7 +1576,7 @@ class TestTheFloorWhenEveryLineIsExempt:
         Without this, a guard that returned the entry for EVERY input would
         pass the negative arm above and no arm here would see it.
         """
-        from working_memory import (
+        from scripts.working_memory import (
             _MEMORY_ID_LABEL,
             _apply_entry_token_ceiling,
             _format_memory_entry,
@@ -1637,7 +1637,7 @@ class TestCompressedSummaryCapIsReferencedNotSpelled:
         """
         import ast
 
-        from working_memory import COMPRESSED_SUMMARY_CHAR_CAP
+        from scripts.working_memory import COMPRESSED_SUMMARY_CHAR_CAP
 
         tree = ast.parse(self._module_source())
         target = None

--- a/pact-plugin/tests/test_token_budget_constants_coupling.py
+++ b/pact-plugin/tests/test_token_budget_constants_coupling.py
@@ -30,7 +30,6 @@ string.
 """
 
 import re
-import sys
 from pathlib import Path
 
 import pytest

--- a/pact-plugin/tests/test_token_budget_constants_coupling.py
+++ b/pact-plugin/tests/test_token_budget_constants_coupling.py
@@ -35,8 +35,6 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"))
-
 
 def _densest(nchars):
     """Return the densest string of `nchars` that `str.split()` can meet.

--- a/pact-plugin/tests/test_tool_response.py
+++ b/pact-plugin/tests/test_tool_response.py
@@ -11,11 +11,7 @@ Also pins defensive shapes (non-dict input, non-dict field values, empty
 fields, missing fields).
 """
 
-import sys
-from pathlib import Path
 
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.tool_response import extract_tool_response  # noqa: E402
 

--- a/pact-plugin/tests/test_track_files.py
+++ b/pact-plugin/tests/test_track_files.py
@@ -15,12 +15,9 @@ import io
 import json
 import sys
 from datetime import datetime
-from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 class TestTrackFilesTimestamps:

--- a/pact-plugin/tests/test_validate_handoff.py
+++ b/pact-plugin/tests/test_validate_handoff.py
@@ -19,13 +19,9 @@ Tests cover:
 """
 import io
 import json
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 # =============================================================================

--- a/pact-plugin/tests/test_validate_handoff_integration.py
+++ b/pact-plugin/tests/test_validate_handoff_integration.py
@@ -45,13 +45,10 @@ hooks/+tests/ (never the shared worktree), __pycache__ cleared:
 """
 import io
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.session_journal import read_events  # noqa: E402
 

--- a/pact-plugin/tests/test_variety_divergence.py
+++ b/pact-plugin/tests/test_variety_divergence.py
@@ -37,12 +37,8 @@ GC-immune: every fixture is a synthetic journal event built via
 session_journal.make_event — zero dependence on the GC-reaped task store.
 """
 
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.session_journal import make_event  # noqa: E402
 from shared.variety_divergence import (  # noqa: E402

--- a/pact-plugin/tests/test_variety_scorer.py
+++ b/pact-plugin/tests/test_variety_scorer.py
@@ -8,12 +8,8 @@ Tests cover:
 3. route_workflow: all 4 routing thresholds at exact boundaries
 4. Constants consistency with architecture spec
 """
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.variety_scorer import (
     COMPACT_MAX,

--- a/pact-plugin/tests/test_variety_scorer_fuzz.py
+++ b/pact-plugin/tests/test_variety_scorer_fuzz.py
@@ -9,12 +9,8 @@ Supplements test_variety_scorer.py with:
 Uses hypothesis if available, parametrized fallback if not.
 """
 import itertools
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.variety_scorer import (
     COMPACT_MAX,

--- a/pact-plugin/tests/test_vector_dimension_fixes.py
+++ b/pact-plugin/tests/test_vector_dimension_fixes.py
@@ -27,7 +27,7 @@ import pytest
 
 # Add paths for imports — scripts/ is a package with __init__.py,
 # so we add its parent to sys.path for proper relative imports.
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 
 # =============================================================================

--- a/pact-plugin/tests/test_vector_dimension_fixes.py
+++ b/pact-plugin/tests/test_vector_dimension_fixes.py
@@ -16,18 +16,12 @@ Risk tier: STANDARD — well-understood pattern fix.
 """
 
 import json
-import os
 import struct
-import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-# Add paths for imports — scripts/ is a package with __init__.py,
-# so we add its parent to sys.path for proper relative imports.
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 
 # =============================================================================

--- a/pact-plugin/tests/test_vector_write_path.py
+++ b/pact-plugin/tests/test_vector_write_path.py
@@ -47,7 +47,7 @@ import pytest
 
 from helpers import create_test_schema
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 try:
     import pysqlite3 as sqlite3

--- a/pact-plugin/tests/test_vector_write_path.py
+++ b/pact-plugin/tests/test_vector_write_path.py
@@ -38,16 +38,12 @@ that holds that reasoning up.
 from __future__ import annotations
 
 import logging
-import os
 import struct
-import sys
 from unittest.mock import patch
 
 import pytest
 
 from helpers import create_test_schema
-
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 try:
     import pysqlite3 as sqlite3

--- a/pact-plugin/tests/test_wait_filler_gate.py
+++ b/pact-plugin/tests/test_wait_filler_gate.py
@@ -100,7 +100,6 @@ with the trailing-dot admission arm added at the cycle-1 re-review.
 import ast
 import io
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -110,8 +109,6 @@ PLUGIN_ROOT = Path(__file__).resolve().parent.parent
 HOOK_PATH = PLUGIN_ROOT / "hooks" / "wait_filler_gate.py"
 HOOKS_JSON = PLUGIN_ROOT / "hooks" / "hooks.json"
 ORCHESTRATOR = PLUGIN_ROOT / "agents" / "pact-orchestrator.md"
-
-sys.path.insert(0, str(PLUGIN_ROOT / "hooks"))
 
 DENY_REASON_ANCHOR = "Passive waiting is the protocol"
 

--- a/pact-plugin/tests/test_window_rule_decline.py
+++ b/pact-plugin/tests/test_window_rule_decline.py
@@ -47,7 +47,7 @@ def _family():
     twin literal in a test goes stale without a gate, which is the shape this
     branch keeps removing.
     """
-    from working_memory import (
+    from scripts.working_memory import (
         MEMORY_END_MARKER,
         MEMORY_START_MARKER,
         _MANAGED_END_MARKER,
@@ -100,7 +100,7 @@ class TestTheWindowFamilySelectsThreeDifferentSteps:
         row three mean something: a family that answered the same way at each
         row would separate no states at all.
         """
-        from working_memory import (
+        from scripts.working_memory import (
             MEMORY_START_MARKER,
             _SESSION_END_MARKER,
             _resolve_write_window,
@@ -191,7 +191,7 @@ class TestTheSyncMappingsCarryTheNewReason:
         call site alone leaves the sibling arm green, which is what makes the
         two arms different rather than one arm written twice.
         """
-        from working_memory import SyncResult, sync_to_claude_md
+        from scripts.working_memory import SyncResult, sync_to_claude_md
 
         root = _declining_project(tmp_path, monkeypatch)
         result = sync_to_claude_md(
@@ -228,7 +228,7 @@ class TestTheSyncMappingsCarryTheNewReason:
         reason reaches no status field and no log line. An arm at the function
         is the only thing that holds the mapping in place.
         """
-        from working_memory import SyncResult, sync_retrieved_to_claude_md
+        from scripts.working_memory import SyncResult, sync_retrieved_to_claude_md
 
         root = _declining_project(tmp_path, monkeypatch)
         result = sync_retrieved_to_claude_md(

--- a/pact-plugin/tests/test_window_rule_decline.py
+++ b/pact-plugin/tests/test_window_rule_decline.py
@@ -23,15 +23,10 @@ coarse fact goes first, the finer discrimination second.
 
 import json
 import os
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(
-    0, str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts")
-)
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_working_memory.py
+++ b/pact-plugin/tests/test_working_memory.py
@@ -56,7 +56,7 @@ def _emit(writer_name: str) -> str:
     no payload field, so a richer payload changes the body and not the line
     under test.
     """
-    import working_memory as wm
+    from scripts import working_memory as wm
 
     payload = {"context": "context text", "goal": "goal text"}
     if writer_name == "_format_memory_entry":

--- a/pact-plugin/tests/test_working_memory.py
+++ b/pact-plugin/tests/test_working_memory.py
@@ -34,15 +34,8 @@ DESCRIBE the shape. That description becomes a THIRD spelling of the date
 shape, beside the writer format string and the gate pattern. Three spellings
 that must agree is the generator of the drift this arm is here to catch.
 """
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
-sys.path.insert(
-    0, str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts")
-)
 
 # The two writers that emit a memory-entry heading. Each is driven for real
 # below; nothing here reconstructs what they emit.

--- a/pact-plugin/tests/test_working_memory_concurrency.py
+++ b/pact-plugin/tests/test_working_memory_concurrency.py
@@ -74,7 +74,7 @@ def _sync_worker(args):
     # _get_claude_md_path checks CLAUDE_PROJECT_DIR first, so all writers
     # resolve the same tmp .claude/CLAUDE.md (and thus the same sidecar).
     os.environ["CLAUDE_PROJECT_DIR"] = home
-    import working_memory as wm
+    from scripts import working_memory as wm
 
     # Rendezvous: both writers read the same base before either writes.
     barrier.wait()
@@ -140,7 +140,7 @@ class TestCrossWriterSerialization:
         working_memory.file_lock(target) time out on the SAME target, proving
         the two copies serialize on one sidecar (not two independent locks)."""
         from shared.claude_md_manager import file_lock as canonical
-        import working_memory as wm
+        from scripts import working_memory as wm
 
         target = tmp_path / ".claude" / "CLAUDE.md"
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -160,7 +160,7 @@ class TestCrossWriterSerialization:
         """Both copies derive the sidecar as .{name}.lock beside the target —
         the identity that makes the inode shared across processes."""
         from shared import claude_md_manager as cmm
-        import working_memory as wm
+        from scripts import working_memory as wm
 
         target = tmp_path / "CLAUDE.md"
         target.write_text("# x\n", encoding="utf-8")
@@ -186,7 +186,7 @@ class TestFailOpenOnTimeout:
         two no longer differ on this axis and both assert the REASON rather
         than mere falsiness.
         """
-        import working_memory as wm
+        from scripts import working_memory as wm
 
         claude_md = _seed_claude_md(tmp_path)
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
@@ -215,7 +215,7 @@ class TestFailOpenOnTimeout:
         self, tmp_path, monkeypatch
     ):
         """Same fail-open contract for the retrieved-context sync site."""
-        import working_memory as wm
+        from scripts import working_memory as wm
 
         claude_md = _seed_claude_md(tmp_path)
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))

--- a/pact-plugin/tests/test_working_memory_concurrency_comprehensive.py
+++ b/pact-plugin/tests/test_working_memory_concurrency_comprehensive.py
@@ -85,7 +85,7 @@ def _wm_worker(args):
     lock. Each writer commits one uniquely-marked Working Memory entry."""
     home, writer_id, barrier = args
     _bootstrap(home)
-    import working_memory as wm
+    from scripts import working_memory as wm
 
     barrier.wait()  # rendezvous: everyone reads the same base before any write
     wm.sync_to_claude_md(
@@ -100,7 +100,7 @@ def _retrieved_worker(args):
     writer commits one uniquely-marked Retrieved Context entry."""
     home, writer_id, barrier = args
     _bootstrap(home)
-    import working_memory as wm
+    from scripts import working_memory as wm
 
     barrier.wait()
     wm.sync_retrieved_to_claude_md(
@@ -117,7 +117,7 @@ def _cross_site_worker(args):
     the SAME file/sidecar; each must land its entry in its own section."""
     home, site, barrier = args
     _bootstrap(home)
-    import working_memory as wm
+    from scripts import working_memory as wm
 
     barrier.wait()
     if site == "wm":
@@ -212,7 +212,7 @@ class TestNWriterLostUpdate:
         """
         from importlib import import_module
         sys.path.insert(0, _SCRIPTS_DIR)
-        wm = import_module("working_memory")
+        wm = import_module("scripts.working_memory")
         max_wm = wm.MAX_WORKING_MEMORIES
 
         claude_md = _seed_claude_md(tmp_path)
@@ -347,7 +347,7 @@ class TestSyncSemanticsUnchangedUnderLock:
     def _import_wm(self):
         sys.path.insert(0, _SCRIPTS_DIR)
         from importlib import import_module
-        return import_module("working_memory")
+        return import_module("scripts.working_memory")
 
     def test_working_memory_rolling_window_trims_to_max(self, tmp_path, monkeypatch):
         """Syncing more than MAX_WORKING_MEMORIES entries keeps only the most
@@ -474,7 +474,7 @@ class TestDriftTestIsNotVacuous:
         self._ensure_scripts_on_path()
         import inspect
         from shared.claude_md_manager import file_lock as canonical
-        from working_memory import file_lock as twin
+        from scripts.working_memory import file_lock as twin
         from test_staleness import TestFileLockTwinCopyDrift
 
         extract = TestFileLockTwinCopyDrift._extract_body
@@ -503,7 +503,7 @@ class TestDriftTestIsNotVacuous:
         when one side changes — confirm a simulated mismatch would be caught."""
         self._ensure_scripts_on_path()
         import shared.claude_md_manager as cmm
-        import working_memory as wm
+        from scripts import working_memory as wm
 
         # Live values match (mirrors the real constant-equality drift test).
         assert cmm._LOCK_TIMEOUT_SECONDS == wm._LOCK_TIMEOUT_SECONDS

--- a/pact-plugin/tests/test_working_memory_fidelity.py
+++ b/pact-plugin/tests/test_working_memory_fidelity.py
@@ -25,8 +25,6 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
-
 import scripts.working_memory as wm  # noqa: E402
 from scripts.working_memory import (  # noqa: E402
     MAX_WORKING_MEMORIES,

--- a/pact-plugin/tests/test_working_memory_fidelity.py
+++ b/pact-plugin/tests/test_working_memory_fidelity.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "skills", "pact-memory"))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 import scripts.working_memory as wm  # noqa: E402
 from scripts.working_memory import (  # noqa: E402

--- a/pact-plugin/tests/test_working_memory_projection.py
+++ b/pact-plugin/tests/test_working_memory_projection.py
@@ -20,8 +20,6 @@ from pathlib import Path
 
 import pytest
 
-# skills/pact-memory is the package root, so `scripts.*` imports resolve.
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 import scripts.working_memory as wm  # noqa: E402
 from scripts.memory_api import PACTMemory  # noqa: E402

--- a/pact-plugin/tests/test_working_memory_projection.py
+++ b/pact-plugin/tests/test_working_memory_projection.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import pytest
 
 # skills/pact-memory is the package root, so `scripts.*` imports resolve.
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "skills", "pact-memory"))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 import scripts.working_memory as wm  # noqa: E402
 from scripts.memory_api import PACTMemory  # noqa: E402

--- a/pact-plugin/tests/test_working_memory_redirected_store_refusal.py
+++ b/pact-plugin/tests/test_working_memory_redirected_store_refusal.py
@@ -40,7 +40,7 @@ from pathlib import Path
 import pytest
 
 # skills/pact-memory is the package root, so `scripts.*` imports resolve.
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "skills", "pact-memory"))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 from scripts.config import STORE_ORIGIN_ENV, STORE_ORIGIN_HOME  # noqa: E402
 from scripts.working_memory import (  # noqa: E402

--- a/pact-plugin/tests/test_working_memory_redirected_store_refusal.py
+++ b/pact-plugin/tests/test_working_memory_redirected_store_refusal.py
@@ -39,8 +39,6 @@ from pathlib import Path
 
 import pytest
 
-# skills/pact-memory is the package root, so `scripts.*` imports resolve.
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 from scripts.config import STORE_ORIGIN_ENV, STORE_ORIGIN_HOME  # noqa: E402
 from scripts.working_memory import (  # noqa: E402

--- a/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
+++ b/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
@@ -85,7 +85,7 @@ class TestLockReleaseOnException:
         release by re-acquiring with a SHRUNK timeout: success means the lock
         is free; a TimeoutError would mean it leaked.
         """
-        import working_memory as wm
+        from scripts import working_memory as wm
 
         claude_md = _seed_claude_md(tmp_path)
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
@@ -130,7 +130,7 @@ class TestLockReleaseOnException:
         FAIL — which is exactly why this assertion is coupled to the
         atomic-replace rollback and not vacuous.)
         """
-        import working_memory as wm
+        from scripts import working_memory as wm
 
         claude_md = _seed_claude_md(tmp_path)
         before = claude_md.read_text(encoding="utf-8")
@@ -185,7 +185,7 @@ class TestReadOnlyDirectoryFailSafe:
         the pre-created sidecar the PermissionError comes from file_lock; with it,
         from mkstemp.
         """
-        import working_memory as wm
+        from scripts import working_memory as wm
 
         claude_md = _seed_claude_md(tmp_path)
         before = claude_md.read_text(encoding="utf-8")
@@ -282,7 +282,7 @@ class TestProjectDirDivergenceResidual:
         DIFFERENT sidecar. This is the unprotected residual: two processes in
         this state would lock different inodes and not serialize.
         """
-        import working_memory as wm
+        from scripts import working_memory as wm
 
         root_a = tmp_path / "proj_a"
         root_b = tmp_path / "proj_b"

--- a/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
+++ b/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
@@ -30,15 +30,7 @@ Used by: pytest (the working_memory edge-path gate).
 """
 
 import os
-import sys
 from pathlib import Path
-
-_SCRIPTS_DIR = str(
-    Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"
-)
-if _SCRIPTS_DIR not in sys.path:
-    sys.path.insert(0, _SCRIPTS_DIR)
-
 
 def _seed_claude_md(home: Path) -> Path:
     """Create a minimal project CLAUDE.md with an empty Working Memory section

--- a/pact-plugin/tests/test_working_memory_worktree_sync.py
+++ b/pact-plugin/tests/test_working_memory_worktree_sync.py
@@ -25,14 +25,11 @@ import logging
 import os
 import re
 import subprocess
-import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
 
-# scripts/ is a package; add skills/pact-memory so `scripts.*` imports resolve.
-sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 from scripts.working_memory import (
     _project_root_of,

--- a/pact-plugin/tests/test_working_memory_worktree_sync.py
+++ b/pact-plugin/tests/test_working_memory_worktree_sync.py
@@ -32,7 +32,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 # scripts/ is a package; add skills/pact-memory so `scripts.*` imports resolve.
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "skills", "pact-memory"))
+sys.path.insert(0, os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')))
 
 from scripts.working_memory import (
     _project_root_of,

--- a/pact-plugin/tests/test_worktree_guard.py
+++ b/pact-plugin/tests/test_worktree_guard.py
@@ -15,13 +15,9 @@ Tests cover:
 """
 import io
 import json
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 
 class TestWorktreeGuard:

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,6 +1,7 @@
 {
   "extraPaths": [
     "pact-plugin/hooks",
+    "pact-plugin/skills/pact-memory",
     "pact-plugin/skills/pact-memory/scripts"
   ]
 }

--- a/scripts/codemod_test_imports.py
+++ b/scripts/codemod_test_imports.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""Classify sys.path manipulation across the plugin's test suite (dry-run only).
+
+Location: scripts/codemod_test_imports.py (repo root; maintainer tooling, not
+shipped plugin payload).
+
+Summary: AST-based classifier for the test-import restructure. Walks every
+test file (tests/test_*.py plus skills-adjacent skills/*/test_*.py) and emits,
+per file, a machine-readable record of every sys.path mutation call
+(insert/append/remove), direct sys.path assignment, codegen string-literal
+occurrences, bare scripts-module imports, multiprocessing usage, and
+membership in (or reference by) the source-reading parity/twin-drift test
+family. The report drives the deletion-batch stages: a call is a deletion
+candidate only when its resolved target dir is centrally covered by the two
+conftest files (tests/conftest.py + pact-plugin/conftest.py).
+
+Used by: repo maintainers during the restructure arc. Dry-run only — this
+script never edits a file. Run from the repo root:
+
+    python3 scripts/codemod_test_imports.py [--report PATH]
+
+AST-based on purpose: text/regex matching would rewrite the codegen test
+files that carry 'sys.path.insert' inside string literals.
+"""
+
+import argparse
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLUGIN = REPO_ROOT / "pact-plugin"
+TEST_GLOBS = ("tests/test_*.py", "skills/*/test_*.py")
+
+# Roots centrally provided for tests/ files by tests/conftest.py after the
+# centralization commit, plus the plugin-root conftest's skills/*/scripts glob.
+CENTRAL_ROOTS_TESTS = (
+    "tests",  # tests dir itself
+    "hooks",
+    "skills/pact-memory",
+    "skills/pact-memory/scripts",
+    "skills/pact-coding-standards/scripts",
+    "scripts",  # plugin-level scripts/
+)
+
+BARE_SCRIPT_MODULES = ("working_memory", "memory_init", "embeddings")
+
+# Filename family whose tests read/compare sibling source; edits to files they
+# reference are assertions-affecting, not mechanical. Membership requires BOTH
+# the name pattern AND an observed source-reading call — fixture readers are
+# not family members.
+SOURCE_READER_NAME = re.compile(r"(parity|twin|structure|mirror)")
+
+
+def _iter_test_files():
+    files = []
+    for pattern in TEST_GLOBS:
+        files.extend(PLUGIN.glob(pattern))
+    return sorted(files)
+
+
+class _PathExprEvaluator:
+    """Resolve the tiny Path/os.path expression subset the suite actually uses.
+
+    Handles: __file__, Name lookups against tracked module-level assignments,
+    Path(...), str(...), os.path.join(...), os.path.dirname(...), the `/`
+    join operator, .resolve(), .parent, .parents[i]. Anything else resolves to
+    None (manual-tail classification).
+    """
+
+    def __init__(self, file_path, assignments):
+        self.file_path = file_path
+        self.assignments = assignments
+
+    def eval(self, node):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        if isinstance(node, ast.Name):
+            if node.id == "__file__":
+                return str(self.file_path)
+            if node.id in self.assignments:
+                return self.eval(self.assignments[node.id])
+            return None
+        if isinstance(node, ast.Call):
+            return self._eval_call(node)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+            left, right = self.eval(node.left), self.eval(node.right)
+            if left is None or right is None:
+                return None
+            return str(Path(left) / right)
+        if isinstance(node, ast.Attribute):
+            return self._eval_attr(node)
+        if isinstance(node, ast.Subscript):
+            # <path expr>.parents[i]
+            if (
+                isinstance(node.value, ast.Attribute)
+                and node.value.attr == "parents"
+                and isinstance(node.slice, ast.Constant)
+                and isinstance(node.slice.value, int)
+            ):
+                base = self.eval(node.value.value)
+                if base is None:
+                    return None
+                parents = Path(base).parents
+                idx = node.slice.value
+                return str(parents[idx]) if idx < len(parents) else None
+            return None
+        return None
+
+    def _eval_call(self, node):
+        name = self._call_name(node)
+        if name in ("Path", "str"):
+            return self.eval(node.args[0]) if node.args else None
+        if name == "os.path.join":
+            parts = [self.eval(a) for a in node.args]
+            if any(p is None for p in parts):
+                return None
+            return str(Path(parts[0]).joinpath(*parts[1:]))
+        if name == "os.path.dirname":
+            base = self.eval(node.args[0]) if node.args else None
+            return str(Path(base).parent) if base else None
+        # Method-call form: <path expr>.resolve()
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "resolve"
+            and not node.args
+        ):
+            base = self.eval(node.func.value)
+            return str(Path(base).resolve()) if base else None
+        return None
+
+    def _eval_attr(self, node):
+        if node.attr == "parent":
+            base = self.eval(node.value)
+            return str(Path(base).parent) if base else None
+        if node.attr == "resolve":
+            base = self.eval(node.value)
+            return str(Path(base).resolve()) if base else None
+        # Path(__file__).parents[1] arrives as Subscript(value=Attribute(parents))
+        return None
+
+    @staticmethod
+    def _call_name(node):
+        f = node.func
+        if isinstance(f, ast.Name):
+            return f.id
+        if isinstance(f, ast.Attribute):
+            parts = []
+            while isinstance(f, ast.Attribute):
+                parts.append(f.attr)
+                f = f.value
+            if isinstance(f, ast.Name):
+                parts.append(f.id)
+            return ".".join(reversed(parts))
+        return None
+
+
+def _classify_target(resolved, arg_text):
+    """Map a resolved path (or raw arg text) to its suite root name."""
+    text = resolved or arg_text or ""
+    text_norm = text.replace("\\", "/")
+    plugin = str(PLUGIN).replace("\\", "/")
+    if "pact-memory/scripts" in text_norm:
+        return "skills/pact-memory/scripts"
+    if "pact-coding-standards/scripts" in text_norm:
+        return "skills/pact-coding-standards/scripts"
+    if "pact-memory" in text_norm:
+        return "skills/pact-memory"
+    if re.search(r"/hooks/shared$", text_norm):
+        return "hooks/shared"
+    if re.search(r"/hooks$", text_norm) or text_norm == "hooks" or '"hooks"' in text_norm or "_HOOKS" in arg_text or "HOOKS" in arg_text:
+        return "hooks"
+    if re.search(r"/tests$", text_norm):
+        return "tests"
+    if text_norm.rstrip("/") == plugin:
+        return "plugin root"
+    if re.search(r"/scripts$", text_norm) and "skills" not in text_norm:
+        return "scripts"
+    if "/scripts" in text_norm and "skills" in text_norm:
+        return "skills/*/scripts (other)"
+    if "fixtures" in text_norm:
+        return "tests/fixtures"
+    if resolved is None:
+        return "unresolved"
+    return "other"
+
+
+def _is_syspath_call(node):
+    if not isinstance(node, ast.Call):
+        return None
+    f = node.func
+    if (
+        isinstance(f, ast.Attribute)
+        and f.attr in ("insert", "append", "remove")
+        and isinstance(f.value, ast.Attribute)
+        and f.value.attr == "path"
+        and isinstance(f.value.value, ast.Name)
+        and f.value.value.id == "sys"
+    ):
+        return f.attr
+    return None
+
+
+def _is_syspath_assign(node):
+    """Match sys.path = ... / sys.path[i] = ... assignment targets."""
+    targets = node.targets if isinstance(node, ast.Assign) else []
+    for t in targets:
+        cand = t.value if isinstance(t, ast.Subscript) else t
+        if (
+            isinstance(cand, ast.Attribute)
+            and cand.attr == "path"
+            and isinstance(cand.value, ast.Name)
+            and cand.value.id == "sys"
+        ):
+            return True
+    return False
+
+
+class _FileVisitor(ast.NodeVisitor):
+    def __init__(self, source, file_path):
+        self.source = source
+        self.evaluator = None  # set after assignment pre-pass
+        self.file_path = file_path
+        self.calls = []
+        self.assigns = 0
+        self.imports = []  # (top_name, scope)
+        self.uses_multiprocessing = False
+        self.reads_source = False
+        self.scope_depth = 0
+        self.guard_stack = []
+
+    # -- scope tracking -----------------------------------------------------
+    def visit_FunctionDef(self, node):
+        self.scope_depth += 1
+        self.generic_visit(node)
+        self.scope_depth -= 1
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_If(self, node):
+        seg = ast.get_source_segment(self.source, node.test) or ""
+        self.guard_stack.append("sys.path" in seg)
+        self.generic_visit(node)
+        self.guard_stack.pop()
+
+    # -- imports -------------------------------------------------------------
+    def visit_Import(self, node):
+        for a in node.names:
+            top = a.name.split(".")[0]
+            if top == "multiprocessing":
+                self.uses_multiprocessing = True
+            self.imports.append((top, "function" if self.scope_depth else "module"))
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node):
+        if node.module:
+            top = node.module.split(".")[0]
+            if top == "multiprocessing":
+                self.uses_multiprocessing = True
+            self.imports.append((top, "function" if self.scope_depth else "module"))
+        self.generic_visit(node)
+
+    # -- sys.path mutations ----------------------------------------------------
+    def visit_Assign(self, node):
+        if _is_syspath_assign(node):
+            self.assigns += 1
+        self.generic_visit(node)
+
+    def visit_Call(self, node):
+        kind = _is_syspath_call(node)
+        if kind:
+            path_arg = (
+                node.args[1]
+                if kind == "insert" and len(node.args) > 1
+                else (node.args[0] if node.args else None)
+            )
+            arg_text = (
+                " ".join((ast.get_source_segment(self.source, path_arg) or "").split())
+                if path_arg is not None
+                else ""
+            )
+            resolved = (
+                self.evaluator.eval(path_arg)
+                if self.evaluator is not None and path_arg is not None
+                else None
+            )
+            target = _classify_target(resolved, arg_text)
+            self.calls.append(
+                {
+                    "line": node.lineno,
+                    "kind": kind,
+                    "scope": "function" if self.scope_depth else "module",
+                    "guarded": any(self.guard_stack),
+                    "arg": arg_text,
+                    "resolved": resolved,
+                    "target": target,
+                    "variable_form": bool(
+                        path_arg is not None
+                        and not isinstance(path_arg, (ast.Call, ast.BinOp))
+                    ),
+                    "centrally_covered": target in CENTRAL_ROOTS_TESTS,
+                }
+            )
+        # source-reading detection: read_text()/getsource/open() on anything
+        name = _FileVisitor._call_name(node)
+        if name and any(k in name for k in ("read_text", "getsource", "open")):
+            self.reads_source = True
+        self.generic_visit(node)
+
+    @staticmethod
+    def _call_name(node):
+        f = node.func
+        if isinstance(f, ast.Name):
+            return f.id
+        if isinstance(f, ast.Attribute):
+            parts = []
+            while isinstance(f, ast.Attribute):
+                parts.append(f.attr)
+                f = f.value
+            if isinstance(f, ast.Name):
+                parts.append(f.id)
+            return ".".join(reversed(parts))
+        return ""
+
+
+def _collect_assignments(tree):
+    """Pre-pass: module-level NAME = <expr> assignments for var resolution."""
+    out = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Name):
+                    out.setdefault(t.id, node.value)
+    return out
+
+
+def _codegen_occurrences(tree, source):
+    """Count string constants that themselves contain a sys.path mutation."""
+    count = 0
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if "sys.path.insert" in node.value or "sys.path.append" in node.value:
+                count += 1
+    return count
+
+
+def _referenced_test_names(tree):
+    """String literals naming test files or plugin .py paths (source readers)."""
+    refs = set()
+    pat = re.compile(r"(test_[\w]+\.py|[\w]+\.py)")
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            for m in pat.finditer(node.value):
+                refs.add(m.group(1))
+    return sorted(refs)
+
+
+def classify_file(path):
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    visitor = _FileVisitor(source, path)
+    visitor.evaluator = _PathExprEvaluator(path, _collect_assignments(tree))
+    visitor.visit(tree)
+
+    rel = path.relative_to(PLUGIN)
+    bare_imports = sorted(
+        {name for name, _scope in visitor.imports if name in BARE_SCRIPT_MODULES}
+    )
+    family = bool(SOURCE_READER_NAME.search(path.name)) and visitor.reads_source
+    refs = (
+        [r for r in _referenced_test_names(tree) if r != path.name]
+        if family
+        else []
+    )
+    return {
+        "rel": str(rel),
+        "calls": visitor.calls,
+        "syspath_assignments": visitor.assigns,
+        "codegen_string_occurrences": _codegen_occurrences(tree, source),
+        "bare_scripts_imports": bare_imports,
+        "uses_multiprocessing": visitor.uses_multiprocessing,
+        "source_reader": family,
+        "references": refs,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--report",
+        default=str(REPO_ROOT / "scripts" / "codemod_test_imports_report.json"),
+        help="Where to write the JSON classification report.",
+    )
+    args = parser.parse_args()
+
+    files = _iter_test_files()
+    records = {}
+    summary = {
+        "test_files": len(files),
+        "files_with_calls": 0,
+        "total_calls": 0,
+        "module_scope": 0,
+        "function_scope": 0,
+        "guarded": 0,
+        "unguarded": 0,
+        "targets": {},
+        "centrally_covered_calls": 0,
+        "codegen_only_files": [],
+        "bare_scripts_import_files": [],
+        "multiprocessing_files": [],
+        "source_reader_files": [],
+        "referenced_test_files": [],
+        "syspath_assignment_files": [],
+    }
+    referenced = set()
+    for path in files:
+        rec = classify_file(path)
+        rel = rec.pop("rel")
+        records[rel] = rec
+        if rec["calls"]:
+            summary["files_with_calls"] += 1
+        for c in rec["calls"]:
+            summary["total_calls"] += 1
+            summary["module_scope" if c["scope"] == "module" else "function_scope"] += 1
+            summary["guarded" if c["guarded"] else "unguarded"] += 1
+            summary["targets"][c["target"]] = summary["targets"].get(c["target"], 0) + 1
+            if c["centrally_covered"]:
+                summary["centrally_covered_calls"] += 1
+        if rec["codegen_string_occurrences"] and not rec["calls"]:
+            summary["codegen_only_files"].append(rel)
+        if rec["bare_scripts_imports"]:
+            summary["bare_scripts_import_files"].append(rel)
+        if rec["uses_multiprocessing"]:
+            summary["multiprocessing_files"].append(rel)
+        if rec["source_reader"]:
+            summary["source_reader_files"].append(rel)
+        if rec["syspath_assignments"]:
+            summary["syspath_assignment_files"].append(rel)
+        referenced.update(rec["references"])
+
+    # Restrict to test files that exist in the suite (source readers also name
+    # hooks/scripts modules, which are not deletion-batch members anyway).
+    suite_names = {p.name for p in files}
+    summary["referenced_test_files"] = sorted(referenced & suite_names)
+
+    report = {"summary": summary, "files": records}
+    report_path = Path(args.report)
+    report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(
+        f"classified {summary['test_files']} files, "
+        f"{summary['files_with_calls']} with sys.path calls, "
+        f"{summary['total_calls']} calls; report -> {report_path}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/codemod_test_imports.py
+++ b/scripts/codemod_test_imports.py
@@ -35,7 +35,9 @@ PLUGIN = REPO_ROOT / "pact-plugin"
 TEST_GLOBS = ("tests/test_*.py", "skills/*/test_*.py")
 
 # Roots centrally provided for tests/ files by tests/conftest.py after the
-# centralization commit, plus the plugin-root conftest's skills/*/scripts glob.
+# centralization commit, plus the plugin-root conftest's skills/*/scripts glob
+# and its explicit plugin-root insert (added by the precursor commit — the
+# telegram test family's `from telegram.X import ...` resolves through it).
 CENTRAL_ROOTS_TESTS = (
     "tests",  # tests dir itself
     "hooks",
@@ -43,6 +45,7 @@ CENTRAL_ROOTS_TESTS = (
     "skills/pact-memory/scripts",
     "skills/pact-coding-standards/scripts",
     "scripts",  # plugin-level scripts/
+    "plugin root",  # pact-plugin/ itself, via the root conftest
 )
 
 BARE_SCRIPT_MODULES = ("working_memory", "memory_init", "embeddings")

--- a/scripts/codemod_test_imports_report.json
+++ b/scripts/codemod_test_imports_report.json
@@ -1,4 +1,5 @@
 {
+  "as_of": "e728c924 — point-in-time classification captured when the codemod landed, BEFORE the deletion batches ran; line refs and bare-import lists are historical, not HEAD state",
   "files": {
     "skills/pact-agent-teams/test_skill_loading_agent_teams.py": {
       "bare_scripts_imports": [],

--- a/scripts/codemod_test_imports_report.json
+++ b/scripts/codemod_test_imports_report.json
@@ -1,0 +1,6329 @@
+{
+  "files": {
+    "skills/pact-agent-teams/test_skill_loading_agent_teams.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "skills/pact-handoff-harvest/test_skill_loading_harvest.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_628_coverage.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 33,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_agent_handoff_emitter_integration.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 46,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_agent_handoff_marker.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 1,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_agent_handoff_ts_caller_property.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(_HOOKS_DIR)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 50,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_agent_memory_cap_single_source.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_agent_memory_leaf_construction.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_agent_state_model.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_agents_structure.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [
+        "helpers.py",
+        "test_pact_orchestrator_agent.py"
+      ],
+      "source_reader": true,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_archive_pin.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 59,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/scripts",
+          "scope": "module",
+          "target": "scripts",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 60,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 61,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_archive_pin_emit.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 44,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/scripts",
+          "scope": "module",
+          "target": "scripts",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 45,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 46,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_archive_pin_raise_census.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_archive_pin_resolver.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 51,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/scripts",
+          "scope": "module",
+          "target": "scripts",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 52,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_artifact_paths_durability.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 54,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_audit_protocol.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 16,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_audit_summary_overwrite_906.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 29,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_backlog.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_bin_pact_launcher.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_bootstrap_gate.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 78,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_bootstrap_marker_writer.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 63,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_bootstrap_prompt_gate.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 27,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_calibration_schema.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 13,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_caller_commits_before_embedding.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 56,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_caller_path_is_not_created.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(SCRIPTS_PARENT)",
+          "centrally_covered": true,
+          "guarded": true,
+          "kind": "insert",
+          "line": 55,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_canary_checklist_count.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_canonical_journal_frame_gate.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 81,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_canonical_json_contract.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_canonical_json_identity_certification.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).resolve().parents[1] / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 64,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_catchup_reason_is_read.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_check_pin_caps.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 35,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/scripts",
+          "scope": "module",
+          "target": "scripts",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 36,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 37,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_check_unused_imports.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_ci_collection_scope.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_ci_env_truthiness.py": {
+      "bare_scripts_imports": [
+        "memory_init"
+      ],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory', 'scripts')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 38,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory/scripts",
+          "scope": "module",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_claude_md_manager.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 34,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_claude_md_resolver_parity.py": {
+      "bare_scripts_imports": [
+        "working_memory"
+      ],
+      "calls": [
+        {
+          "arg": "str(_SCRIPTS_DIR)",
+          "centrally_covered": true,
+          "guarded": true,
+          "kind": "insert",
+          "line": 33,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "module",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_claudemd_write_prohibition_guard.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_cli_output_purity.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_commands_structure.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [
+        "backlog.py",
+        "dispatch_gate.py",
+        "session_resume.py",
+        "test_cross_references.py",
+        "test_skills_structure.py"
+      ],
+      "source_reader": true,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_compact_summary_archive_contract.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_compact_summary_session_scope.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 24,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_concurrent_auditor_wake.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_config_dir_comprehensive.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_config_dir_dispatch_integration.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_config_dir_migration_completeness.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_config_injection_both_modes.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_conftest_config_root_isolation.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_connection_transaction_mode.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 43,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_containment_certification.py": {
+      "bare_scripts_imports": [
+        "working_memory"
+      ],
+      "calls": [
+        {
+          "arg": "str(_p)",
+          "centrally_covered": false,
+          "guarded": true,
+          "kind": "insert",
+          "line": 91,
+          "resolved": null,
+          "scope": "module",
+          "target": "unresolved",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 1,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_containment_guard.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "_HOOKS",
+          "centrally_covered": true,
+          "guarded": true,
+          "kind": "insert",
+          "line": 41,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": true
+        },
+        {
+          "arg": "str(Path(__file__).resolve().parent.parent / \"skills\" / \"pact-memory\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 251,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory",
+          "scope": "function",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).resolve().parent.parent / \"skills\" / \"pact-memory\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 280,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory",
+          "scope": "function",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_count_word_guard.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_create_ingress_guard.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 45,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent.parent / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 46,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/scripts",
+          "scope": "module",
+          "target": "scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_cross_references.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_cybernetic_cross_references.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 19,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_declared_anchor_contract.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), \"..\", \"skills\", \"pact-memory\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 30,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        },
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), \"..\", \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 31,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../scripts",
+          "scope": "module",
+          "target": "scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_dispatch_emission_prose.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "hooks",
+          "centrally_covered": true,
+          "guarded": true,
+          "kind": "insert",
+          "line": 193,
+          "resolved": null,
+          "scope": "function",
+          "target": "hooks",
+          "variable_form": true
+        },
+        {
+          "arg": "hooks",
+          "centrally_covered": true,
+          "guarded": true,
+          "kind": "insert",
+          "line": 223,
+          "resolved": null,
+          "scope": "function",
+          "target": "hooks",
+          "variable_form": true
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_dispatch_gate.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 56,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_dispatch_gate_cause_enumeration.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 91,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_dispatch_gate_integration.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 38,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_dispatch_gate_smoke.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 34,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_dispatch_gate_stale_diagnosis.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 52,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_dispatch_helpers.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 36,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_dispatch_site_emit.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 41,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_dispatch_variety_deny_honor_probe.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_dispatch_variety_teachback_ack_emit.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 30,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_dogfood_livelock_invariant.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(_HOOKS_DIR)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 94,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_dual_channel_acceptance_pinned.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_embedding_catchup.py": {
+      "bare_scripts_imports": [
+        "embeddings"
+      ],
+      "calls": [
+        {
+          "arg": "_scripts_path",
+          "centrally_covered": true,
+          "guarded": true,
+          "kind": "insert",
+          "line": 31,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "module",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": true
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_embedding_status_contract.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 2,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_embedding_status_wiring.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_embedding_window.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(SCRIPTS_PARENT)",
+          "centrally_covered": true,
+          "guarded": true,
+          "kind": "insert",
+          "line": 39,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_emit_skip_accounting.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 28,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_emitter_happy_and_gates.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_emitter_idempotency.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_emitter_path_sanitization.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_emitter_race_regression.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_emitter_real_disk.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_emitter_resolution.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_emitter_robustness.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_environment_drift.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 15,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_environment_drift_convention.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_error_output.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 24,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_exemption_policy_tripwires.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 29,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 39,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_failure_cause_convention.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 33,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_failure_log.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 34,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_file_permissions.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(SCRIPTS_DIR.parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 22,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_file_tracker.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 24,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_file_tracker_composite_key_edges.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_first_observable_write_misfire_invariant.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_gate_crashpath_hardening.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 45,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_gate_invalid_mode_resolution.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 43,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_gh_helpers.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 36,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_git_commit_check.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 23,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_git_helpers.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_handoff_917_captured_regression.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 49,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_handoff_advisories.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 23,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_handoff_b1_b2_dedup.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 35,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_handoff_census.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).resolve().parent.parent / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 21,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/scripts",
+          "scope": "module",
+          "target": "scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_handoff_content_discrimination.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_handoff_eligibility_parity.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 35,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_handoff_key_annotation_pinned.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 60,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_handoff_ordering_gate.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 25,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_handoff_schema.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 25,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_handoff_unclaim_twin_917.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 27,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_handoff_writability_parity.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 49,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": true,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_handoff_write_after_completion_backstop.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 32,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_harness_aware_bootstrap.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 81,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_harvest_ledger_read_contract.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_harvest_prune_foreign_root.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_harvest_trigger_coherence.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_hook_emitted_config_root.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_hook_infra_classifier.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(HOOKS)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 46,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_hook_schema_compliance.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_hooks_json.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_idle_preamble.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 20,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_import_bar_cause_presence.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_import_hygiene.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_import_identity_map.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_index_append_method_pinned.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_ingress_guard_mechanisms.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 39,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_intentional_wait.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 25,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_is_lead.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_lazy_load_cross_references.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_lead_discriminator_invariant.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_lead_side_handoff_emit.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 27,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_learning_ii.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_lint_check_argument_accounting.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_lint_check_files_mode.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_lint_check_help.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_lock_identity_certification.py": {
+      "bare_scripts_imports": [
+        "working_memory"
+      ],
+      "calls": [
+        {
+          "arg": "str(_p)",
+          "centrally_covered": false,
+          "guarded": true,
+          "kind": "insert",
+          "line": 81,
+          "resolved": null,
+          "scope": "module",
+          "target": "unresolved",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_managed_comment_emitted.py": {
+      "bare_scripts_imports": [
+        "working_memory"
+      ],
+      "calls": [
+        {
+          "arg": "str(_PLUGIN_ROOT / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 70,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(_PLUGIN_ROOT / \"skills\" / \"pact-memory\" / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 71,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "module",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_managed_comment_mirror.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [
+        "claude_md_manager.py",
+        "session_resume.py",
+        "test_managed_comment_emitted.py",
+        "working_memory.py"
+      ],
+      "source_reader": true,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_marker_helper_twin_drift.py": {
+      "bare_scripts_imports": [
+        "working_memory"
+      ],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"skills\" / \"pact-memory\" / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 71,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "module",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [
+        "cli.py",
+        "conftest.py",
+        "pin_markers.py",
+        "test_staleness.py",
+        "test_working_memory_parser.py",
+        "working_memory.py"
+      ],
+      "source_reader": true,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_marker_namespace.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_marker_schema.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 37,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_memory_api_import_time_reach.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_memory_cli.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 38,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 2,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_memory_ct_fields.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 23,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_memory_database.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 24,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        },
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 526,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "function",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        },
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 564,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "function",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        },
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 2097,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "function",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_memory_end_marker_bounds_the_pin_scan.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_memory_graph.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 31,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_memory_init.py": {
+      "bare_scripts_imports": [
+        "memory_init"
+      ],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"skills\" / \"pact-memory\" / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 28,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "module",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": false
+        },
+        {
+          "arg": "str(scripts_path.parent.parent.parent)",
+          "centrally_covered": false,
+          "guarded": false,
+          "kind": "insert",
+          "line": 1583,
+          "resolved": null,
+          "scope": "function",
+          "target": "unresolved",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 2,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_memory_layer_composition.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 58,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_memory_models.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 21,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_memory_patterns_docs.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_memory_reachability.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).resolve().parent.parent / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 14,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/scripts",
+          "scope": "module",
+          "target": "scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 1,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_memory_store_isolation.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(SCRIPTS_PARENT)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 35,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 2,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_memory_store_scope.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(SCRIPTS_PARENT)",
+          "centrally_covered": true,
+          "guarded": true,
+          "kind": "insert",
+          "line": 53,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 37,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 2,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_1037_narrow.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 34,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_1118_output_selector.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 30,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_1118_output_selector_cert.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 37,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_1118_recert.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 38,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_1129_r1_branch_set.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 28,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_1129_r1_cert.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 50,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_1129_r2_cert.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 67,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_1129_r3_cert.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 87,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_1134_cert.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 123,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 124,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_1136_canonical_join_ssot.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 42,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_1140_carrier5_cert.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 67,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_1148_cert.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 37,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 38,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_1155_cert.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 40,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 41,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_1178_cert.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 50,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_1178_f2_cert.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 44,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_1181_cert.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 43,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 44,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_1203_cert.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 87,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 88,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_auth_symmetry.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_mint_parity.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 36,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_obs_cert.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 33,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 34,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_op_recognition_completeness.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 41,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_output_side_process_sub.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 63,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_over_block_batch.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 45,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_overblock_cluster_monotonicity.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 83,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 84,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_overblock_tokenizers.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_perf.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 68,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_pre.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 40,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_privileged_flags.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_seam_integration.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_merge_guard_why_oracle.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_migration_section_comment.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(_PLUGIN_ROOT / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 38,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_missed_wake_scan.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 42,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_missed_wake_scan_integration.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 59,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_no_broadcast_addressing.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_orchestration_retrospective.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 21,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_packaging_boundary.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pact_config.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 28,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pact_config_gate_migration.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 36,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pact_config_injection.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pact_context.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 142,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pact_harvest_cli.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(_HOOKS_DIR)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 55,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pact_orchestrator_agent.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pact_session_config_dir_parity.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 1,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_paths.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_peer_inject.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 25,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_peer_review_greedy_pin.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_peer_review_independence_pin.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_per_dispatch_variety.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 38,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_per_write_adversarial_matrix.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 55,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_per_write_mirror_registry.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_per_write_snapshot_seam.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 27,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pin_caps.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 18,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pin_caps_adversarial.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 25,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pin_caps_gate.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 27,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 28,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pin_caps_gate_counter_test.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 31,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 32,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pin_caps_gate_low_priority.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 27,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 28,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pin_caps_gate_matrix.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 41,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 42,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pin_caps_integration.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 22,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 23,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pin_caps_phantom_green.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 25,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent.parent / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 26,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/scripts",
+          "scope": "module",
+          "target": "scripts",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 27,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pin_comment_dominance.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 38,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 39,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pin_comment_pipeline.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 38,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 39,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pin_marker_writer.py": {
+      "bare_scripts_imports": [
+        "working_memory"
+      ],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pin_marker_writer_adversarial.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 2,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pin_staleness_gate.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 18,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 19,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pin_staleness_gate_two_rules.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(HOOKS)",
+          "centrally_covered": true,
+          "guarded": true,
+          "kind": "insert",
+          "line": 25,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pin_staleness_marker_clear.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 54,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_planning_artifact_scrub.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_plugin_json_orchestrator.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_plugin_manifest.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 24,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_plugin_manifest_parity.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": true,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_plugin_version_bump.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_postcompact_archive.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 34,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pr4_drain_survival_harvest.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 42,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_pr4_revision_v2_on_journal.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 58,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_precompact_state_reminder.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 30,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_progress_signals.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_project_dir_resolution.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 1,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_project_id.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_prose_root_gate.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_prune_memory_integration.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 30,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent.parent / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 31,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/scripts",
+          "scope": "module",
+          "target": "scripts",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 32,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests",
+          "scope": "module",
+          "target": "tests",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_prune_telemetry_contract.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_py39_annotation_compat.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_read_lead_session_id_parity.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_read_trigger_precondition_pinned.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_recovery_pointer_fallback.py": {
+      "bare_scripts_imports": [
+        "working_memory"
+      ],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"skills\" / \"pact-memory\" / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 65,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "module",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_resume_team_realign_1507.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 64,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_resumption_marker_mirror.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [
+        "session_init.py",
+        "session_journal.py",
+        "test_audit_protocol.py",
+        "test_commands_structure.py",
+        "test_session_init.py",
+        "test_session_journal.py",
+        "test_skill_loading_harvest.py"
+      ],
+      "source_reader": true,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_resumption_marker_seam.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_role_gate_flip_and_postcompact.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_seam_line_ending_call_sites.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 35,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent.parent / \"skills\" / \"pact-memory\" / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 36,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "module",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_block_substitution.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 46,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_consolidated_integration.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 49,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_discovery_route.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_end.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 25,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_end_integration.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 58,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_end_registry_prune.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_end_survives_a_forged_heading.py": {
+      "bare_scripts_imports": [
+        "working_memory"
+      ],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"skills\" / \"pact-memory\" / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 79,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "module",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_init.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 57,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_init_env_file.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_init_integration.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 46,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_init_primary_frame_keeps_the_ladder.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(_HOOKS)",
+          "centrally_covered": true,
+          "guarded": true,
+          "kind": "insert",
+          "line": 49,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_init_role_suppression.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_init_routing_contract.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_init_teammate_peer_inject.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_init_teammate_peer_inject_acceptance.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_init_three_way_role_gate.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(_HOOKS)",
+          "centrally_covered": true,
+          "guarded": true,
+          "kind": "insert",
+          "line": 50,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_journal.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 113,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": true
+    },
+    "tests/test_session_registry.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_registry_concurrency.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "_HOOKS_DIR",
+          "centrally_covered": true,
+          "guarded": true,
+          "kind": "insert",
+          "line": 102,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "function",
+          "target": "hooks",
+          "variable_form": true
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": true
+    },
+    "tests/test_session_registry_integrity.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_registry_mode_gate.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_registry_trust_partition.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_resume.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 59,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_session_state.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 29,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_settings_example_json.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_settings_well_formed.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_setup_memory.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 16,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_shred_detect.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 47,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/scripts",
+          "scope": "module",
+          "target": "scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_skills_structure.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [
+        "session_end.py",
+        "test_commands_structure.py",
+        "test_session_end.py"
+      ],
+      "source_reader": true,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_snapshot_adversarial_matrix.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 33,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_snapshot_empty_team_dedup_cert.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 48,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_snapshot_key_count_discriminator.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_snapshot_marker_root_fallback.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_snapshot_provenance_semantics.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 34,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_snapshot_roundtrip.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 19,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_snapshot_seam_emitter.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_snapshot_seams_gate.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 24,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_snapshot_subprocess_seam.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(HOOKS_DIR)",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 68,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_spawn_overhead_benchmark.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(_REPO_ROOT / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 24,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_splice_window_memory_region.py": {
+      "bare_scripts_imports": [
+        "working_memory"
+      ],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"skills\" / \"pact-memory\" / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 47,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "module",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_stale_session.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 29,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_staleness.py": {
+      "bare_scripts_imports": [
+        "working_memory"
+      ],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 30,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent.parent / \"skills\" / \"pact-memory\" / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 32,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "module",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_store_access_bar_presence.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_store_scope_decorator_contract.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 44,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_subagent_start_selects_teammate_frames.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_symlinks.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 24,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_sync_result_contract.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), \"..\", \"skills\", \"pact-memory\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 34,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 1,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_task_claim_gate.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 47,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent / \"fixtures\")",
+          "centrally_covered": false,
+          "guarded": false,
+          "kind": "insert",
+          "line": 48,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/fixtures",
+          "scope": "module",
+          "target": "tests/fixtures",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_task_id_sanitization_parity.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_task_integration.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 25,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_task_lifecycle_gate.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 47,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_task_lifecycle_gate_degraded.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_task_lifecycle_gate_smoke.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 34,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_task_metadata_snapshot.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_task_utils.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 18,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\" / \"shared\")",
+          "centrally_covered": false,
+          "guarded": false,
+          "kind": "insert",
+          "line": 19,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks/shared",
+          "scope": "module",
+          "target": "hooks/shared",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_taskb_claim_prose_guard.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_teachback_reasoning_reconstruction.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_teachback_schema.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_teachback_subject_hoist_parity.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 33,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [
+        "task_lifecycle_gate.py",
+        "task_utils.py"
+      ],
+      "source_reader": true,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_team_name_detect_align.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 47,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_team_name_resolution_both_modes.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 88,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_team_registration_skill.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_teammate_idle.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 28,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_teammate_mode.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 69,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_telegram_client.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent)",
+          "centrally_covered": false,
+          "guarded": false,
+          "kind": "insert",
+          "line": 24,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin",
+          "scope": "module",
+          "target": "plugin root",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_telegram_config.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent)",
+          "centrally_covered": false,
+          "guarded": false,
+          "kind": "insert",
+          "line": 23,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin",
+          "scope": "module",
+          "target": "plugin root",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_telegram_content_filter.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent)",
+          "centrally_covered": false,
+          "guarded": false,
+          "kind": "insert",
+          "line": 18,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin",
+          "scope": "module",
+          "target": "plugin root",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_telegram_deps.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent)",
+          "centrally_covered": false,
+          "guarded": false,
+          "kind": "insert",
+          "line": 16,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin",
+          "scope": "module",
+          "target": "plugin root",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_telegram_main.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent)",
+          "centrally_covered": false,
+          "guarded": false,
+          "kind": "insert",
+          "line": 17,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin",
+          "scope": "module",
+          "target": "plugin root",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_telegram_notify.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent)",
+          "centrally_covered": false,
+          "guarded": false,
+          "kind": "insert",
+          "line": 24,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin",
+          "scope": "module",
+          "target": "plugin root",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_telegram_routing.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent)",
+          "centrally_covered": false,
+          "guarded": false,
+          "kind": "insert",
+          "line": 24,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin",
+          "scope": "module",
+          "target": "plugin root",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_telegram_server.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent)",
+          "centrally_covered": false,
+          "guarded": false,
+          "kind": "insert",
+          "line": 20,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin",
+          "scope": "module",
+          "target": "plugin root",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_telegram_tools.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent)",
+          "centrally_covered": false,
+          "guarded": false,
+          "kind": "insert",
+          "line": 22,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin",
+          "scope": "module",
+          "target": "plugin root",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_telegram_voice.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent)",
+          "centrally_covered": false,
+          "guarded": false,
+          "kind": "insert",
+          "line": 21,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin",
+          "scope": "module",
+          "target": "plugin root",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_testing_craft_pins.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_three_surface_split_enforcement.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_token_budget.py": {
+      "bare_scripts_imports": [
+        "working_memory"
+      ],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"skills\" / \"pact-memory\" / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 20,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "module",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_token_budget_constants_coupling.py": {
+      "bare_scripts_imports": [
+        "working_memory"
+      ],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"skills\" / \"pact-memory\" / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 38,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "module",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_tool_response.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 18,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_track_files.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 23,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_validate_handoff.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 28,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_validate_handoff_integration.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 54,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_variety_divergence.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 45,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_variety_rationale_contamination.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_variety_scorer.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 16,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_variety_scorer_fuzz.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 17,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_vector_dimension_fixes.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 30,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_vector_write_path.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory')",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 50,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_verify_gate_tree.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_wait_discipline_layers_pinned.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_wait_discipline_pins.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_wait_filler_gate.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(PLUGIN_ROOT / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 114,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_wake_ordering_pinned.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_window_rule_decline.py": {
+      "bare_scripts_imports": [
+        "working_memory"
+      ],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"skills\" / \"pact-memory\" / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 32,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "module",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_working_memory.py": {
+      "bare_scripts_imports": [
+        "working_memory"
+      ],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 42,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        },
+        {
+          "arg": "str(Path(__file__).parent.parent / \"skills\" / \"pact-memory\" / \"scripts\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 43,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "module",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_working_memory_concurrency.py": {
+      "bare_scripts_imports": [
+        "working_memory"
+      ],
+      "calls": [
+        {
+          "arg": "_SCRIPTS_DIR",
+          "centrally_covered": true,
+          "guarded": true,
+          "kind": "insert",
+          "line": 60,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "module",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": true
+        },
+        {
+          "arg": "_SCRIPTS_DIR",
+          "centrally_covered": true,
+          "guarded": true,
+          "kind": "insert",
+          "line": 73,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "function",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": true
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": true
+    },
+    "tests/test_working_memory_concurrency_comprehensive.py": {
+      "bare_scripts_imports": [
+        "working_memory"
+      ],
+      "calls": [
+        {
+          "arg": "_SCRIPTS_DIR",
+          "centrally_covered": true,
+          "guarded": true,
+          "kind": "insert",
+          "line": 76,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "function",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": true
+        },
+        {
+          "arg": "_SCRIPTS_DIR",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 214,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "function",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": true
+        },
+        {
+          "arg": "_SCRIPTS_DIR",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 348,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "function",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": true
+        },
+        {
+          "arg": "_SCRIPTS_DIR",
+          "centrally_covered": true,
+          "guarded": true,
+          "kind": "insert",
+          "line": 467,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "function",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": true
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": true
+    },
+    "tests/test_working_memory_fidelity.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), \"..\", \"skills\", \"pact-memory\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 28,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_working_memory_parser.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_working_memory_projection.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), \"..\", \"skills\", \"pact-memory\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 24,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_working_memory_redirected_store_refusal.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), \"..\", \"skills\", \"pact-memory\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 43,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_working_memory_resolver_and_lock_release.py": {
+      "bare_scripts_imports": [
+        "working_memory"
+      ],
+      "calls": [
+        {
+          "arg": "_SCRIPTS_DIR",
+          "centrally_covered": true,
+          "guarded": true,
+          "kind": "insert",
+          "line": 40,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/skills/pact-memory/scripts",
+          "scope": "module",
+          "target": "skills/pact-memory/scripts",
+          "variable_form": true
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_working_memory_worktree_sync.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "os.path.join(os.path.dirname(__file__), \"..\", \"skills\", \"pact-memory\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 35,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/tests/../skills/pact-memory",
+          "scope": "module",
+          "target": "skills/pact-memory",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_worktree_cleanup_docs_probe.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_worktree_guard.py": {
+      "bare_scripts_imports": [],
+      "calls": [
+        {
+          "arg": "str(Path(__file__).parent.parent / \"hooks\")",
+          "centrally_covered": true,
+          "guarded": false,
+          "kind": "insert",
+          "line": 24,
+          "resolved": "/Users/mj/Sites/collab/PACT-prompt/.worktrees/chore/test-import-restructure/pact-plugin/hooks",
+          "scope": "module",
+          "target": "hooks",
+          "variable_form": false
+        }
+      ],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    },
+    "tests/test_wrapup_datasafety_contracts.py": {
+      "bare_scripts_imports": [],
+      "calls": [],
+      "codegen_string_occurrences": 0,
+      "references": [],
+      "source_reader": false,
+      "syspath_assignments": 0,
+      "uses_multiprocessing": false
+    }
+  },
+  "summary": {
+    "bare_scripts_import_files": [
+      "tests/test_ci_env_truthiness.py",
+      "tests/test_claude_md_resolver_parity.py",
+      "tests/test_containment_certification.py",
+      "tests/test_embedding_catchup.py",
+      "tests/test_lock_identity_certification.py",
+      "tests/test_managed_comment_emitted.py",
+      "tests/test_marker_helper_twin_drift.py",
+      "tests/test_memory_init.py",
+      "tests/test_pin_marker_writer.py",
+      "tests/test_recovery_pointer_fallback.py",
+      "tests/test_session_end_survives_a_forged_heading.py",
+      "tests/test_splice_window_memory_region.py",
+      "tests/test_staleness.py",
+      "tests/test_token_budget.py",
+      "tests/test_token_budget_constants_coupling.py",
+      "tests/test_window_rule_decline.py",
+      "tests/test_working_memory.py",
+      "tests/test_working_memory_concurrency.py",
+      "tests/test_working_memory_concurrency_comprehensive.py",
+      "tests/test_working_memory_resolver_and_lock_release.py"
+    ],
+    "centrally_covered_calls": 244,
+    "codegen_only_files": [
+      "tests/test_agent_handoff_marker.py",
+      "tests/test_embedding_status_contract.py",
+      "tests/test_pact_session_config_dir_parity.py",
+      "tests/test_pin_marker_writer_adversarial.py",
+      "tests/test_project_dir_resolution.py"
+    ],
+    "files_with_calls": 213,
+    "function_scope": 14,
+    "guarded": 19,
+    "module_scope": 245,
+    "multiprocessing_files": [
+      "tests/test_session_journal.py",
+      "tests/test_session_registry_concurrency.py",
+      "tests/test_working_memory_concurrency.py",
+      "tests/test_working_memory_concurrency_comprehensive.py"
+    ],
+    "referenced_test_files": [
+      "test_audit_protocol.py",
+      "test_commands_structure.py",
+      "test_cross_references.py",
+      "test_managed_comment_emitted.py",
+      "test_pact_orchestrator_agent.py",
+      "test_session_end.py",
+      "test_session_init.py",
+      "test_session_journal.py",
+      "test_skill_loading_harvest.py",
+      "test_skills_structure.py",
+      "test_staleness.py",
+      "test_working_memory_parser.py"
+    ],
+    "source_reader_files": [
+      "tests/test_agents_structure.py",
+      "tests/test_commands_structure.py",
+      "tests/test_handoff_writability_parity.py",
+      "tests/test_managed_comment_mirror.py",
+      "tests/test_marker_helper_twin_drift.py",
+      "tests/test_plugin_manifest_parity.py",
+      "tests/test_resumption_marker_mirror.py",
+      "tests/test_skills_structure.py",
+      "tests/test_teachback_subject_hoist_parity.py"
+    ],
+    "syspath_assignment_files": [],
+    "targets": {
+      "hooks": 159,
+      "hooks/shared": 1,
+      "plugin root": 10,
+      "scripts": 11,
+      "skills/pact-memory": 30,
+      "skills/pact-memory/scripts": 22,
+      "tests": 22,
+      "tests/fixtures": 1,
+      "unresolved": 3
+    },
+    "test_files": 345,
+    "total_calls": 259,
+    "unguarded": 240
+  }
+}


### PR DESCRIPTION
## Summary

Restructures how the plugin's test suite imports modules under test: path setup moves from ~200 per-file `sys.path.insert` boilerplate blocks into the conftest layer, and the 21 bare `scripts/`-module imports convert to package style. Test-infrastructure only — production hook loading is byte-untouched.

## What landed

- **Conftest centralization**: `tests/conftest.py`'s existing block (which already covered `hooks/` for ~165 files) extended to the remaining skill script roots; new disjoint `pact-plugin/conftest.py` covers skills-adjacent tests via a guarded glob. Both conftests are path-insert only — no imports at conftest scope.
- **AST codemod** (`scripts/codemod_test_imports.py` + committed classification report): classifies every per-file insert (scope, guardedness, target, variable form, codegen literals excluded, source-reading parity tests flagged) and drove the deletion batches.
- **21 bare imports converted** to `from scripts.X import` across 20 files. This repairs latently-broken relative-only lazy legs in `memory_init.py`/`embeddings.py` consumers and unifies module identity (no more bare-vs-package dead-patch hazard). One true latent bug surfaced and fixed: a `test_memory_init` arm passed only because the broken lazy leg manufactured an `ImportError`; it now forces the degradation path deterministically.
- **~500 vestigial inserts deleted** across 3 batches + assertions-affecting files (individually verified) + manual tail. Exclusions kept: spawn/subprocess self-sufficiency, codegen literals, and a small verified allowlist.
- **Permanent guards**: structural pin test banning new module-level inserts outside the allowlist (negative-tested with planted violations), basename-collision monitor, and an import-identity map harness (per-module `find_spec` origins captured at `pytest_collection_modifyitems`) with a committed baseline regenerated from the final import regime.
- **Version bump**: 4.7.18 → 4.7.19 (PATCH — no user-facing behavioral change).

## Behavior-preservation proof (4 layers, final HEAD)

1. **Gate parity**: 15879 passed / 85 skipped / 0 errors (15873 prior + 6 new guard tests, exact accounting), unpiped rc=0, summary line asserted.
2. **Collection census**: 15945 → 15964 (+19 intended guard/harness tests; 3 parametrized ids renamed by the conversion, none lost).
3. **Standalone sweep**: all strata files green under `pytest <file>` — the 67-file in-arc sweep (40 conftest-dependent + spawn/codegen/bare-import strata) plus 21 more files across the plugin-root, plugin-scripts, and skills-adjacent classes measured standalone-green during review (88/88 total).
4. **Import-identity diff**: zero precedence flips — the only deltas are 13 benign key additions (`scripts` package rows created by the conversion) and 88 pure spelling canonicalizations.

## Notes

- Spawn/subprocess test files (16) are deliberately untouched: their in-worker path rebuilds are inherent to the spawn boundary.
- During the arc the identity harness caught and fixed two of its own bugs (granularity for from-package imports; stdlib sentinel-origin leak) and the suite caught a `..`-path normalization issue in 21 insert sites (fixed before deletion).
- `hooks/shared` pyright entry verified load-bearing by ablation and left untouched.
- Review remediation (2 commits): stale/orphaned comment cleanup + codemod report as-of marker, and the path-setup pin's matcher extended from literal `insert(` to append/extend/slice-assign/aug-assign with a committed negative fixture (self-pinning) and a documented adversarial-only under-block (alias/getattr/exotic spacing).
